### PR TITLE
fix: accessToken 만료시 무한 요청이 되던 문제를 해결했어요.

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -47,11 +47,17 @@ const setAuthHeader: BeforeRequestHook = (request) => {
   }
 };
 
-export const api = ky.create({
+/* 
+  API 토큰이 필요없는 상황에서 사용해요.
+*/
+export const nativeApi = ky.create({
   prefixUrl: API_CONFIG.BASE_URL,
   retry: {
     limit: DEFAULT_API_RETRY_LIMIT,
   },
+});
+
+export const api = nativeApi.extend({
   hooks: {
     beforeRequest: [setAuthHeader],
     afterResponse: [handleTokenRefresh],

--- a/src/apis/auth.service.ts
+++ b/src/apis/auth.service.ts
@@ -1,4 +1,4 @@
-import { api } from '@/apis/api';
+import { nativeApi } from '@/apis/api';
 import { API_CONFIG } from '@/constants/config';
 import { GoogleLoginResponse, TokenResponse } from '@/types/auth.types';
 
@@ -7,7 +7,7 @@ import { tokenService } from './token.service';
 export const authService = {
   googleLogin: async (code: string): Promise<GoogleLoginResponse> => {
     try {
-      const response = await api
+      const response = await nativeApi
         .post('oauth2/login/google', {
           json: { authorizationCode: code },
           throwHttpErrors: false,
@@ -43,7 +43,7 @@ export const authService = {
   // },
 
   refreshToken: async (refreshToken: string): Promise<TokenResponse> => {
-    const response = await api
+    const response = await nativeApi
       .post('refresh-token', {
         json: { refreshToken: `${refreshToken}` },
       })
@@ -55,7 +55,7 @@ export const authService = {
 
   logout: async () => {
     try {
-      await api.post('logout', {
+      await nativeApi.post('logout', {
         json: { refreshToken: `${tokenService.getAccessToken()}` },
       });
     } catch (error) {


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

accessToken이 만료됐을 때, 무한으로 /refresh-token API 를 찌르던 문제를 해결했어요.

### 배경 지식

- 백엔드에 /refresh-token API가 요청 헤더에 유효하지 않은 accessToken을 같이 넘겼을 때 무조건 에러를 반환하는 문제가 있어요.

- 기존 코드 상에서 이 엔드포인트를 호출할 때 현재 들고있는 accessToken을 같이 넘기고 있었는데, 문제는 `/refresh-token` 을 요청하는 시점에는 accessToken이 유효하지 않다는 것 이에요.

- 따라서 아무리 /refresh-token을 요청하더라도 항상 에러를 반환하게 되어 무한루프가 발생하고 있었습니다.

### 해결

스펙상 accessToken에 종속되지 않은 API 호출시에는 요청 헤더에 accessToken을 넣지 않게 만드는 방식으로 변경했어요.
