### PR TITLE
feat: Tooltip 컴포넌트 제작

### DIFF
--- a/src/components/StateButton/StateButton.tsx
+++ b/src/components/StateButton/StateButton.tsx
@@ -22,14 +22,17 @@ export const StateButton = ({
 }: StateButtonProps) => {
   return (
     <GenericDialog options={options} onSelect={onSelect}>
-      <StyledBoxButton
-        size="small"
-        variant={variant}
-        rightIcon={<IcArrowsChevronUpLine />}
-        $selectedValue={selectedValue}
-      >
-        {selectedValue}
-      </StyledBoxButton>
+      {(triggerProps) => (
+        <StyledBoxButton
+          size="small"
+          variant={variant}
+          rightIcon={<IcArrowsChevronUpLine />}
+          $selectedValue={selectedValue}
+          {...triggerProps}
+        >
+          {selectedValue}
+        </StyledBoxButton>
+      )}
     </GenericDialog>
   );
 };

--- a/src/components/Tooltip/Tooltip.style.ts
+++ b/src/components/Tooltip/Tooltip.style.ts
@@ -1,0 +1,94 @@
+import styled, { css } from "styled-components";
+
+export const TooltipWrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+  width: fit-content;
+  height: fit-content;
+`;
+
+interface TooltipContentProps {
+  $position?: "top" | "bottom" | "left" | "right";
+  $offset?: number;
+}
+
+export const TooltipContent = styled.div<TooltipContentProps>`
+  position: absolute;
+  white-space: nowrap;
+  z-index: 1;
+  padding: 8px 12px;
+  background: #373a43;
+  border-radius: ${({ theme }) => theme.semantic.radius.xs}px;
+  color: ${({ theme }) => theme.semantic.color.textBasicWhite};
+  ${({ theme }) => theme.typo.C1_Rg_13};
+
+  ${({ $position = "top", $offset = 10 }) => {
+    switch ($position) {
+      case "bottom":
+        return css`
+          top: calc(100% + ${$offset}px);
+          left: 50%;
+          transform: translateX(-50%);
+
+          &::after {
+            top: -8px;
+            bottom: auto;
+            border-top: none;
+            border-bottom: 8px solid #373a43;
+          }
+        `;
+      case "left":
+        return css`
+          right: calc(100% + ${$offset}px);
+          top: 50%;
+          transform: translateY(-50%);
+          margin-bottom: 0;
+
+          &::after {
+            left: auto;
+            right: -8px;
+            top: 50%;
+            transform: translateY(-50%);
+            border-left: 8px solid #373a43;
+            border-top: 8px solid transparent;
+            border-bottom: 8px solid transparent;
+            border-right: none;
+          }
+        `;
+      case "right":
+        return css`
+          left: calc(100% + ${$offset}px);
+          top: 50%;
+          transform: translateY(-50%);
+          margin-bottom: 0;
+
+          &::after {
+            left: -8px;
+            top: 50%;
+            transform: translateY(-50%);
+            border-right: 8px solid #373a43;
+            border-top: 8px solid transparent;
+            border-bottom: 8px solid transparent;
+            border-left: none;
+          }
+        `;
+      default:
+        return css`
+          bottom: calc(100% + ${$offset}px);
+          left: 50%;
+          transform: translateX(-50%);
+
+          &::after {
+            content: "";
+            position: absolute;
+            bottom: -8px;
+            left: 50%;
+            transform: translateX(-50%);
+            border-left: 8px solid transparent;
+            border-right: 8px solid transparent;
+            border-top: 8px solid #373a43;
+          }
+        `;
+    }
+  }}
+`;

--- a/src/components/Tooltip/Tooltip.style.ts
+++ b/src/components/Tooltip/Tooltip.style.ts
@@ -22,6 +22,11 @@ export const TooltipContent = styled.div<TooltipContentProps>`
   color: ${({ theme }) => theme.semantic.color.textBasicWhite};
   ${({ theme }) => theme.typo.C1_Rg_13};
 
+  &::after {
+    content: "";
+    position: absolute;
+  }
+
   ${({ $position = "top", $offset = 10 }) => {
     switch ($position) {
       case "bottom":
@@ -32,8 +37,10 @@ export const TooltipContent = styled.div<TooltipContentProps>`
 
           &::after {
             top: -8px;
-            bottom: auto;
-            border-top: none;
+            left: 50%;
+            transform: translateX(-50%);
+            border-left: 8px solid transparent;
+            border-right: 8px solid transparent;
             border-bottom: 8px solid #373a43;
           }
         `;
@@ -45,14 +52,12 @@ export const TooltipContent = styled.div<TooltipContentProps>`
           margin-bottom: 0;
 
           &::after {
-            left: auto;
             right: -8px;
             top: 50%;
             transform: translateY(-50%);
             border-left: 8px solid #373a43;
             border-top: 8px solid transparent;
             border-bottom: 8px solid transparent;
-            border-right: none;
           }
         `;
       case "right":
@@ -69,7 +74,6 @@ export const TooltipContent = styled.div<TooltipContentProps>`
             border-right: 8px solid #373a43;
             border-top: 8px solid transparent;
             border-bottom: 8px solid transparent;
-            border-left: none;
           }
         `;
       default:
@@ -79,8 +83,6 @@ export const TooltipContent = styled.div<TooltipContentProps>`
           transform: translateX(-50%);
 
           &::after {
-            content: "";
-            position: absolute;
             bottom: -8px;
             left: 50%;
             transform: translateX(-50%);

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { TooltipContent, TooltipWrapper } from "./Tooltip.style";
+
+interface TooltipProps {
+  content: string;
+  children: React.ReactNode;
+  position?: "top" | "bottom" | "left" | "right";
+  offset?: number;
+}
+
+export const Tooltip = ({
+  content,
+  children,
+  position = "top",
+  offset = 10,
+}: TooltipProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <TooltipWrapper
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}
+    >
+      {children}
+      {isVisible && (
+        <TooltipContent $position={position} $offset={offset}>
+          {content}
+        </TooltipContent>
+      )}
+    </TooltipWrapper>
+  );
+};

--- a/src/components/dialog/Dialog.style.ts
+++ b/src/components/dialog/Dialog.style.ts
@@ -5,14 +5,18 @@ export const DialogContainer = styled.div<{
   $isOpen: boolean;
   $position: "top" | "bottom";
   $width: number;
+  $top: number;
+  $left: number;
 }>`
   display: ${({ $isOpen }) => ($isOpen ? "block" : "none")};
-  position: absolute;
-  ${({ $position }) => ($position === "top" ? "bottom: 110%" : "top: 110%")};
+  position: fixed;
+  will-change: transform;
+  top: ${({ $top }) => `${$top}px`};
+  left: ${({ $left }) => `${$left}px`};
   width: ${({ $width }) => `${$width}px`};
-  background: ${({ theme }) => theme.semantic.color.bgBasicDefault};
-  border: 1px solid ${({ theme }) => theme.semantic.color.lineBasicLight};
-  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
+  background: white;
+  border: 1px solid #f1f1f4;
+  border-radius: 12px;
   box-shadow: 0px 0px 10px 0px rgba(110, 118, 135, 0.25);
   padding: 8px;
   z-index: 1;
@@ -21,14 +25,14 @@ export const DialogContainer = styled.div<{
 export const StyledTextButton = styled(TextButton)`
   width: 100%;
   text-align: left;
-  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
+  border-radius: 8px;
   justify-content: flex-start;
   padding: 8px;
   white-space: nowrap;
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.semantic.color.buttonTextSecondaryPressed};
-    color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
+    background: #f1f1f4;
+    color: #25262c;
+    border-color: transparent;
   }
 `;

--- a/src/components/dialog/Dialog.style.ts
+++ b/src/components/dialog/Dialog.style.ts
@@ -10,9 +10,9 @@ export const DialogContainer = styled.div<{
   position: absolute;
   ${({ $position }) => ($position === "top" ? "bottom: 110%" : "top: 110%")};
   width: ${({ $width }) => `${$width}px`};
-  background: white;
-  border: 1px solid #f1f1f4;
-  border-radius: 12px;
+  background: ${({ theme }) => theme.semantic.color.bgBasicDefault};
+  border: 1px solid ${({ theme }) => theme.semantic.color.lineBasicLight};
+  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
   box-shadow: 0px 0px 10px 0px rgba(110, 118, 135, 0.25);
   padding: 8px;
   z-index: 1;
@@ -21,14 +21,14 @@ export const DialogContainer = styled.div<{
 export const StyledTextButton = styled(TextButton)`
   width: 100%;
   text-align: left;
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
   justify-content: flex-start;
   padding: 8px;
   white-space: nowrap;
 
   &:hover {
-    background: #f1f1f4;
-    color: #25262c;
-    border-color: transparent;
+    background: ${({ theme }) =>
+      theme.semantic.color.buttonTextSecondaryPressed};
+    color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
   }
 `;

--- a/src/components/dialog/Dialog.style.ts
+++ b/src/components/dialog/Dialog.style.ts
@@ -5,18 +5,12 @@ export const DialogContainer = styled.div<{
   $isOpen: boolean;
   $position: "top" | "bottom";
   $width: number;
-  $top: number;
-  $left: number;
 }>`
   display: ${({ $isOpen }) => ($isOpen ? "block" : "none")};
-  position: fixed;
-  will-change: transform;
-  top: ${({ $top }) => `${$top}px`};
-  left: ${({ $left }) => `${$left}px`};
   width: ${({ $width }) => `${$width}px`};
-  background: white;
-  border: 1px solid #f1f1f4;
-  border-radius: 12px;
+  background: ${({ theme }) => theme.semantic.color.bgBasicDefault};
+  border: 1px solid ${({ theme }) => theme.semantic.color.lineBasicLight};
+  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
   box-shadow: 0px 0px 10px 0px rgba(110, 118, 135, 0.25);
   padding: 8px;
   z-index: 1;
@@ -25,14 +19,14 @@ export const DialogContainer = styled.div<{
 export const StyledTextButton = styled(TextButton)`
   width: 100%;
   text-align: left;
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.semantic.radius.m}px;
   justify-content: flex-start;
   padding: 8px;
   white-space: nowrap;
 
   &:hover {
-    background: #f1f1f4;
-    color: #25262c;
-    border-color: transparent;
+    background: ${({ theme }) =>
+      theme.semantic.color.buttonTextSecondaryPressed};
+    color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
   }
 `;

--- a/src/components/dialog/GenericDialog.tsx
+++ b/src/components/dialog/GenericDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { DialogOption } from "../StateButton/StateButton";
 import { Dialog } from "./Dialog";
 
@@ -18,6 +18,7 @@ export const GenericDialog = ({
   position = "bottom",
 }: GenericDialogProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   const dialogOpener = React.cloneElement(children, {
     onClick: () => setIsOpen((prev) => !prev),
@@ -25,7 +26,7 @@ export const GenericDialog = ({
   });
 
   return (
-    <div style={{ position: "relative" }}>
+    <div ref={anchorRef}>
       {dialogOpener}
       <Dialog
         isOpen={isOpen}
@@ -34,6 +35,7 @@ export const GenericDialog = ({
         onSelect={onSelect}
         position={position}
         width={width}
+        anchorEl={anchorRef.current}
       />
     </div>
   );

--- a/src/components/dialog/GenericDialog.tsx
+++ b/src/components/dialog/GenericDialog.tsx
@@ -1,13 +1,16 @@
 import React, { useRef, useState } from "react";
 import { DialogOption } from "../StateButton/StateButton";
-import { Dialog } from "./Dialog";
 
+import { Dialog } from "./Dialog";
 interface GenericDialogProps {
   options: DialogOption[];
   onSelect: (value: string) => void;
-  children: React.ReactElement;
   width?: number;
   position?: "top" | "bottom";
+  children: (props: {
+    onClick: () => void;
+    onMouseDown: (e: React.MouseEvent) => void;
+  }) => React.ReactElement;
 }
 
 export const GenericDialog = ({
@@ -20,14 +23,12 @@ export const GenericDialog = ({
   const [isOpen, setIsOpen] = useState(false);
   const anchorRef = useRef<HTMLDivElement>(null);
 
-  const dialogOpener = React.cloneElement(children, {
-    onClick: () => setIsOpen((prev) => !prev),
-    onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
-  });
-
   return (
     <div ref={anchorRef}>
-      {dialogOpener}
+      {children({
+        onClick: () => setIsOpen((prev) => !prev),
+        onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+      })}
       <Dialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
- resolved #6 

https://github.com/user-attachments/assets/d8630d8d-8abf-49e9-8f82-c8df5e8bc114

Tooltip 컴포넌트를 제작했습니다.

Tooltip props 설명
```ts
position: 'top' | 'bottom' | 'left' | 'right' // 툴팁 위치 상하좌우
offset: number // 툴팁 거리 조절
```

- offset prop으로 거리 조절 가능 (기본값: 10px)
- 기본적으로 상단에 표시되며 position prop으로 위치 변경 가능
<img width="222" alt="스크린샷 2025-02-02 오후 5 26 21" src="https://github.com/user-attachments/assets/b41dcc89-49e7-41da-bb7f-4eb0fe590c9f" />
<img width="224" alt="스크린샷 2025-02-02 오후 5 26 45" src="https://github.com/user-attachments/assets/fdfdf08e-e944-4dfb-b967-46dbf308caf6" />

이런식으로 위치 변경 가능합니당

### 기존 코드에 영향을 미치는 변경사항
dialog 컴포넌트의 css도 Handy에 정의된 상수 값을 사용하는 걸로 수정했습니다!
리뷰 감사합니당

## 2️⃣ 알아두시면 좋아요!
Table 컴포넌트의 편집 아이콘에 Tooltip 적용하려면 이렇게 수정하면 됩니다

**기존 코드**
```ts
{
  !specialCols.includes(cell.column.id) &&
  <StyledEditIcon>
      <IcEditLine width={20} height={20}/>
  </StyledEditIcon>
}
```

**Tooltip 사용 코드**
```ts
{!specialCols.includes(cell.column.id) && (
  <StyledEditIcon>
    <Tooltip
      content={`${cell.row.original.name} 정보 수정`}
    >
      <IcEditLine width={20} height={20} />
    </Tooltip>
  </StyledEditIcon>
)}
```
이렇게 각 행의 이름과 연동해서 "[이름] 정보 수정" 텍스트를 표시해주면 돼욤

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
