### PR TITLE
chore: 환경변수로 옵셔널하게 vite HMR polling 방식을 트리거해요.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
+    "@types/node": "^24.5.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react-swc": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@eslint/js':
         specifier: ^9.35.0
         version: 9.35.0
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.5.2
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.20
@@ -95,7 +98,7 @@ importers:
         version: 18.3.6(@types/react@18.3.20)
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.1
-        version: 4.0.1(vite@6.3.6(yaml@2.8.1))
+        version: 4.0.1(vite@6.3.6(@types/node@24.5.2)(yaml@2.8.1))
       eslint:
         specifier: ^9.35.0
         version: 9.35.0
@@ -137,10 +140,10 @@ importers:
         version: 8.42.0(eslint@9.35.0)(typescript@5.9.2)
       vite:
         specifier: ^6.3.6
-        version: 6.3.6(yaml@2.8.1)
+        version: 6.3.6(@types/node@24.5.2)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@6.3.6(yaml@2.8.1))
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.6(@types/node@24.5.2)(yaml@2.8.1))
 
 packages:
 
@@ -1558,6 +1561,9 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/node@24.5.2':
+    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
+
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
 
@@ -2944,6 +2950,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@7.12.0:
+    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -4469,6 +4478,10 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/node@24.5.2':
+    dependencies:
+      undici-types: 7.12.0
+
   '@types/prop-types@15.7.14': {}
 
   '@types/react-dom@18.3.6(@types/react@18.3.20)':
@@ -4577,11 +4590,11 @@ snapshots:
       '@typescript-eslint/types': 8.42.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react-swc@4.0.1(vite@6.3.6(yaml@2.8.1))':
+  '@vitejs/plugin-react-swc@4.0.1(vite@6.3.6(@types/node@24.5.2)(yaml@2.8.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.32
       '@swc/core': 1.13.5
-      vite: 6.3.6(yaml@2.8.1)
+      vite: 6.3.6(@types/node@24.5.2)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -6197,6 +6210,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@7.12.0: {}
+
   update-browserslist-db@1.1.3(browserslist@4.25.4):
     dependencies:
       browserslist: 4.25.4
@@ -6226,18 +6241,18 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@6.3.6(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@6.3.6(@types/node@24.5.2)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 6.3.6(yaml@2.8.1)
+      vite: 6.3.6(@types/node@24.5.2)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.6(yaml@2.8.1):
+  vite@6.3.6(@types/node@24.5.2)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6246,6 +6261,7 @@ snapshots:
       rollup: 4.39.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 24.5.2
       fsevents: 2.3.3
       yaml: 2.8.1
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
+  readonly VITE_USE_POLLING: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,28 @@
 import react from '@vitejs/plugin-react-swc';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+const useViteHMRPolling = (env: Record<string, string>) => {
+  if (env.VITE_USE_POLLING !== 'true') {
+    return false;
+  }
+  // console orange color
+  console.warn(
+    '\x1b[33m[WARN] Vite HMR에 Polling을 사용하도록 변경했어요. CPU 사용에 유의해주세요.\x1b[0m',
+  );
+  return true;
+};
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+
+  return {
+    plugins: [react(), tsconfigPaths()],
+    server: {
+      watch: {
+        usePolling: useViteHMRPolling(env),
+      },
+    },
+  };
 });


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

`VITE_USE_POLLING` 환경변수를 통해 옵셔널하게 vite HMR 방식을 polling으로 선택하는 여지를 제공해요.

### 배경

- vite HMR의 파일 변경 감지 방식은 node의 `fs.watch` 이벤트를 받아서 사용해요.

- 저의 환경에서 이 이벤트가 제대로 트리거되지 않는 문제가 발생했는데, 아무리 트러블슈팅을 해봐도 원인을 못찾겠더라고요.

- 따라서 우선 임시 방편으로 폴링 방식으로 파일을 감지할 수 있도록 해줬어요. 이 이슈는 계속 트래킹해볼 예정입니다.

### 구현 내용

vite.config.ts 에서 `VITE_USE_POLLING` 환경변수의 값이 'true' 라면 polling 방식을 사용하도록 해요.

이 경우, 콘솔에서 주황색으로 폴링을 사용중이라고 알려주도록 했어요.

<img width="851" height="324" alt="스크린샷 2025-09-21 04 02 08" src="https://github.com/user-attachments/assets/4a7b804f-6139-458b-8e5a-2971f64aa9cc" />

### 주의

나리의 환경에서는 필요없을 가능성이 높아요.
기본적으로 이 옵션은 꺼져있어서 큰 문제는 없겠지만, 혹여나 사용시 CPU 사용량에 주의해주세요. (사실 큰 문제는 안됩니다.)

