### PR TITLE
feat: 면접 일정 관리 페이지 라우트를 추가했어요.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Main from '@/components/Main/Main.tsx';
 import ScouterErrorBoundary from '@/components/ScouterErrorBoundary.tsx';
 import { Applicants } from '@/pages/Applicants/Applicants.tsx';
 import CalendarTestPage from '@/pages/CalendarTestPage';
+import { InterviewPage } from '@/pages/Interview';
 import { Members } from '@/pages/Members/Members.tsx';
 import { SendMail } from '@/pages/SendMail/SendMail';
 
@@ -17,6 +18,7 @@ function App() {
           <Route element={<GoogleCallback />} path="/oauth/callback/google" />
           <Route element={<Main />} path="*">
             <Route element={<>응애</>} index />
+            <Route element={<InterviewPage />} path="interview" />
             <Route element={<CalendarTestPage />} path="test" />
             <Route element={<Members />} path="members" />
             <Route element={<Applicants />} path="recruiting" />

--- a/src/components/Main/SideNavigation/SideNavigation.tsx
+++ b/src/components/Main/SideNavigation/SideNavigation.tsx
@@ -41,7 +41,7 @@ const SideNavigation = () => {
         {
           icon: <IcCalenderLine />,
           text: '면접 일정 관리',
-          pathname: '/schedules',
+          pathname: '/interview',
         },
         {
           icon: <IcPinLine />,

--- a/src/pages/Interview/index.tsx
+++ b/src/pages/Interview/index.tsx
@@ -1,0 +1,9 @@
+import { StyledContainer, StyledTitle } from '@/styles/pages/table';
+
+export const InterviewPage = () => {
+  return (
+    <StyledContainer>
+      <StyledTitle>면접 일정 관리</StyledTitle>
+    </StyledContainer>
+  );
+};


### PR DESCRIPTION
## 어떤 작업을 했나요? (Summary)

- 면접 일정 관리 페이지에 대한 라우트 경로를 추가했어요. (`/interview`)

  - 하는 김에 타이틀 페이지 까지는 만들어줬습니다.

- 기존 사이드바의 링크가 `/schedule` 로 되어있었는데, 이를 `/interview` 로 변경해줬어요.

<br />

## 알아두시면 좋아요

- #31 

~어차피 곧 머지될거 같아서 브랜치를 base branch로 일단 따뒀어요.~ -> 완료