### PR TITLE
fix: Dialog 컴포넌트의 콘텐츠 포지셔닝을 fixed로 변경해요

### DIFF
--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -86,7 +86,7 @@ export const Dialog = ({
             </DialogPrimitive.Overlay>
             <DialogPrimitive.Content
               {...contentProps}
-              className="absolute top-1/2 left-1/2 z-50 min-w-[386px] -translate-1/2"
+              className="fixed top-1/2 left-1/2 z-50 min-w-[386px] -translate-1/2"
               onInteractOutside={onCloseWithOutside}
               onPointerDownOutside={onCloseWithOutside}
             >


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

다이얼로그 콘텐츠 포지셔닝이 absolute로 지정되어 있어서, 

뷰포트 기준으로 중앙에 렌더링되는 것이 아닌, 페이지 크기를 기준으로 중앙에 렌더링되고 있었어요.

이 문제를 해결해요.

| as-is | to-be | 
| --- | --- |
| <img width="1266" height="720" alt="스크린샷 2025-12-31 21 08 47" src="https://github.com/user-attachments/assets/d682a9d2-5edf-437f-9dfc-595aea5cb123" /> | <img width="1264" height="722" alt="스크린샷 2025-12-31 21 08 57" src="https://github.com/user-attachments/assets/fa771dcb-9162-49cf-8c19-12a9e4b94bfb" /> |


- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
