### PR TITLE
feat: dialog와 statebutton 컴포넌트 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,17 @@
-import {Route, Routes} from "react-router";
 import SideNavigation from "@/components/SideNavigation/SideNavigation.tsx";
+import { Route, Routes } from "react-router";
+import { Test } from "./pages/Test";
 
 function App() {
-
   return (
-      <Routes>
-        <Route path="*" element={<SideNavigation />}>
-          <Route index element={<>응애</>} />
-          <Route path="about" element={<></>} />
-        </Route>
-      </Routes>
-
-  )
+    <Routes>
+      <Route path="test" element={<Test />} />
+      <Route path="*" element={<SideNavigation />}>
+        <Route index element={<>응애</>} />
+        <Route path="about" element={<></>} />
+      </Route>
+    </Routes>
+  );
 }
 
-export default App
+export default App;

--- a/src/components/StateButton/ApplicantStateButton.tsx
+++ b/src/components/StateButton/ApplicantStateButton.tsx
@@ -1,0 +1,19 @@
+import { APPLICANT_STATE_OPTIONS } from "@/constants/options";
+import { StateButton } from "./StateButton";
+
+export const ApplicantStateButton = ({
+  selectedValue,
+  onStateChange,
+}: {
+  selectedValue: string;
+  onStateChange: (value: string) => void;
+}) => {
+  return (
+    <StateButton
+      options={APPLICANT_STATE_OPTIONS}
+      selectedValue={selectedValue}
+      onSelect={onStateChange}
+      variant="filledSecondary"
+    />
+  );
+};

--- a/src/components/StateButton/MemberStateButton.tsx
+++ b/src/components/StateButton/MemberStateButton.tsx
@@ -1,0 +1,19 @@
+import { MEMBER_STATE_OPTIONS } from "@/constants/options";
+import { StateButton } from "./StateButton";
+
+export const MemberStateButton = ({
+  selectedValue,
+  onStateChange,
+}: {
+  selectedValue: string;
+  onStateChange: (value: string) => void;
+}) => {
+  return (
+    <StateButton
+      options={MEMBER_STATE_OPTIONS}
+      selectedValue={selectedValue}
+      onSelect={onStateChange}
+      variant="filledSecondary"
+    />
+  );
+};

--- a/src/components/StateButton/RoleStateButton.tsx
+++ b/src/components/StateButton/RoleStateButton.tsx
@@ -1,0 +1,19 @@
+import { ROLE_STATE_OPTIONS } from "@/constants/options";
+import { StateButton } from "./StateButton";
+
+export const RoleStateButton = ({
+  selectedValue,
+  onStateChange,
+}: {
+  selectedValue: string;
+  onStateChange: (value: string) => void;
+}) => {
+  return (
+    <StateButton
+      options={ROLE_STATE_OPTIONS}
+      selectedValue={selectedValue}
+      onSelect={onStateChange}
+      variant="outlined"
+    />
+  );
+};

--- a/src/components/StateButton/StateButton.style.ts
+++ b/src/components/StateButton/StateButton.style.ts
@@ -1,0 +1,43 @@
+import { BoxButton } from "@yourssu/design-system-react";
+import styled from "styled-components";
+
+interface StyledBoxButtonProps {
+  $selectedValue: string;
+}
+
+export const StyledBoxButton = styled(BoxButton)<StyledBoxButtonProps>`
+  ${(props) => {
+    const colorMap = {
+      gray: {
+        states: ["심사 진행 중", "비액티브", "졸업"],
+        colors: {
+          bg: "#F1F1F4",
+          text: "#9093A5",
+          hover: "#DDDDE4",
+        },
+      },
+      red: {
+        states: ["탈퇴", "면접 불합", "인큐베이팅 불합", "서류 불합"],
+        colors: {
+          bg: "#FFEBEB",
+          text: "#FF5C5C",
+          hover: "#FFC2C2",
+        },
+      },
+    };
+
+    for (const [, config] of Object.entries(colorMap)) {
+      if (config.states.includes(props.$selectedValue)) {
+        return `
+            background-color: ${config.colors.bg} !important;
+            color: ${config.colors.text} !important;
+            svg {
+              fill: ${config.colors.text} !important;
+            }
+            &:hover { background-color: ${config.colors.hover} !important; }
+         `;
+      }
+    }
+    return "";
+  }}
+`;

--- a/src/components/StateButton/StateButton.tsx
+++ b/src/components/StateButton/StateButton.tsx
@@ -1,0 +1,35 @@
+import { IcArrowsChevronUpLine } from "@yourssu/design-system-react";
+import { GenericDialog } from "../dialog/GenericDialog";
+import { StyledBoxButton } from "./StateButton.style";
+
+export type DialogOption = {
+  label: string;
+  color?: string;
+};
+
+interface StateButtonProps {
+  options: DialogOption[];
+  selectedValue: string;
+  onSelect: (value: string) => void;
+  variant?: "filledPrimary" | "filledSecondary" | "outlined";
+}
+
+export const StateButton = ({
+  options,
+  selectedValue,
+  onSelect,
+  variant = "filledSecondary",
+}: StateButtonProps) => {
+  return (
+    <GenericDialog options={options} onSelect={onSelect}>
+      <StyledBoxButton
+        size="small"
+        variant={variant}
+        rightIcon={<IcArrowsChevronUpLine />}
+        $selectedValue={selectedValue}
+      >
+        {selectedValue}
+      </StyledBoxButton>
+    </GenericDialog>
+  );
+};

--- a/src/components/StateButton/index.ts
+++ b/src/components/StateButton/index.ts
@@ -1,0 +1,3 @@
+export * from "./ApplicantStateButton";
+export * from "./MemberStateButton";
+export * from "./RoleStateButton";

--- a/src/components/dialog/Dialog.style.ts
+++ b/src/components/dialog/Dialog.style.ts
@@ -1,0 +1,34 @@
+import { TextButton } from "@yourssu/design-system-react";
+import styled from "styled-components";
+
+export const DialogContainer = styled.div<{
+  $isOpen: boolean;
+  $position: "top" | "bottom";
+  $width: number;
+}>`
+  display: ${({ $isOpen }) => ($isOpen ? "block" : "none")};
+  position: absolute;
+  ${({ $position }) => ($position === "top" ? "bottom: 110%" : "top: 110%")};
+  width: ${({ $width }) => `${$width}px`};
+  background: white;
+  border: 1px solid #f1f1f4;
+  border-radius: 12px;
+  box-shadow: 0px 0px 10px 0px rgba(110, 118, 135, 0.25);
+  padding: 8px;
+  z-index: 1;
+`;
+
+export const StyledTextButton = styled(TextButton)`
+  width: 100%;
+  text-align: left;
+  border-radius: 8px;
+  justify-content: flex-start;
+  padding: 8px;
+  white-space: nowrap;
+
+  &:hover {
+    background: #f1f1f4;
+    color: #25262c;
+    border-color: transparent;
+  }
+`;

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import { DialogContainer, StyledTextButton } from "./Dialog.style";
+
+interface DialogOption {
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface DialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  options: DialogOption[];
+  onSelect: (value: string) => void;
+  position: "top" | "bottom";
+  width: number;
+}
+
+export const Dialog = ({
+  isOpen,
+  onClose,
+  options,
+  onSelect,
+  position,
+  width,
+}: DialogProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!(e.target instanceof Node)) return;
+
+      if (dialogRef.current && !dialogRef.current.contains(e.target)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  const handleOptionClick = (label: string) => {
+    onSelect(label);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <DialogContainer
+      ref={dialogRef}
+      $isOpen={isOpen}
+      $position={position}
+      $width={width}
+    >
+      {options.map((option) => (
+        <StyledTextButton
+          key={option.label}
+          size="medium"
+          variant="textSecondary"
+          leftIcon={option.icon}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={() => handleOptionClick(option.label)}
+        >
+          {option.label}
+        </StyledTextButton>
+      ))}
+    </DialogContainer>
+  );
+};

--- a/src/components/dialog/GenericDialog.tsx
+++ b/src/components/dialog/GenericDialog.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
+import { DialogOption } from "../StateButton/StateButton";
 import { Dialog } from "./Dialog";
 
 interface GenericDialogProps {
-  options: Array<{ label: string; value?: string; icon?: React.ReactNode }>;
+  options: DialogOption[];
   onSelect: (value: string) => void;
   children: React.ReactElement;
   width?: number;

--- a/src/components/dialog/GenericDialog.tsx
+++ b/src/components/dialog/GenericDialog.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import { Dialog } from "./Dialog";
+
+interface GenericDialogProps {
+  options: Array<{ label: string; value?: string; icon?: React.ReactNode }>;
+  onSelect: (value: string) => void;
+  children: React.ReactElement;
+  width?: number;
+  position?: "top" | "bottom";
+}
+
+export const GenericDialog = ({
+  options,
+  onSelect,
+  children,
+  width = 128,
+  position = "bottom",
+}: GenericDialogProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const dialogOpener = React.cloneElement(children, {
+    onClick: () => setIsOpen((prev) => !prev),
+    onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+  });
+
+  return (
+    <div style={{ position: "relative" }}>
+      {dialogOpener}
+      <Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        options={options}
+        onSelect={(value) => {
+          onSelect(value);
+          setIsOpen(false);
+        }}
+        position={position}
+        width={width}
+      />
+    </div>
+  );
+};

--- a/src/constants/IconOptions.tsx
+++ b/src/constants/IconOptions.tsx
@@ -1,0 +1,12 @@
+import { IcCopyLine, IcTrashLine } from "@yourssu/design-system-react";
+
+export const EDIT_OPTIONS = [
+  {
+    label: "URL 복사",
+    icon: <IcCopyLine />,
+  },
+  {
+    label: "파트 삭제",
+    icon: <IcTrashLine />,
+  },
+];

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -1,0 +1,43 @@
+export const MEMBER_STATE_OPTIONS = [
+  { label: "액티브" },
+  { label: "비액티브" },
+  { label: "졸업" },
+  { label: "탈퇴" },
+];
+
+export const APPLICANT_STATE_OPTIONS = [
+  { label: "심사 진행 중" },
+  { label: "서류 불합" },
+  { label: "면접 불합" },
+  { label: "인큐베이팅 불합" },
+  { label: "최종 합격" },
+];
+
+export const ROLE_STATE_OPTIONS = [
+  { label: "Lead" },
+  { label: "Vice Lead" },
+  { label: "Member" },
+];
+
+export const PARTS_OPTIONS = [
+  { label: "HR" },
+  { label: "PM" },
+  { label: "Marketing" },
+  { label: "Legal" },
+  { label: "Backend" },
+  { label: "Android" },
+  { label: "iOS" },
+  { label: "Web-frontend" },
+  { label: "Product Design" },
+];
+
+export const SEMESTER_OPTIONS = [
+  { label: "24-2학기" },
+  { label: "24-1학기" },
+  { label: "23-2학기" },
+  { label: "23-1학기" },
+  { label: "22-2학기" },
+  { label: "22-1학기" },
+  { label: "21-2학기" },
+  { label: "21-1학기" },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -39,7 +39,7 @@ h1 {
   line-height: 1.1;
 }
 
-button {
+/* button {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
@@ -56,7 +56,7 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
+} */
 
 @media (prefers-color-scheme: light) {
   :root {
@@ -66,7 +66,7 @@ button:focus-visible {
   a:hover {
     color: #747bff;
   }
-  button {
+  /* button {
     background-color: #f9f9f9;
-  }
+  } */
 }

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,0 +1,119 @@
+import { GenericDialog } from "@/components/dialog/GenericDialog";
+import {
+  ApplicantStateButton,
+  MemberStateButton,
+  RoleStateButton,
+} from "@/components/StateButton";
+import { EDIT_OPTIONS } from "@/constants/IconOptions";
+import {
+  MEMBER_STATE_OPTIONS,
+  PARTS_OPTIONS,
+  ROLE_STATE_OPTIONS,
+  SEMESTER_OPTIONS,
+} from "@/constants/options";
+import { BoxButton, Chip, TextField } from "@yourssu/design-system-react";
+import { useState } from "react";
+
+export const Test = () => {
+  const [selections, setSelections] = useState({
+    memberState: "액티브",
+    applicantState: "심사 진행 중",
+    roleState: "Lead",
+    role: "",
+    member: "",
+    parts: "",
+    edit: "",
+    semester: "",
+  });
+
+  const handleSelect = (type: keyof typeof selections) => (value: string) => {
+    setSelections((prev) => ({
+      ...prev,
+      [type]: value,
+    }));
+  };
+
+  return (
+    <div>
+      <div>
+        <MemberStateButton
+          selectedValue={selections.memberState}
+          onStateChange={handleSelect("memberState")}
+        />
+        <ApplicantStateButton
+          selectedValue={selections.applicantState}
+          onStateChange={handleSelect("applicantState")}
+        />
+        <RoleStateButton
+          selectedValue={selections.roleState}
+          onStateChange={handleSelect("roleState")}
+        />
+      </div>
+
+      <div>
+        <GenericDialog
+          options={ROLE_STATE_OPTIONS}
+          onSelect={handleSelect("role")}
+          width={150}
+        >
+          <BoxButton size="medium" variant="outlined">
+            파트 선택
+          </BoxButton>
+        </GenericDialog>
+
+        <GenericDialog
+          options={MEMBER_STATE_OPTIONS}
+          onSelect={handleSelect("member")}
+        >
+          <button>다이얼로그 쓰는 방법</button>
+        </GenericDialog>
+
+        <GenericDialog
+          options={PARTS_OPTIONS}
+          onSelect={handleSelect("parts")}
+          position="bottom"
+          width={196}
+        >
+          <BoxButton size="large" variant="filledPrimary">
+            핸디 boxbutton 버튼 썼을 때
+          </BoxButton>
+        </GenericDialog>
+
+        <GenericDialog
+          options={EDIT_OPTIONS}
+          onSelect={handleSelect("edit")}
+          position="top"
+          width={128}
+        >
+          <Chip size="medium" role="suggestion">
+            핸디 chip 썼을 때
+          </Chip>
+        </GenericDialog>
+
+        <GenericDialog
+          options={SEMESTER_OPTIONS}
+          onSelect={handleSelect("semester")}
+          position="bottom"
+          width={128}
+        >
+          <TextField>Gradient Button</TextField>
+        </GenericDialog>
+      </div>
+
+      {/* 선택된 값들 표시 */}
+      <div>
+        <h3>Selected Values</h3>
+        <ul>
+          <li>Member State Button: {selections.memberState}</li>
+          <li>Applicant State Button: {selections.applicantState}</li>
+          <li>Role State Button: {selections.roleState}</li>
+          <li>Role State Dialog: {selections.role || "Not selected"}</li>
+          <li>Member State Dialog: {selections.member || "Not selected"}</li>
+          <li>Parts Dialog: {selections.parts || "Not selected"}</li>
+          <li>Edit Dialog: {selections.edit || "Not selected"}</li>
+          <li>Semester Dialog: {selections.semester || "Not selected"}</li>
+        </ul>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
- resolved #1 

https://github.com/user-attachments/assets/8ad1534f-22f5-4118-8f81-556f0b68aa20

dialog와 statebutton 컴포넌트를 제작하였습니다.

### 기존 코드에 영향을 미치는 변경사항
- Handy 디자인 시스템의 버튼 스타일이 정상적으로 적용되도록 `index.css`에 button 관련 코드 주석처리 해두었습니다. 
- 컴포넌트 테스트 페이지를 하나 만들어서 라우터에도 임시로 넣어뒀는데 확인하고 사용 방법 익히고 삭제하면 될 듯 합니다. `/test` 이 경로로 들어가면 확인 가능합니당
- 그리고 pr이랑 이슈 템플릿 main에 올려뒀어요 숨쉴 꺼 가져왔슴다

### 기존 코드에 영향을 미치지 않는 변경사항
- dialog 컴포넌트와 statebutton 컴포넌트, 그리고 상수를 추가했습니다. 컴포넌트 사용방법 자세히 밑에 적을게요

##  컴포넌트 사용 방법
일단 컴포넌트 전체 구조입니다! 추가된 부분만 썼어요
```
├── src
│   ├── components
│   │   ├── StateButton
│   │   │   ├── ApplicantStateButton.tsx
│   │   │   ├── MemberStateButton.tsx
│   │   │   ├── RoleStateButton.tsx
│   │   │   ├── StateButton.style.ts
│   │   │   ├── StateButton.tsx
│   │   │   └── index.ts
│   │   └── dialog
│   │       ├── Dialog.style.ts
│   │       ├── Dialog.tsx
│   │       └── GenericDialog.tsx
│   ├── constants
│   │   ├── IconOptions.tsx
│   │   └── options.ts
```

### Dialog 컴포넌트 구현
1. 컴포넌트 개요

Handy의 TextButton을 기반으로 한 리스트 형태의 다이얼로그 컴포넌트입니다. TextButton을 여러개 이어서 만들었어요.

2. DialogProps 설명

```ts
interface DialogProps {
  isOpen: boolean;
  onClose: () => void; // 클릭에 따라 다이얼로그가 열리고 닫히게
  options: DialogOption[]; // 다이얼로그의 option들 (ex) 액티브, 비액티브, 졸업, 탈퇴)
  onSelect: (value: string) => void; // 현재 선택된 option (ex) 액티브)
  position: "top" | "bottom"; // 다이얼로그가 어느 방향으로 나타날지 (피그마 상에 위, 아래만 존재해서 두 개만 제작)
  width: number; // 다이얼로그 가로 길이에 맞는거 넣어서 쓰세요 (119, 128, 150, 196)
}
```

3. 사용 방법 - 새로운 다이얼로그 만드는 방법

만약 새로운 다이얼로그가 필요한 경우 options에 새로운 배열을 넣고 만들면 돼요!

```ts
 <Dialog
          isOpen={true}
          onClose={() => {}}
          options={ROLE_STATE_OPTIONS}
          onSelect={() => {}}
          position="bottom"
          width={150}
        />
```
이런 식으로 props를 넣어주면 

![스크린샷 2025-01-27 오전 9 14 14](https://github.com/user-attachments/assets/506e5ab8-1f60-442b-bfc3-03a5993aaf44)

이런 다이얼로그가 생겨요

### GenericDialog 컴포넌트 구현
1. 컴포넌트 개요

그럼 이건 무엇이냐 하면 Dialog를 버튼과 같이 쉽게 쓰기 위해 만든 래퍼 컴포넌트에요

```
Dialog - 순수하게 다이얼로그 UI와 기본 동작만 담당
GenericDialog - 다이얼로그를 열고 닫는 트리거 요소와 Dialog를 조합
```

2. GenericDialogProps 설명

```ts
interface GenericDialogProps {
  options: DialogOption[];
  onSelect: (value: string) => void;
  children: React.ReactElement;
  width?: number;
  position?: "top" | "bottom";
}
```
래퍼라 `children: React.ReactElement;` 이 부분만 추가된 거 확인하면 될 것 같습니당
버튼을 children로 받는 거라고 생각하면 돼요! 그래서 받은 버튼 + GenericDialog = 드롭다운 형태를 쉽게 만들도록 했어요

3. 사용 방법 - 드롭다운 만드는 방법

```ts
<GenericDialog
          options={PARTS_OPTIONS}
          onSelect={handleSelect("parts")}
          position="bottom"
          width={196}
        >
          <BoxButton size="large" variant="filledPrimary">
            핸디 boxbutton 버튼 썼을 때
          </BoxButton>
        </GenericDialog>
```

이런식으로 사용하면 됩니당 핸디에서 쓰는 BoxButton과 같이 버튼을 안에 넣어주면

![스크린샷 2025-01-27 오전 9 51 35](https://github.com/user-attachments/assets/aa1d4238-a375-47fc-8635-919be0e47b9b)

이렇게 쓸 수 있어요

### StateButton 컴포넌트 구현

1. 컴포넌트 개요

위에서 설명한 `GenericDialog`와 버튼을 합쳐두었어요! 

![스크린샷 2025-01-27 오전 9 52 35](https://github.com/user-attachments/assets/f637e769-66c9-4505-93f4-beaedd69679c)

이거 세 개는 미리 만들어 두었어요

2. StateButtonProps 설명 

```ts
interface StateButtonProps {
  options: DialogOption[]; // 이름은 같은데 위에 옵션이랑 달라요! 핸디의 boxbutton을 커스텀하기 위한 label과 color가 있다고 생각해주세요
  selectedValue: string; // 현재 상태
  onSelect: (value: string) => void; // 상태 변경 함수
  variant?: "filledPrimary" | "filledSecondary" | "outlined"; // 핸디의 boxbutton을 커스텀하기 위한~
}
```

3. 사용 방법

얘네는 만들어둔거라 이런식으로 사용하면 될 것 같아요

```ts
const [userRole, setUserRole] = useState<string>("액티브"); 

  const handleRoleChange = (newRole: string) => {
    setUserRole(newRole);
  };

return (
       <MemberStateButton
          selectedValue={userRole}
          onStateChange={handleRoleChange}
       />
       <ApplicantStateButton
          // 얘네도
       />
       <RoleStateButton
          // 똑같이
       />
)
```

![스크린샷 2025-01-27 오전 10 03 54](https://github.com/user-attachments/assets/ff41833d-1c60-424c-aa30-336599aaf063)

순서대로 이거 세 개 입니당

## 2️⃣ 알아두시면 좋아요!
- statebutton이 좀 많아서 index.ts에서 여러 파일을 한 번에 export 했습니당
- 옵션들(액티브, 비액티브, 졸업, 탈퇴) 상수로 지정해뒀는데 학기(24-1)같은 건 api로 불러와야 될 것 같아요 일단은 상수로 뒀어요

## 3️⃣ 추후 작업
- 렌더 프롭 해결하기
다이얼로그 외부 클릭이랑 버튼 재 클릭시 다이얼로그가 닫히게 하기 위해서`cloneElement`를 썼는데요, [이걸 쓰지 말라고 하더라구요](https://ko.react.dev/reference/react/cloneElement) 암튼 그래서 이 부분 수정할건데 아마 전반적인 코드는 안바뀔 것 같아서 일단 pr 올리고 제롬이 저의 고봉밥 pr을 읽는 동안 수정해서 커밋하도록 하겠습니당

- 그리고 쉽게 갖다 쓸 수 있게 생각하고 코드 짜긴 했는데 너무 어렵더라구여... 이 부분 이상하다 이 컴포넌트 도저히 못 쓰겠다 하는 건 바로 말해주세요 이해 안가는 부분도 말해주세요 바로 달려오겠음 자 여기까지 pr 읽어주셔서 감사합니다 ㅎ 

## 4️⃣ 체크리스트 (Checklist)

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
