### PR TITLE
chore: 프로젝트에서 ESNext를 쓸 수 있도록 해요

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tiptap/starter-kit": "^2.11.5",
     "@yourssu/design-system-react": "^2.3.4",
     "clsx": "^2.1.1",
+    "core-js": "^3.45.1",
     "date-fns": "^4.1.0",
     "ky": "^1.7.4",
     "radix-ui": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      core-js:
+        specifier: ^3.45.1
+        version: 3.45.1
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1934,6 +1937,9 @@ packages:
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
+
+  core-js@3.45.1:
+    resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -5173,6 +5179,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.0.2: {}
+
+  core-js@3.45.1: {}
 
   crelt@1.0.6: {}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import { BrowserRouter } from 'react-router';
 
 import App from '@/App.tsx';
 
+import 'core-js/stable';
+
 import './styles/index.css';
 
 const queryClient = new QueryClient();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
+    "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

앞으로 ESNext 같은 채신기술을 쓸 수 있도록 tsconfig에서 컴파일러 타게팅을 높였어요.

- 무려 toSorted를 쓸 수 있습니다.

하지만 일부 구형 브라우저는 사용할 수 없기 때문에 core-js/stable 폴리필을 추가해줬습니다.