### PR TITLE
feat: RFC 표준에 따라 인증 토큰에서 타입을 분리해서 관리하고 요청해요

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -41,8 +41,9 @@ const handleTokenRefresh: AfterResponseHook = async (request, _options, response
 
 const setAuthHeader: BeforeRequestHook = (request) => {
   const accessToken = tokenService.getAccessToken();
+  const tokenType = tokenService.getTokenType();
   if (accessToken) {
-    request.headers.set('Authorization', `${accessToken}`);
+    request.headers.set('Authorization', `${tokenType} ${accessToken}`);
     request.headers.set('Content-Type', 'application/json');
   }
 };

--- a/src/apis/auth.service.ts
+++ b/src/apis/auth.service.ts
@@ -18,7 +18,7 @@ export const authService = {
         throw new Error('Login failed');
       }
 
-      tokenService.setTokens(response.accessToken, response.refreshToken);
+      tokenService.setTokens(response);
       return response;
     } catch (error) {
       console.error('Google login error:', error);
@@ -49,7 +49,7 @@ export const authService = {
       })
       .json<TokenResponse>();
 
-    tokenService.setTokens(response.accessToken, response.refreshToken);
+    tokenService.setTokens(response);
     return response;
   },
 

--- a/src/apis/token.service.ts
+++ b/src/apis/token.service.ts
@@ -1,21 +1,32 @@
+import { AuthTokenType } from '@/types/auth.types';
+
+const accessTokenKey = 'accessToken';
+const refreshTokenKey = 'refreshToken';
+const tokenTypeKey = 'tokenType';
+
 export const tokenService = {
-  getAccessToken: () => localStorage.getItem('accessToken'),
+  getAccessToken: () => localStorage.getItem(accessTokenKey),
 
-  getRefreshToken: () => localStorage.getItem('refreshToken'),
+  getRefreshToken: () => localStorage.getItem(refreshTokenKey),
 
-  setTokens: (accessToken: string, refreshToken: string) => {
-    localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
+  getTokenType: () => localStorage.getItem(tokenTypeKey),
+
+  setTokens: ({ accessToken, refreshToken, tokenType }: AuthTokenType) => {
+    localStorage.setItem(accessTokenKey, accessToken);
+    localStorage.setItem(refreshTokenKey, refreshToken);
+    localStorage.setItem(tokenTypeKey, tokenType);
   },
 
   clearTokens: () => {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    localStorage.removeItem(accessTokenKey);
+    localStorage.removeItem(refreshTokenKey);
+    localStorage.removeItem(tokenTypeKey);
   },
 
   hasTokens: () => {
-    const accessToken = localStorage.getItem('accessToken');
-    const refreshToken = localStorage.getItem('refreshToken');
-    return !!(accessToken && refreshToken);
+    const accessToken = tokenService.getAccessToken();
+    const refreshToken = tokenService.getRefreshToken();
+    const tokenType = tokenService.getTokenType();
+    return !!(accessToken && refreshToken && tokenType);
   },
 };

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -1,13 +1,8 @@
-export interface TokenResponse {
+export type AuthTokenType = {
   accessToken: string;
   refreshToken: string;
-}
+  tokenType: string;
+};
 
-// export interface ValidateTokenResponse {
-//   validated: boolean;
-// }
-
-export interface GoogleLoginResponse {
-  accessToken: string;
-  refreshToken: string;
-}
+export type TokenResponse = AuthTokenType;
+export type GoogleLoginResponse = AuthTokenType;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

[RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4)에 따르면 인증 토큰과 토큰 타입을 분리해서 관리하는게 표준이에요.
기존 백엔드에서는 인증 관련 요청시 타입을 토큰 값과 합친 문자열을 응답으로 내려주고 있었는데, 표준에 맞춰 분리하는 작업이 진행되었어요.
이를 팔로업하는 PR입니다.

### 작업 내용

- 백엔드 응답으로 내려오는 tokenType을 가져다 localStorage에서 tokenType을 저장하도록 했어요.
- 인증이 필요한 api 요청시 헤더에 이 토큰 타입을 명시하도록 했어요.