### PR TITLE
fix: 날짜 응답 데이터 형식을 yyyy-mm-dd로 변경 대응

### DIFF
--- a/src/scheme/common.ts
+++ b/src/scheme/common.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const DateSchema = z
   .string()
   .regex(
-    /^(19|20)\d{2}\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])$/,
-    '날짜는 yyyy.mm.dd 형식으로 입력해주세요',
+    /^(19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/,
+    '날짜는 yyyy-mm-dd 형식으로 입력해주세요',
   );
 
 export const PhoneNumberSchema = z.string();


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

### 맥락

https://yourssu.slack.com/archives/C082XCSQK0F/p1763633872080939

날짜 데이터 응답 포맷이 일관되지 않았던 문제가 수정되면서 

기존 날짜 포맷(yyyy.mm.dd)을 검증하던 스키마에서 에러가 발생하는 상황이 생겼습니다.

이를 대응해줘요.

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
