### PR TITLE
Refactor: variables를 Template interface 안에서 관리하도록 변경

### DIFF
--- a/src/pages/Template/Templates.tsx
+++ b/src/pages/Template/Templates.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import TableSearchBar from '@/components/TableSearchBar/TableSearchBar';
 import { TemplateList } from '@/components/TemplateList/TemplateList';
+import { Template } from '@/types/template';
 
 import { AddTemplateDialog } from './components/AddTemplateDialog/AddTemplateDialog';
 import { DeleteTemplateDialog } from './components/DeleteTemplateDialog/DeleteTemplateDialog';
@@ -21,13 +22,6 @@ type TabType = (typeof templateTypes)[number];
 
 interface TemplateFormData {
   search: string;
-}
-
-interface Template {
-  content?: string; // 편집에 필요한 추가 데이터
-  date: string;
-  id: number;
-  title: string;
 }
 
 const convertEnterToBr = (text: string) => {

--- a/src/pages/Template/components/AddTemplateDialog/AddTemplateDialog.tsx
+++ b/src/pages/Template/components/AddTemplateDialog/AddTemplateDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog } from 'radix-ui';
 import { useState } from 'react';
 
 import { TemplateEditor } from '@/pages/Template/components/TemplateEditor';
+import { Template } from '@/types/template';
 
 import {
   StyledBody,
@@ -13,13 +14,6 @@ import {
   StyledOverlay,
   StyledTitleInput,
 } from './AddTemplateDialog.style';
-
-interface Template {
-  content?: string;
-  date: string;
-  id: number;
-  title: string;
-}
 
 interface AddTemplateDialogProps {
   isOpen: boolean;

--- a/src/pages/Template/components/AddTemplateDialog/AddTemplateDialog.tsx
+++ b/src/pages/Template/components/AddTemplateDialog/AddTemplateDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog } from 'radix-ui';
 import { useState } from 'react';
 
 import { TemplateEditor } from '@/pages/Template/components/TemplateEditor';
+import { defaultVariables, Variable } from '@/types/editor';
 import { Template } from '@/types/template';
 
 import {
@@ -25,6 +26,7 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
   const [formData, setFormData] = useState({
     title: '',
     content: '',
+    variables: defaultVariables,
   });
 
   const handleSave = () => {
@@ -32,6 +34,7 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
       onSave({
         title: formData.title.trim(),
         content: formData.content,
+        variables: formData.variables,
       });
       handleClose();
     }
@@ -41,6 +44,7 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
     setFormData({
       title: '',
       content: '',
+      variables: defaultVariables,
     });
     onClose();
   };
@@ -56,6 +60,13 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
     setFormData((prev) => ({
       ...prev,
       content,
+    }));
+  };
+
+  const handleVariablesChange = (variables: Variable[]) => {
+    setFormData((prev) => ({
+      ...prev,
+      variables,
     }));
   };
 
@@ -79,7 +90,9 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
           <StyledBody>
             <TemplateEditor
               onContentChange={handleContentChange}
+              onVariablesChange={handleVariablesChange}
               templateContent={formData.content}
+              templateVariables={formData.variables}
             />
           </StyledBody>
           <StyledFooter>

--- a/src/pages/Template/components/EditTemplateDialog/EditTemplateDialog.tsx
+++ b/src/pages/Template/components/EditTemplateDialog/EditTemplateDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog } from 'radix-ui';
 import { useEffect, useState } from 'react';
 
 import { TemplateEditor } from '@/pages/Template/components/TemplateEditor';
+import { Template } from '@/types/template';
 
 import {
   StyledBody,
@@ -13,13 +14,6 @@ import {
   StyledOverlay,
   StyledTitleInput,
 } from './EditTemplateDialog.style';
-
-interface Template {
-  content?: string;
-  date: string;
-  id: number;
-  title: string;
-}
 
 interface EditTemplateDialogProps {
   isOpen: boolean;

--- a/src/pages/Template/components/EditTemplateDialog/EditTemplateDialog.tsx
+++ b/src/pages/Template/components/EditTemplateDialog/EditTemplateDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog } from 'radix-ui';
 import { useEffect, useState } from 'react';
 
 import { TemplateEditor } from '@/pages/Template/components/TemplateEditor';
+import { defaultVariables, Variable } from '@/types/editor';
 import { Template } from '@/types/template';
 
 import {
@@ -31,6 +32,7 @@ export const EditTemplateDialog = ({
   const [formData, setFormData] = useState({
     title: template?.title ?? '',
     content: template?.content ?? '',
+    variables: template?.variables ?? defaultVariables,
   });
 
   // template이 변경될 때 폼 데이터 업데이트
@@ -39,6 +41,7 @@ export const EditTemplateDialog = ({
       setFormData({
         title: template.title,
         content: template.content || '',
+        variables: template.variables || defaultVariables,
       });
     }
   }, [template]);
@@ -49,6 +52,7 @@ export const EditTemplateDialog = ({
         ...template,
         title: formData.title.trim(),
         content: formData.content,
+        variables: formData.variables,
       });
       onClose();
     }
@@ -73,6 +77,13 @@ export const EditTemplateDialog = ({
     }));
   };
 
+  const handleVariablesChange = (variables: Variable[]) => {
+    setFormData((prev) => ({
+      ...prev,
+      variables,
+    }));
+  };
+
   return (
     <Dialog.Root onOpenChange={handleClose} open={isOpen}>
       <Dialog.Portal>
@@ -94,7 +105,9 @@ export const EditTemplateDialog = ({
           <StyledBody>
             <TemplateEditor
               onContentChange={handleContentChange}
-              templateContent={template.content ?? ''}
+              onVariablesChange={handleVariablesChange}
+              templateContent={formData.content ?? ''}
+              templateVariables={formData.variables || defaultVariables}
             />
           </StyledBody>
 

--- a/src/pages/Template/components/TemplateEditor.tsx
+++ b/src/pages/Template/components/TemplateEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import { getChipType } from '@/components/VariableChip/utils';
 import { EditorContainer } from '@/pages/SendMail/MailEditor/MailEditor.style';
@@ -11,15 +11,17 @@ import { Variable, VariableType } from '@/types/editor';
 
 interface TemplateEditorProps {
   onContentChange: (content: string) => void;
+  onVariablesChange: (variables: Variable[]) => void;
   templateContent: string;
+  templateVariables: Variable[];
 }
 
-export const TemplateEditor = ({ templateContent, onContentChange }: TemplateEditorProps) => {
-  const [variables, setVariables] = useState<Variable[]>([
-    { id: '1', type: '텍스트/파트명', name: '파트명', differentForEachPerson: false },
-    { id: '2', type: '사람/지원자', name: '지원자', differentForEachPerson: true },
-  ]);
-
+export const TemplateEditor = ({
+  templateContent,
+  templateVariables,
+  onContentChange,
+  onVariablesChange,
+}: TemplateEditorProps) => {
   const editorRef = useRef<MailEditorContentRef>(null);
 
   const handleVariableClick = (variable: Variable) => {
@@ -37,12 +39,12 @@ export const TemplateEditor = ({ templateContent, onContentChange }: TemplateEdi
       differentForEachPerson,
     };
 
-    setVariables((prev) => [...prev, newVariable]);
+    onVariablesChange([...templateVariables, newVariable]);
   };
 
   const handleVariableDelete = (variable: Variable) => {
     if (editorRef.current) {
-      setVariables((prev) => prev.filter((v) => v.id !== variable.id));
+      onVariablesChange(templateVariables.filter((v) => v.id !== variable.id));
       editorRef.current.deleteVariable(variable.name);
     }
   };
@@ -55,7 +57,7 @@ export const TemplateEditor = ({ templateContent, onContentChange }: TemplateEdi
           onVariableClick={handleVariableClick}
           onVariableDelete={handleVariableDelete}
           type="normal"
-          variables={variables}
+          variables={templateVariables}
         />
         <MailEditorContent
           initialContent={templateContent}

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -6,3 +6,8 @@ export interface Variable {
   name: string;
   type: VariableType;
 }
+
+export const defaultVariables: Variable[] = [
+  { id: '1', type: '텍스트/파트명', name: '파트명', differentForEachPerson: false },
+  { id: '2', type: '사람/지원자', name: '지원자', differentForEachPerson: true },
+];

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,6 +1,9 @@
+import { Variable } from '@/types/editor';
+
 export interface Template {
   content?: string;
   date: string;
   id: number;
   title: string;
+  variables?: Variable[];
 }

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,6 @@
+export interface Template {
+  content?: string;
+  date: string;
+  id: number;
+  title: string;
+}


### PR DESCRIPTION
## 어떤 작업을 했나요? (Summary)
- 기존 코드는 `varaibles`를 `TempalteEditor` 내부에서만 관리해서 `varaibles` 변경사항이 상위로 전달되지 않았음
- 백엔드에 템플릿 요청할 때도 변수를 포함해서 보내야 하기에 구조를 `Template` 인터페이스 안에서 `variables`를 관리하도록 변경함

## 추후 작업
- 보니까 변수가 많아졌을 때 디자인이 다 깨져서 이 부분 수정하는 PR을 올리려고 합니다. 일단 `flex-wrap: wrap;` 추가해서 변수가 많아졌을 때 다음 줄로 넘어가게 했는데, 이 부분 관련해서 우미가 원하는 다른 그림이 있을까봐 여쭤본 상태

## 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
