### PR TITLE
feat: `희망일정` 모드에서의 캘린더를 구현했어요.

### DIFF
--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock.tsx
@@ -1,5 +1,7 @@
+import { motion } from 'motion/react';
 import { tv } from 'tailwind-variants';
 
+import { useAvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
 import { Applicant } from '@/query/applicant/schema';
 
 interface AvailableTimesBlockProps {
@@ -24,6 +26,8 @@ export const AvailableTimesBlock = ({
   applicants,
   totalPartApplicants,
 }: AvailableTimesBlockProps) => {
+  const { setHoveredBlockApplicantIds } = useAvailableTimesModeHoverContext();
+
   const getOpacityLevel = () => {
     const ratio = applicants.length / totalPartApplicants;
     if (ratio <= 0.2) {
@@ -41,5 +45,13 @@ export const AvailableTimesBlock = ({
     return 'full' as const;
   };
 
-  return <div className={block({ opacity: getOpacityLevel() })} />;
+  return (
+    <motion.div
+      className={block({ opacity: getOpacityLevel() })}
+      onHoverEnd={() => setHoveredBlockApplicantIds([])}
+      onHoverStart={() =>
+        setHoveredBlockApplicantIds(applicants.map(({ applicantId }) => applicantId))
+      }
+    />
+  );
 };

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock.tsx
@@ -1,0 +1,45 @@
+import { tv } from 'tailwind-variants';
+
+import { Applicant } from '@/query/applicant/schema';
+
+interface AvailableTimesBlockProps {
+  applicants: Applicant[];
+  totalPartApplicants: number;
+}
+
+const block = tv({
+  base: 'bg-bg-brandPrimary size-full rounded-lg',
+  variants: {
+    opacity: {
+      light: 'opacity-20',
+      small: 'opacity-40',
+      medium: 'opacity-60',
+      high: 'opacity-80',
+      full: 'opacity-100',
+    },
+  },
+});
+
+export const AvailableTimesBlock = ({
+  applicants,
+  totalPartApplicants,
+}: AvailableTimesBlockProps) => {
+  const getOpacityLevel = () => {
+    const ratio = applicants.length / totalPartApplicants;
+    if (ratio <= 0.2) {
+      return 'light' as const;
+    }
+    if (ratio <= 0.4) {
+      return 'small' as const;
+    }
+    if (ratio <= 0.6) {
+      return 'medium' as const;
+    }
+    if (ratio <= 0.8) {
+      return 'high' as const;
+    }
+    return 'full' as const;
+  };
+
+  return <div className={block({ opacity: getOpacityLevel() })} />;
+};

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock.tsx
@@ -6,6 +6,7 @@ import { Applicant } from '@/query/applicant/schema';
 
 interface AvailableTimesBlockProps {
   applicants: Applicant[];
+  isStatic?: boolean;
   totalPartApplicants: number;
 }
 
@@ -25,8 +26,23 @@ const block = tv({
 export const AvailableTimesBlock = ({
   applicants,
   totalPartApplicants,
+  isStatic,
 }: AvailableTimesBlockProps) => {
   const { setHoveredBlockApplicantIds } = useAvailableTimesModeHoverContext();
+
+  const onHoverStart = () => {
+    if (isStatic) {
+      return;
+    }
+    setHoveredBlockApplicantIds(applicants.map(({ applicantId }) => applicantId));
+  };
+
+  const onHoverEnd = () => {
+    if (isStatic) {
+      return;
+    }
+    setHoveredBlockApplicantIds([]);
+  };
 
   const getOpacityLevel = () => {
     const ratio = applicants.length / totalPartApplicants;
@@ -47,11 +63,9 @@ export const AvailableTimesBlock = ({
 
   return (
     <motion.div
-      className={block({ opacity: getOpacityLevel() })}
-      onHoverEnd={() => setHoveredBlockApplicantIds([])}
-      onHoverStart={() =>
-        setHoveredBlockApplicantIds(applicants.map(({ applicantId }) => applicantId))
-      }
+      className={block({ opacity: isStatic ? 'full' : getOpacityLevel() })}
+      onHoverEnd={onHoverEnd}
+      onHoverStart={onHoverStart}
     />
   );
 };

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar.tsx
@@ -1,0 +1,48 @@
+import { setHours, setMinutes } from 'date-fns';
+
+import { useDateMap } from '@/hooks/useDateMap';
+import { AvailableTimesBlock } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock';
+import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
+import { Applicant } from '@/query/applicant/schema';
+
+interface AvailableTimesCalendarProps {
+  availableApplicants: Applicant[];
+  month: number;
+  week: number;
+  year: number;
+}
+
+type AvailableApplicantEntry = [Date, Applicant[]];
+
+export const AvailableTimesCalendar = ({
+  month,
+  week,
+  year,
+  availableApplicants,
+}: AvailableTimesCalendarProps) => {
+  const makeAvailableApplicantEntries = (applicant: Applicant): AvailableApplicantEntry[] => {
+    return applicant.availableTimes.map((time) => [new Date(time), [applicant]]);
+  };
+
+  const [map] = useDateMap({
+    initialEntries: availableApplicants.flatMap(makeAvailableApplicantEntries),
+    precision: '분',
+  });
+
+  return (
+    <InterviewCalendar month={month} week={week} year={year}>
+      {({ date, hour, minute }) => {
+        const targetDate = setMinutes(setHours(date, hour), minute);
+        const applicants = map.get(targetDate) ?? [];
+        return (
+          applicants.length > 0 && (
+            <AvailableTimesBlock
+              applicants={applicants}
+              totalPartApplicants={availableApplicants.length}
+            />
+          )
+        );
+      }}
+    </InterviewCalendar>
+  );
+};

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar.tsx
@@ -2,6 +2,7 @@ import { setHours, setMinutes } from 'date-fns';
 
 import { useDateMap } from '@/hooks/useDateMap';
 import { AvailableTimesBlock } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesBlock';
+import { useAvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
 import { Applicant } from '@/query/applicant/schema';
 
@@ -20,6 +21,8 @@ export const AvailableTimesCalendar = ({
   year,
   availableApplicants,
 }: AvailableTimesCalendarProps) => {
+  const { hoveredChipApplicantId } = useAvailableTimesModeHoverContext();
+
   const makeAvailableApplicantEntries = (applicant: Applicant): AvailableApplicantEntry[] => {
     return applicant.availableTimes.map((time) => [new Date(time), [applicant]]);
   };
@@ -34,10 +37,17 @@ export const AvailableTimesCalendar = ({
       {({ date, hour, minute }) => {
         const targetDate = setMinutes(setHours(date, hour), minute);
         const applicants = map.get(targetDate) ?? [];
+
+        const filteredApplicants =
+          hoveredChipApplicantId !== null
+            ? applicants.filter(({ applicantId }) => applicantId === hoveredChipApplicantId)
+            : applicants;
+
         return (
-          applicants.length > 0 && (
+          filteredApplicants.length > 0 && (
             <AvailableTimesBlock
-              applicants={applicants}
+              applicants={filteredApplicants}
+              isStatic={hoveredChipApplicantId !== null}
               totalPartApplicants={availableApplicants.length}
             />
           )

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeader.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeader.tsx
@@ -4,19 +4,18 @@ import { PartFilterDropdown } from '@/pages/Interview/components/InterviewSchedu
 import { Applicant } from '@/query/applicant/schema';
 
 interface AvailableTimesHeaderProps {
-  applicants: Applicant[];
+  availableApplicants: Applicant[];
   indicator: {
     month: number;
     onNextWeek: () => void;
     onPrevWeek: () => void;
     week: number;
-    year: number;
   };
 }
 
 export const AvailableTimesHeader = ({
-  indicator: { year, month, week, onNextWeek, onPrevWeek },
-  applicants,
+  indicator: { month, week, onNextWeek, onPrevWeek },
+  availableApplicants,
 }: AvailableTimesHeaderProps) => {
   return (
     <InterviewHeaderLayout>
@@ -31,12 +30,7 @@ export const AvailableTimesHeader = ({
         </InterviewHeaderLayout.ButtonGroup>
       </InterviewHeaderLayout.Row>
       <InterviewHeaderLayout.Row>
-        <AvailableTimesHeaderChipGroup
-          applicants={applicants}
-          month={month}
-          week={week}
-          year={year}
-        />
+        <AvailableTimesHeaderChipGroup availableApplicants={availableApplicants} />
       </InterviewHeaderLayout.Row>
     </InterviewHeaderLayout>
   );

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeaderChipGroup.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeaderChipGroup.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'motion/react';
 import { tv } from 'tailwind-variants';
 
 import { useAvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
@@ -8,7 +9,7 @@ interface AvailableTimesHeaderChipGroupProps {
 }
 
 const chip = tv({
-  base: 'typo-b2_rg_15 rounded-full px-3 py-1.5',
+  base: 'typo-b2_rg_15 hover:bg-chipSelected hover:text-text-brandPrimary rounded-full px-3 py-1.5 hover:font-semibold',
   variants: {
     active: {
       true: 'bg-chipSelected text-text-brandPrimary font-semibold',
@@ -20,7 +21,8 @@ const chip = tv({
 export const AvailableTimesHeaderChipGroup = ({
   availableApplicants,
 }: AvailableTimesHeaderChipGroupProps) => {
-  const { hoveredBlockApplicantIds } = useAvailableTimesModeHoverContext();
+  const { hoveredBlockApplicantIds, setHoveredChipApplicantId } =
+    useAvailableTimesModeHoverContext();
 
   const isAnyBlockHovered = hoveredBlockApplicantIds.length > 0;
 
@@ -34,10 +36,15 @@ export const AvailableTimesHeaderChipGroup = ({
     <div className="flex items-center gap-6">
       <div className="typo-b1_sb_16 text-text-basicSecondary">지원자</div>
       <div className="flex flex-wrap items-center gap-2">
-        {applicants.map(({ name }) => (
-          <div className={chip({ active: isAnyBlockHovered })} key={name}>
+        {applicants.map(({ name, applicantId }) => (
+          <motion.div
+            className={chip({ active: isAnyBlockHovered })}
+            key={name}
+            onHoverEnd={() => setHoveredChipApplicantId(null)}
+            onHoverStart={() => setHoveredChipApplicantId(applicantId)}
+          >
             {name}
-          </div>
+          </motion.div>
         ))}
       </div>
     </div>

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeaderChipGroup.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeaderChipGroup.tsx
@@ -1,47 +1,17 @@
-import { addDays } from 'date-fns';
-import { useMemo } from 'react';
-
-import { useCalendarWeekDates } from '@/hooks/useCalendarWeekDates';
 import { Applicant } from '@/query/applicant/schema';
-import { isInRange } from '@/utils/date';
 
 interface AvailableTimesHeaderChipGroupProps {
-  applicants: Applicant[];
-  month: number;
-  week: number;
-  year: number;
+  availableApplicants: Applicant[];
 }
 
 export const AvailableTimesHeaderChipGroup = ({
-  applicants,
-  month,
-  week,
-  year,
+  availableApplicants,
 }: AvailableTimesHeaderChipGroupProps) => {
-  const weekDates = useCalendarWeekDates({ year, month, week });
-  const startOfWeekDates = weekDates[0];
-  const endOfWeekDates = weekDates[weekDates.length - 1];
-  const availableTimesOfApplicants = useMemo(
-    () =>
-      applicants
-        .map(({ availableTimes, ...applicant }) => ({
-          ...applicant,
-          availableTimes: availableTimes.filter((availableTime) =>
-            isInRange(availableTime, {
-              from: startOfWeekDates,
-              to: addDays(endOfWeekDates, 1),
-            }),
-          ),
-        }))
-        .filter(({ availableTimes }) => availableTimes.length > 0),
-    [applicants, startOfWeekDates, endOfWeekDates],
-  );
-
   return (
     <div className="flex items-center gap-6">
       <div className="typo-b1_sb_16 text-text-basicSecondary">지원자</div>
       <div className="flex flex-wrap items-center gap-2">
-        {availableTimesOfApplicants.map(({ name }) => (
+        {availableApplicants.map(({ name }) => (
           <div
             className="typo-b2_rg_15 text-text-basicSecondary bg-chipUnselected rounded-full px-3 py-1.5"
             key={name}

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeaderChipGroup.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesHeaderChipGroup.tsx
@@ -1,21 +1,41 @@
+import { tv } from 'tailwind-variants';
+
+import { useAvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
 import { Applicant } from '@/query/applicant/schema';
 
 interface AvailableTimesHeaderChipGroupProps {
   availableApplicants: Applicant[];
 }
 
+const chip = tv({
+  base: 'typo-b2_rg_15 rounded-full px-3 py-1.5',
+  variants: {
+    active: {
+      true: 'bg-chipSelected text-text-brandPrimary font-semibold',
+      false: 'bg-chipUnselected text-text-basicSecondary',
+    },
+  },
+});
+
 export const AvailableTimesHeaderChipGroup = ({
   availableApplicants,
 }: AvailableTimesHeaderChipGroupProps) => {
+  const { hoveredBlockApplicantIds } = useAvailableTimesModeHoverContext();
+
+  const isAnyBlockHovered = hoveredBlockApplicantIds.length > 0;
+
+  const applicants = isAnyBlockHovered
+    ? availableApplicants.filter(({ applicantId }) =>
+        hoveredBlockApplicantIds.includes(applicantId),
+      )
+    : availableApplicants;
+
   return (
     <div className="flex items-center gap-6">
       <div className="typo-b1_sb_16 text-text-basicSecondary">지원자</div>
       <div className="flex flex-wrap items-center gap-2">
-        {availableApplicants.map(({ name }) => (
-          <div
-            className="typo-b2_rg_15 text-text-basicSecondary bg-chipUnselected rounded-full px-3 py-1.5"
-            key={name}
-          >
+        {applicants.map(({ name }) => (
+          <div className={chip({ active: isAnyBlockHovered })} key={name}>
             {name}
           </div>
         ))}

--- a/src/pages/Interview/components/AvailableTimesMode/context.ts
+++ b/src/pages/Interview/components/AvailableTimesMode/context.ts
@@ -1,0 +1,19 @@
+import { assert } from 'es-toolkit';
+import { createContext, Dispatch, SetStateAction, useContext } from 'react';
+
+interface AvailableTimesModeHoverContextProps {
+  hoveredBlockApplicantIds: number[];
+  setHoveredBlockApplicantIds: Dispatch<SetStateAction<number[]>>;
+}
+
+export const AvailableTimesModeHoverContext =
+  createContext<AvailableTimesModeHoverContextProps | null>(null);
+
+export const useAvailableTimesModeHoverContext = () => {
+  const context = useContext(AvailableTimesModeHoverContext);
+  assert(
+    !!context,
+    'useAvailableTimesModeHoverContext는 AvailableTimesModeHoverContext.Provider 하위에서 사용해야해요.',
+  );
+  return context;
+};

--- a/src/pages/Interview/components/AvailableTimesMode/context.ts
+++ b/src/pages/Interview/components/AvailableTimesMode/context.ts
@@ -3,7 +3,9 @@ import { createContext, Dispatch, SetStateAction, useContext } from 'react';
 
 interface AvailableTimesModeHoverContextProps {
   hoveredBlockApplicantIds: number[];
+  hoveredChipApplicantId: null | number;
   setHoveredBlockApplicantIds: Dispatch<SetStateAction<number[]>>;
+  setHoveredChipApplicantId: Dispatch<SetStateAction<null | number>>;
 }
 
 export const AvailableTimesModeHoverContext =

--- a/src/pages/Interview/components/AvailableTimesMode/index.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/index.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { AvailableTimesHeader } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesHeader';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
+import { useAvailableApplicantsInWeek } from '@/pages/Interview/hooks/useAvailableApplicantsInWeek';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 import { applicantOptions } from '@/query/applicant/options';
 
@@ -11,15 +12,20 @@ export const AvailableTimesMode = () => {
   const { year, month, week, handlePrevWeek, handleNextWeek } = useWeekIndicator();
 
   const { data: applicants } = useSuspenseQuery(applicantOptions({ partId }));
+  const availableApplicants = useAvailableApplicantsInWeek({
+    year,
+    month,
+    week,
+    applicants,
+  });
 
   return (
     <InterviewPageLayout
       slots={{
         header: (
           <AvailableTimesHeader
-            applicants={applicants}
+            availableApplicants={availableApplicants}
             indicator={{
-              year,
               month,
               week,
               onNextWeek: handleNextWeek,

--- a/src/pages/Interview/components/AvailableTimesMode/index.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/index.tsx
@@ -1,5 +1,6 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
+import { AvailableTimesCalendar } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar';
 import { AvailableTimesHeader } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesHeader';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
@@ -33,7 +34,14 @@ export const AvailableTimesMode = () => {
             }}
           />
         ),
-        calendar: <div />,
+        calendar: (
+          <AvailableTimesCalendar
+            availableApplicants={availableApplicants}
+            month={month}
+            week={week}
+            year={year}
+          />
+        ),
         sidebar: <div />,
       }}
     />

--- a/src/pages/Interview/components/AvailableTimesMode/index.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/index.tsx
@@ -23,12 +23,15 @@ export const AvailableTimesMode = () => {
   });
 
   const [hoveredBlockApplicantIds, setHoveredBlockApplicantIds] = useState<number[]>([]);
+  const [hoveredChipApplicantId, setHoveredChipApplicantId] = useState<null | number>(null);
 
   return (
     <AvailableTimesModeHoverContext.Provider
       value={{
         hoveredBlockApplicantIds,
+        hoveredChipApplicantId,
         setHoveredBlockApplicantIds,
+        setHoveredChipApplicantId,
       }}
     >
       <InterviewPageLayout

--- a/src/pages/Interview/components/AvailableTimesMode/index.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/index.tsx
@@ -1,7 +1,9 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { AvailableTimesCalendar } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar';
 import { AvailableTimesHeader } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesHeader';
+import { AvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
 import { useAvailableApplicantsInWeek } from '@/pages/Interview/hooks/useAvailableApplicantsInWeek';
@@ -20,30 +22,39 @@ export const AvailableTimesMode = () => {
     applicants,
   });
 
+  const [hoveredBlockApplicantIds, setHoveredBlockApplicantIds] = useState<number[]>([]);
+
   return (
-    <InterviewPageLayout
-      slots={{
-        header: (
-          <AvailableTimesHeader
-            availableApplicants={availableApplicants}
-            indicator={{
-              month,
-              week,
-              onNextWeek: handleNextWeek,
-              onPrevWeek: handlePrevWeek,
-            }}
-          />
-        ),
-        calendar: (
-          <AvailableTimesCalendar
-            availableApplicants={availableApplicants}
-            month={month}
-            week={week}
-            year={year}
-          />
-        ),
-        sidebar: <div />,
+    <AvailableTimesModeHoverContext.Provider
+      value={{
+        hoveredBlockApplicantIds,
+        setHoveredBlockApplicantIds,
       }}
-    />
+    >
+      <InterviewPageLayout
+        slots={{
+          header: (
+            <AvailableTimesHeader
+              availableApplicants={availableApplicants}
+              indicator={{
+                month,
+                week,
+                onNextWeek: handleNextWeek,
+                onPrevWeek: handlePrevWeek,
+              }}
+            />
+          ),
+          calendar: (
+            <AvailableTimesCalendar
+              availableApplicants={availableApplicants}
+              month={month}
+              week={week}
+              year={year}
+            />
+          ),
+          sidebar: <div />,
+        }}
+      />
+    </AvailableTimesModeHoverContext.Provider>
   );
 };

--- a/src/pages/Interview/hooks/useAvailableApplicantsInWeek.tsx
+++ b/src/pages/Interview/hooks/useAvailableApplicantsInWeek.tsx
@@ -1,0 +1,46 @@
+import { addDays } from 'date-fns';
+import { useCallback, useMemo } from 'react';
+
+import { useCalendarWeekDates } from '@/hooks/useCalendarWeekDates';
+import { Applicant } from '@/query/applicant/schema';
+import { isInRange } from '@/utils/date';
+
+interface UseAvailableApplicantsInWeekProps {
+  applicants: Applicant[];
+  month: number;
+  week: number;
+  year: number;
+}
+
+export const useAvailableApplicantsInWeek = ({
+  year,
+  month,
+  week,
+  applicants,
+}: UseAvailableApplicantsInWeekProps) => {
+  const weekDates = useCalendarWeekDates({ year, month, week });
+  const startOfWeekDates = weekDates[0];
+  const endOfWeekDates = weekDates[weekDates.length - 1];
+
+  const pickAvailableTimesInWeek = useCallback(
+    (availableTimes: string[]) =>
+      availableTimes.filter((availableTime) =>
+        isInRange(availableTime, {
+          from: startOfWeekDates,
+          to: addDays(endOfWeekDates, 1),
+        }),
+      ),
+    [startOfWeekDates, endOfWeekDates],
+  );
+
+  return useMemo(
+    () =>
+      applicants
+        .map(({ availableTimes, ...applicant }) => ({
+          ...applicant,
+          availableTimes: pickAvailableTimesInWeek(availableTimes),
+        }))
+        .filter(({ availableTimes }) => availableTimes.length > 0),
+    [applicants, pickAvailableTimesInWeek],
+  );
+};

--- a/src/utils/DateMap/DateMap.ts
+++ b/src/utils/DateMap/DateMap.ts
@@ -61,9 +61,8 @@ export class DateMap<T> {
 
   constructor(options?: DateMapOptions<T>) {
     this.precisionRange = this.makePrecisionRange(options?.precision);
-    this.map = new Map<number, T>(
-      options?.initialEntries?.map(([k, v]) => [this.normalizeKey(k), v]),
-    );
+    this.map = new Map<number, T>();
+    this.setAll(options?.initialEntries ?? []);
     this.assertPrecisionRangeIsValid();
   }
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

### 개요

<img width="2540" height="1216" alt="스크린샷 2025-11-20 19 55 06" src="https://github.com/user-attachments/assets/5607a410-27cf-48ef-bb61-6b41055014e9" />

`희망일정` 모드에서 캘린더를 렌더링해요.

- 동시에, 캘린더에 렌더링되는 일정들을 헤더의 지원자 목록과 연동시켜서 호버 액션들을 구현했어요.

  - 캘린더 블럭 호버: 해당 블럭에 해당하는 지원자들만 헤더 칩에서 보여줌
  
  - 헤더 칩 호버: 해당 지원자가 입력한 가능 일정들만 캘린더에 보여줌


<br />

## 2️⃣ 추후 작업

- `희망일정` 모드 사이드바 만들기

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
