### PR TITLE
feat: `희망일정` 모드에서의 사이드바를 구현했어요

### DIFF
--- a/src/pages/Interview/Interview.tsx
+++ b/src/pages/Interview/Interview.tsx
@@ -5,27 +5,38 @@ import { usePartFilter } from '@/hooks/usePartFilter';
 import { AvailableTimesMode } from '@/pages/Interview/components/AvailableTimesMode';
 import { InterviewScheduleMode } from '@/pages/Interview/components/InterviewScheduleMode';
 import {
+  InterviewAutoScheduleContext,
   InterviewCalendarModeContext,
   InterviewPartSelectionContext,
 } from '@/pages/Interview/context';
-import { CalendarModeType } from '@/pages/Interview/type';
+import {
+  CalendarModeType,
+  InterviewAutoScheduleStrategyType,
+  InterviewDurationType,
+} from '@/pages/Interview/type';
 
 export const InterviewPage = () => {
   const [calendarMode, setCalendarMode] = useState<CalendarModeType>('면접일정');
+  const [duration, setDuration] = useState<InterviewDurationType>('1시간');
+  const [strategy, setStrategy] = useState<InterviewAutoScheduleStrategyType>('분산형');
   const { partId, partName, onPartChange } = usePartFilter();
 
   return (
     <InterviewCalendarModeContext.Provider value={{ calendarMode, setCalendarMode }}>
       <InterviewPartSelectionContext.Provider value={{ partId, partName, onPartChange }}>
-        <SwitchCase
-          caseBy={{
-            면접일정: () => <InterviewScheduleMode />,
-            희망일정: () => <AvailableTimesMode />,
-            수동생성: () => <div />,
-            자동생성: () => <div />,
-          }}
-          value={calendarMode}
-        />
+        <InterviewAutoScheduleContext.Provider
+          value={{ duration, setDuration, strategy, setStrategy }}
+        >
+          <SwitchCase
+            caseBy={{
+              면접일정: () => <InterviewScheduleMode />,
+              희망일정: () => <AvailableTimesMode />,
+              수동생성: () => <div />,
+              자동생성: () => <div />,
+            }}
+            value={calendarMode}
+          />
+        </InterviewAutoScheduleContext.Provider>
       </InterviewPartSelectionContext.Provider>
     </InterviewCalendarModeContext.Provider>
   );

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
@@ -4,7 +4,9 @@ import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSi
 export const AvailableTimesSidebar = () => {
   return (
     <InterviewSidebarLayout>
-      <AvailableTimesSidebarDurationCard />
+      <InterviewSidebarLayout.CardList>
+        <AvailableTimesSidebarDurationCard />
+      </InterviewSidebarLayout.CardList>
     </InterviewSidebarLayout>
   );
 };

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
@@ -1,0 +1,5 @@
+import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+
+export const AvailableTimesSidebar = () => {
+  return <InterviewSidebarLayout />;
+};

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
@@ -1,3 +1,5 @@
+import { BoxButton } from '@yourssu/design-system-react';
+
 import { AvailableTimesSidebarDurationCard } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
 
@@ -7,6 +9,16 @@ export const AvailableTimesSidebar = () => {
       <InterviewSidebarLayout.CardList>
         <AvailableTimesSidebarDurationCard />
       </InterviewSidebarLayout.CardList>
+      <InterviewSidebarLayout.BottomArea>
+        <div className="grid grid-cols-2 gap-3">
+          <BoxButton className="w-full" size="xlarge" variant="filledSecondary">
+            일정 수동 생성
+          </BoxButton>
+          <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
+            일정 자동 생성
+          </BoxButton>
+        </div>
+      </InterviewSidebarLayout.BottomArea>
     </InterviewSidebarLayout>
   );
 };

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
@@ -1,5 +1,10 @@
+import { AvailableTimesSidebarDurationCard } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
 
 export const AvailableTimesSidebar = () => {
-  return <InterviewSidebarLayout />;
+  return (
+    <InterviewSidebarLayout>
+      <AvailableTimesSidebarDurationCard />
+    </InterviewSidebarLayout>
+  );
 };

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard.tsx
@@ -1,0 +1,69 @@
+import { IcArrowsChevronDownLine, IcCheckLine, IcClockFilled } from '@yourssu/design-system-react';
+import clsx from 'clsx';
+import { tv } from 'tailwind-variants';
+
+import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
+
+interface SelectItemProps {
+  selected?: boolean;
+  value: string;
+}
+
+const item = tv({
+  slots: {
+    container: 'flex w-full cursor-pointer items-center justify-between',
+    content: 'flex items-center gap-3',
+    title: 'typo-b1_sb_16 text-text-basicSecondary',
+    valueContainer: 'flex items-center',
+    icon: 'text-icon-brandPrimary invisible size-4',
+    value: 'typo-b3_rg_14 text-text-basicTertiary px-2',
+  },
+  variants: {
+    selected: {
+      true: {
+        value: 'text-text-brandPrimary',
+        icon: 'visible',
+      },
+    },
+  },
+});
+
+const SelectItem = ({ value, selected }: SelectItemProps) => {
+  const { container, content, title, icon, value: valueStyle, valueContainer } = item();
+
+  return (
+    <button className={container()}>
+      <div className={clsx(content())}>
+        <div className={clsx(title(), 'invisible')}>면접 시간</div>
+        <div className={clsx(valueContainer())}>
+          <IcCheckLine className={clsx(icon({ selected }))} />
+          <div className={clsx(valueStyle({ selected }))}>{value}</div>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export const AvailableTimesSidebarDurationCard = () => {
+  const { content, title, icon, value: valueStyle, valueContainer } = item();
+
+  return (
+    <InterviewSidebarCard>
+      <InterviewSidebarCard.Title rightIcon={<IcArrowsChevronDownLine className="size-6" />}>
+        <div className={clsx(content())}>
+          <div className={clsx(title())}>면접 시간</div>
+          <div className={clsx(valueContainer())}>
+            <IcClockFilled className={clsx(icon({ selected: true }))} />
+            <div className={clsx(valueStyle({ selected: true }))}>1 hour</div>
+          </div>
+        </div>
+      </InterviewSidebarCard.Title>
+
+      {/* // Todo: Divider, VerticalDivider 컴포넌트로 공통화? */}
+      <div className="bg-line-basicMedium h-[1px] w-full" />
+
+      <SelectItem value="30 minutes" />
+      <SelectItem selected value="1 hour" />
+    </InterviewSidebarCard>
+  );
+};

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard.tsx
@@ -9,14 +9,16 @@ import { useState } from 'react';
 import { tv } from 'tailwind-variants';
 
 import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
+import { useInterviewAutoScheduleContext } from '@/pages/Interview/context';
+import { interviewDurationOptions, InterviewDurationType } from '@/pages/Interview/type';
 
 interface SelectHeaderProps {
   onOpenChange: (open: boolean) => void;
   open: boolean;
-  value: SelectValueType;
+  value: InterviewDurationType;
 }
 
-interface SelectItemProps<TValue extends SelectValueType> {
+interface SelectItemProps<TValue extends InterviewDurationType> {
   onSelect: (v: TValue) => void;
   selected?: boolean;
   value: TValue;
@@ -63,7 +65,7 @@ const SelectHeader = ({ onOpenChange, open, value }: SelectHeaderProps) => {
   );
 };
 
-const SelectItem = <TValue extends SelectValueType>({
+const SelectItem = <TValue extends InterviewDurationType>({
   value,
   selected,
   onSelect,
@@ -85,28 +87,20 @@ const SelectItem = <TValue extends SelectValueType>({
 
 export const AvailableTimesSidebarDurationCard = () => {
   const [open, setOpen] = useState(false);
-  const [selectedValue, setSelectedValue] = useState<SelectValueType>('1 hour');
+  const { duration, setDuration } = useInterviewAutoScheduleContext();
 
   return (
     <InterviewSidebarCard>
-      <SelectHeader onOpenChange={setOpen} open={open} value={selectedValue} />
+      <SelectHeader onOpenChange={setOpen} open={open} value={duration} />
       {open && (
         <>
           {/* // Todo: Divider, VerticalDivider 컴포넌트로 공통화? */}
           <div className="bg-line-basicMedium h-[1px] w-full" />
-          {selectValues.map((value) => (
-            <SelectItem
-              key={value}
-              onSelect={setSelectedValue}
-              selected={selectedValue === value}
-              value={value}
-            />
+          {interviewDurationOptions.map((v) => (
+            <SelectItem key={v} onSelect={setDuration} selected={duration === v} value={v} />
           ))}
         </>
       )}
     </InterviewSidebarCard>
   );
 };
-
-const selectValues = ['30 minutes', '1 hour'] as const;
-type SelectValueType = (typeof selectValues)[number];

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebarDurationCard.tsx
@@ -1,12 +1,25 @@
-import { IcArrowsChevronDownLine, IcCheckLine, IcClockFilled } from '@yourssu/design-system-react';
+import {
+  IcArrowsChevronDownLine,
+  IcArrowsChevronUpLine,
+  IcCheckLine,
+  IcClockFilled,
+} from '@yourssu/design-system-react';
 import clsx from 'clsx';
+import { useState } from 'react';
 import { tv } from 'tailwind-variants';
 
 import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
 
-interface SelectItemProps {
+interface SelectHeaderProps {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  value: SelectValueType;
+}
+
+interface SelectItemProps<TValue extends SelectValueType> {
+  onSelect: (v: TValue) => void;
   selected?: boolean;
-  value: string;
+  value: TValue;
 }
 
 const item = tv({
@@ -28,11 +41,37 @@ const item = tv({
   },
 });
 
-const SelectItem = ({ value, selected }: SelectItemProps) => {
+const SelectHeader = ({ onOpenChange, open, value }: SelectHeaderProps) => {
+  const { content, title, icon, value: valueStyle, valueContainer } = item();
+
+  const Icon = open ? IcArrowsChevronUpLine : IcArrowsChevronDownLine;
+
+  return (
+    <InterviewSidebarCard.Title
+      className="cursor-pointer"
+      onClick={() => onOpenChange(!open)}
+      rightIcon={<Icon className="size-6" />}
+    >
+      <div className={clsx(content())}>
+        <div className={clsx(title())}>면접 시간</div>
+        <div className={clsx(valueContainer())}>
+          <IcClockFilled className={clsx(icon({ selected: true }))} />
+          <div className={clsx(valueStyle({ selected: true }))}>{value}</div>
+        </div>
+      </div>
+    </InterviewSidebarCard.Title>
+  );
+};
+
+const SelectItem = <TValue extends SelectValueType>({
+  value,
+  selected,
+  onSelect,
+}: SelectItemProps<TValue>) => {
   const { container, content, title, icon, value: valueStyle, valueContainer } = item();
 
   return (
-    <button className={container()}>
+    <button className={container()} onClick={() => onSelect(value)}>
       <div className={clsx(content())}>
         <div className={clsx(title(), 'invisible')}>면접 시간</div>
         <div className={clsx(valueContainer())}>
@@ -45,25 +84,29 @@ const SelectItem = ({ value, selected }: SelectItemProps) => {
 };
 
 export const AvailableTimesSidebarDurationCard = () => {
-  const { content, title, icon, value: valueStyle, valueContainer } = item();
+  const [open, setOpen] = useState(false);
+  const [selectedValue, setSelectedValue] = useState<SelectValueType>('1 hour');
 
   return (
     <InterviewSidebarCard>
-      <InterviewSidebarCard.Title rightIcon={<IcArrowsChevronDownLine className="size-6" />}>
-        <div className={clsx(content())}>
-          <div className={clsx(title())}>면접 시간</div>
-          <div className={clsx(valueContainer())}>
-            <IcClockFilled className={clsx(icon({ selected: true }))} />
-            <div className={clsx(valueStyle({ selected: true }))}>1 hour</div>
-          </div>
-        </div>
-      </InterviewSidebarCard.Title>
-
-      {/* // Todo: Divider, VerticalDivider 컴포넌트로 공통화? */}
-      <div className="bg-line-basicMedium h-[1px] w-full" />
-
-      <SelectItem value="30 minutes" />
-      <SelectItem selected value="1 hour" />
+      <SelectHeader onOpenChange={setOpen} open={open} value={selectedValue} />
+      {open && (
+        <>
+          {/* // Todo: Divider, VerticalDivider 컴포넌트로 공통화? */}
+          <div className="bg-line-basicMedium h-[1px] w-full" />
+          {selectValues.map((value) => (
+            <SelectItem
+              key={value}
+              onSelect={setSelectedValue}
+              selected={selectedValue === value}
+              value={value}
+            />
+          ))}
+        </>
+      )}
     </InterviewSidebarCard>
   );
 };
+
+const selectValues = ['30 minutes', '1 hour'] as const;
+type SelectValueType = (typeof selectValues)[number];

--- a/src/pages/Interview/components/AvailableTimesMode/index.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { AvailableTimesCalendar } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar';
 import { AvailableTimesHeader } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesHeader';
+import { AvailableTimesSidebar } from '@/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar';
 import { AvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
@@ -55,7 +56,7 @@ export const AvailableTimesMode = () => {
               year={year}
             />
           ),
-          sidebar: <div />,
+          sidebar: <AvailableTimesSidebar />,
         }}
       />
     </AvailableTimesModeHoverContext.Provider>

--- a/src/pages/Interview/components/InterviewCalendar/InterviewCalendarHead.tsx
+++ b/src/pages/Interview/components/InterviewCalendar/InterviewCalendarHead.tsx
@@ -47,7 +47,7 @@ export const InterviewCalendarHead = ({ month, week, year }: InterviewCalendarHe
   }).map((v) => formatTemplates['Mon 12'](v).split(' '));
 
   return (
-    <thead className="border-line-basicMedium shadow-fabPrimary sticky top-0 bg-white">
+    <thead className="border-line-basicMedium shadow-fabPrimary sticky top-0 z-50 bg-white">
       <tr>
         <th className={cellContainer()}>
           <div className={cellBorder({ first: true })}>

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
@@ -13,10 +13,12 @@ export const InterviewScheduleSidebar = ({ schedules }: InterviewScheduleSidebar
 
   return (
     <InterviewSidebarLayout>
-      {confilctGroups.map((group, i) => (
-        <InterviewSidebarConflictCard key={i} schedules={group} />
-      ))}
-      <InterviewSidebarDownloadCard />
+      <InterviewSidebarLayout.CardList>
+        {confilctGroups.map((group, i) => (
+          <InterviewSidebarConflictCard key={i} schedules={group} />
+        ))}
+        <InterviewSidebarDownloadCard />
+      </InterviewSidebarLayout.CardList>
     </InterviewSidebarLayout>
   );
 };

--- a/src/pages/Interview/components/InterviewSidebarCard.tsx
+++ b/src/pages/Interview/components/InterviewSidebarCard.tsx
@@ -1,10 +1,16 @@
-const Title = ({ children, leftIcon }: React.PropsWithChildren<{ leftIcon?: React.ReactNode }>) => {
+interface TitleProps {
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+}
+
+const Title = ({ children, leftIcon, rightIcon }: React.PropsWithChildren<TitleProps>) => {
   return (
     <div className="flex w-full items-center justify-between">
       <div className="flex items-center gap-[7px]">
         {leftIcon && <div className="size-5">{leftIcon}</div>}
         <p className="typo-b1_sb_16 text-text-basicSecondary">{children}</p>
       </div>
+      {rightIcon && <div className="size-6">{rightIcon}</div>}
     </div>
   );
 };

--- a/src/pages/Interview/components/InterviewSidebarCard.tsx
+++ b/src/pages/Interview/components/InterviewSidebarCard.tsx
@@ -1,11 +1,19 @@
-interface TitleProps {
+import { cn } from '@/utils/dom';
+
+interface TitleProps extends React.HTMLAttributes<HTMLDivElement> {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
 }
 
-const Title = ({ children, leftIcon, rightIcon }: React.PropsWithChildren<TitleProps>) => {
+const Title = ({
+  children,
+  className,
+  leftIcon,
+  rightIcon,
+  ...props
+}: React.PropsWithChildren<TitleProps>) => {
   return (
-    <div className="flex w-full items-center justify-between">
+    <div className={cn('flex w-full items-center justify-between', className)} {...props}>
       <div className="flex items-center gap-[7px]">
         {leftIcon && <div className="size-5">{leftIcon}</div>}
         <p className="typo-b1_sb_16 text-text-basicSecondary">{children}</p>

--- a/src/pages/Interview/components/InterviewSidebarLayout.tsx
+++ b/src/pages/Interview/components/InterviewSidebarLayout.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
 
-export const InterviewSidebarLayout = ({ children }: React.PropsWithChildren<unknown>) => {
+const BottomArea = ({ children }: React.PropsWithChildren<unknown>) => {
   return (
-    <div className="bg-bg-basicLight flex h-full w-full flex-col gap-2.5 px-5 py-12">
+    <div className="bg-bg-basicDefault border-line-basicMedium sticky bottom-0 border-t border-l px-5 pt-4 pb-10">
       {children}
     </div>
   );
 };
+
+const CardList = ({ children }: React.PropsWithChildren<unknown>) => {
+  return <div className="flex flex-[1_1_0] flex-col gap-2.5 px-5 py-12">{children}</div>;
+};
+
+export const InterviewSidebarLayout = ({ children }: React.PropsWithChildren<unknown>) => {
+  return <div className="bg-bg-basicLight flex size-full flex-col">{children}</div>;
+};
+
+InterviewSidebarLayout.CardList = CardList;
+InterviewSidebarLayout.BottomArea = BottomArea;

--- a/src/pages/Interview/context.ts
+++ b/src/pages/Interview/context.ts
@@ -1,7 +1,11 @@
 import { assert } from 'es-toolkit';
 import { createContext, Dispatch, SetStateAction, useContext } from 'react';
 
-import { CalendarModeType } from '@/pages/Interview/type';
+import {
+  CalendarModeType,
+  InterviewAutoScheduleStrategyType,
+  InterviewDurationType,
+} from '@/pages/Interview/type';
 
 interface InterviewCalendarModeContextProps {
   calendarMode: CalendarModeType;
@@ -14,12 +18,23 @@ interface InterviewPartSelectionContextProps {
   partName: null | string;
 }
 
+interface InterviewAutoScheduleContextProps {
+  duration: InterviewDurationType;
+  setDuration: Dispatch<SetStateAction<InterviewDurationType>>;
+  setStrategy: Dispatch<SetStateAction<InterviewAutoScheduleStrategyType>>;
+  strategy: InterviewAutoScheduleStrategyType;
+}
+
 export const InterviewCalendarModeContext = createContext<InterviewCalendarModeContextProps | null>(
   null,
 );
 
 export const InterviewPartSelectionContext =
   createContext<InterviewPartSelectionContextProps | null>(null);
+
+export const InterviewAutoScheduleContext = createContext<InterviewAutoScheduleContextProps | null>(
+  null,
+);
 
 export const useInterviewCalendarModeContext = () => {
   const context = useContext<InterviewCalendarModeContextProps | null>(
@@ -42,6 +57,19 @@ export const useInterviewPartSelectionContext = () => {
   assert(
     !!context,
     'useInterviewPartSelectionContext는 InterviewPartSelectionContext.Provider 하위에서 사용해야해요.',
+  );
+
+  return context;
+};
+
+export const useInterviewAutoScheduleContext = () => {
+  const context = useContext<InterviewAutoScheduleContextProps | null>(
+    InterviewAutoScheduleContext,
+  );
+
+  assert(
+    !!context,
+    'useInterviewAutoScheduleContext는 InterviewAutoScheduleContext.Provider 하위에서 사용해야해요.',
   );
 
   return context;

--- a/src/pages/Interview/type.ts
+++ b/src/pages/Interview/type.ts
@@ -1,1 +1,6 @@
 export type CalendarModeType = '면접일정' | '수동생성' | '자동생성' | '희망일정';
+
+export const interviewDurationOptions = ['30분', '1시간'] as const;
+export type InterviewDurationType = (typeof interviewDurationOptions)[number];
+
+export type InterviewAutoScheduleStrategyType = '밀집형' | '분산형';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

<img width="2551" height="1233" alt="스크린샷 2025-11-22 18 38 17" src="https://github.com/user-attachments/assets/8f1e9ad1-3d4c-4066-a534-439a87c6ac81" />

---

1. 날짜 범위 필터링 카드는 리소스가 많이 들고, 핵심 기능이 아니므로 우선순위 낮춰서 구현할 예정이에요. (싱크 완료)

2. [피그마](https://www.figma.com/design/HjonnCf2jKCRgw3DlzQf1v/Yourssu-Scouter?node-id=2188-26550&m=dev)에는 사이드바 하단 버튼이 '면접 시간표 생성' 하나였는데 액션을 예측하지 못한다는 점, 정책적으로 각 생성 방식에 뎁스를 둘 필요가 없다고 판단해서 버튼을 두개 만들었습니다.

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
