### PR TITLE
feat: 구글 로그인 로직 수정

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,5 +1,5 @@
 import { API_CONFIG } from '@/constants/config';
-import ky, { AfterResponseHook } from 'ky';
+import ky, { AfterResponseHook, BeforeRequestHook } from 'ky';
 import { authService } from './auth.service';
 import { tokenService } from './token.service';
 
@@ -41,7 +41,7 @@ const handleTokenRefresh: AfterResponseHook = async (
   }
 };
 
-const setAuthHeader = (request: Request) => {
+const setAuthHeader: BeforeRequestHook = (request) => {
   const accessToken = tokenService.getAccessToken();
   if (accessToken) {
     request.headers.set('Authorization', `${accessToken}`);

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,34 +1,46 @@
 import { API_CONFIG } from '@/constants/config';
-import ky, { type BeforeRetryHook, HTTPError } from 'ky';
+import ky, { AfterResponseHook } from 'ky';
 import { authService } from './auth.service';
 import { tokenService } from './token.service';
 
 const DEFAULT_API_RETRY_LIMIT = 2;
 
-const stopWithLogout = (): typeof ky.stop => {
-  authService.logout();
-  return ky.stop;
-};
+const handleTokenRefresh: AfterResponseHook = async (
+  request,
+  _options,
+  response,
+) => {
+  if (response.status !== 401) {
+    return response;
+  }
 
-const handleTokenRefresh: BeforeRetryHook = async ({ error }) => {
-  const httpError = error as HTTPError;
+  const errorResponse = await response.json().catch(() => null);
+  const errorCode = (errorResponse as { errorCode?: string })?.errorCode;
 
-  if (httpError.response.status !== 401) {
-    return ky.stop;
+  if (errorCode === 'Auth-004') {
+    authService.logout();
+    authService.initiateGoogleLogin();
+    return response;
   }
 
   const refreshToken = tokenService.getRefreshToken();
   if (!refreshToken) {
-    return stopWithLogout();
+    authService.initiateGoogleLogin();
+    return response;
   }
 
   try {
     await authService.refreshToken(refreshToken);
+    const newAccessToken = tokenService.getAccessToken();
+    request.headers.set('Authorization', `${newAccessToken}`);
+    return ky(request);
   } catch (error) {
-    console.error('Token refresh 실패, 로그아웃', error);
-    return stopWithLogout();
+    authService.logout();
+    authService.initiateGoogleLogin();
+    throw error;
   }
 };
+
 const setAuthHeader = (request: Request) => {
   const accessToken = tokenService.getAccessToken();
   if (accessToken) {
@@ -44,6 +56,6 @@ export const api = ky.create({
   },
   hooks: {
     beforeRequest: [setAuthHeader],
-    beforeRetry: [handleTokenRefresh],
+    afterResponse: [handleTokenRefresh],
   },
 });

--- a/src/apis/auth.service.ts
+++ b/src/apis/auth.service.ts
@@ -7,7 +7,7 @@ export const authService = {
   googleLogin: async (code: string): Promise<GoogleLoginResponse> => {
     try {
       const response = await api
-        .post(API_CONFIG.GOOGLE_OAUTH_LOGIN_URI, {
+        .post('oauth2/login/google', {
           json: { authorizationCode: code },
           throwHttpErrors: false,
         })
@@ -26,7 +26,7 @@ export const authService = {
   },
 
   initiateGoogleLogin: () => {
-    const redirectUrl = `${API_CONFIG.BASE_URL}/${API_CONFIG.GOOGLE_OAUTH_URI}?redirect_uri=${API_CONFIG.GOOGLE_REDIRECT_URI}`;
+    const redirectUrl = `${API_CONFIG.BASE_URL}/oauth2/google?redirect_uri=${API_CONFIG.GOOGLE_REDIRECT_URI}`;
     window.location.href = redirectUrl;
   },
 

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,6 +1,4 @@
 export const API_CONFIG = {
   BASE_URL: import.meta.env.VITE_API_BASE_URL,
   GOOGLE_REDIRECT_URI: `${window.location.origin}/oauth/callback/google`,
-  GOOGLE_OAUTH_URI: import.meta.env.VITE_API_GOOGLE_OAUTH_URI,
-  GOOGLE_OAUTH_LOGIN_URI: import.meta.env.VITE_API_GOOGLE_OAUTH_LOGIN_URI,
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #11 

- [슬랙 논의 내용](https://yourssu.slack.com/archives/C082XCSQK0F/p1741886114744899?thread_ts=1741765427.580439&cid=C082XCSQK0F)에 따라 리다이렉트 uri를 기존으로 변경했습니다. 
`.env`도 기존껄로 수정해야 하는데 이 pr 머지 후에 수정해서 버셀로 재배포 부탁드려요!

- API 요청 처리 방식을 `beforeRetry` 훅에서 `afterResponse` 훅으로 변경하여 401 에러 감지 로직을 개선했습니다.
- 토큰 갱신 실패 시 로그아웃 함수 호출 대신 Google 로그인 페이지로 직접 이동하도록 수정했습니다.
- Error code 'Auth-004' 감지 시 자동으로 Google 로그인 페이지로 리다이렉션하는 로직 추가했습니다.

## 2️⃣ 알아두시면 좋아요!
### 수정 배경 및 이유

1. **401 토큰 재발급 오류 해결**
  - 이전 `beforeRetry` 방식에서는 401 오류 발생 시 토큰 재발급 로직이 정상적으로 동작하지 않는 문제가 있었습니다. 이걸 이제 발견하다니
  - `afterResponse` 훅으로 변경함으로써 모든 응답에 대해 즉시 인증 상태를 확인하고 토큰 재발급을 시도할 수 있게 되었습니다.   
  - `afterResponse` 훅에서는 새 `Response` 객체를 반환하면 Ky가 이를 실제 응답으로 사용하는데 이를 사용해서 토큰 재발급 후 `return ky(request)`로 새로운 요청을 보내고 그 응답을 반환해서 원래 요청을 새 토큰으로 재시도하게 했습니다.
  
   <img width="674" alt="스크린샷 2025-03-14 오후 12 20 06" src="https://github.com/user-attachments/assets/70f9e375-7012-4f64-9314-e28d3924a9e5" />

한 시간 후 토큰 재발급 정상 작동까지 확인했슴니당

2. **특정 에러 코드(Auth-004) 처리 추가**
  - 서버에서 가끔 'Auth-004' 에러 코드와 함께 "유저가 없음" 메시지가 반환되는 상황이 발생합니다. 세션을 켜두고 이틀 정도 지나고 나서 가끔씩 발생하는데 (토큰 만료 기간인 14일과는 별개 문제) 이 경우에는 토큰 재발급이 정상적으로 작동하지 않고 무한 재발급 루프에 빠지는 현상이 발생합니다! 왜 그런지는 에러 재현도 잘 안돼서 원인을 바로 못 찾겠는데요 🥹 일단 임시로 무한 루프에서 빠져나오도록 처리해두고 추가로 계속 찾아볼게요! Google 로그인 과정에서 사용자 정보 처리 문제일 가능성이 있어 그 부분 찾아볼 예정입니다.
  
## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
