### PR TITLE
fix: 캘린더 시간 선택 후 날짜 변경 시 이전 시간으로 돌아가는 이슈 해결

### DIFF
--- a/src/components/CalendarDialog/CalendarDialog.tsx
+++ b/src/components/CalendarDialog/CalendarDialog.tsx
@@ -7,6 +7,7 @@ import {
   endOfWeek,
   isSameDay,
   setHours,
+  setMinutes,
   startOfHour,
   startOfWeek,
 } from 'date-fns';
@@ -65,19 +66,34 @@ export const CalendarDialog = ({ onSelect, trigger, selectedDate }: CalendarDial
   const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
   const dates = generateCalendarDates(currentDate);
 
-  const handleSelectDate = (date: Date) => {
-    onSelect(date);
-  };
-
   const handleMonthChange = (amount: number) => {
     const newDate = addMonths(new Date(currentDate.year, currentDate.month, 1), amount);
     setCurrentDate({ year: newDate.getFullYear(), month: newDate.getMonth() });
   };
 
+  const handleDateChange = (date: Date) => {
+    if (selectedDate) {
+      const selectedHours = selectedDate.getHours();
+      const selectedMinutes = selectedDate.getMinutes();
+      const updatedDate = setHours(setMinutes(date, selectedMinutes), selectedHours);
+      onSelect(updatedDate);
+    } else {
+      onSelect(getCloseHour(date));
+    }
+  };
+
+  const handleTimeChange = (date: Date) => {
+    onSelect(date);
+  };
+
   const getCloseHour = (date: Date) => {
     const now = new Date();
     const nextHour = startOfHour(addHours(now, 1));
-    return setHours(date, nextHour.getHours());
+    let targetHour = nextHour.getHours();
+    if (targetHour < 9 || targetHour > 22) {
+      targetHour = 9;
+    }
+    return setHours(date, targetHour);
   };
 
   return (
@@ -107,7 +123,7 @@ export const CalendarDialog = ({ onSelect, trigger, selectedDate }: CalendarDial
                       date={date}
                       isToday={isSameDay(date, today)}
                       key={date.toISOString()}
-                      onClick={() => handleSelectDate(getCloseHour(date))}
+                      onClick={() => handleDateChange(date)}
                       selectedDate={selectedDate}
                     />
                   ))}
@@ -116,7 +132,7 @@ export const CalendarDialog = ({ onSelect, trigger, selectedDate }: CalendarDial
             </CalendarContainer>
             <DateFieldWrapper>
               <MiniDateField date={displayDate} />
-              <MiniTimeField date={displayDate} onDateChange={handleSelectDate} />
+              <MiniTimeField date={displayDate} onDateChange={handleTimeChange} />
             </DateFieldWrapper>
           </CalendarDialogContainer>
         </Popover.Content>

--- a/src/components/CalendarDialog/MiniTimeField.tsx
+++ b/src/components/CalendarDialog/MiniTimeField.tsx
@@ -50,7 +50,7 @@ export const MiniTimeField = ({ date, onDateChange }: MiniTimeFieldProps) => {
         <MiniDateFieldContainer>
           <IcClockLine color="#6E7687" height={24} width={24} />
           {time}
-          <IcArrowsChevronDownFilled color="#6E7687" height={16} width={16} />
+          <IcArrowsChevronDownFilled color="#6E7687" height={15} width={15} />
         </MiniDateFieldContainer>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>


### PR DESCRIPTION
## 어떤 작업을 했나요? (Summary)

- resolved #37 
- 시간을 선택하고, 날짜를 변경 시 선택된 시간 유지하도록 변경
- 오전 10:00 ~ 오후 12:30 시간대가 선택되면 줄이 바뀌는 문제가 있어서 down chevron 아이콘 크기를 조금 줄였습니다

## 추후 작업
- 어프룹 받으면 `pages/calendarTestPage` 삭제하고 머지하려고 합니다(웬만한 캘린더 테스트는 끝난 것 같아서 불필요하다고 생각됨)

## 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
