### PR TITLE
chore: 리뷰어 및 리뷰이 자동할당 스크립트 작성

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,24 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - 'wwwlnyy'
+  - 'fecapark'
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 1
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip
+  - WIP


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

.github/auto_assign.yml 을 통해 자동으로 reviewers와 assignees를 할당할 수 있어요.

- 누군가 pr을 열면 @fecapark 와 @wwwlnyy 가 자동으로 할당되게 설정했어요.
- assignee는 작성자로 자동으로 할당이 되도록 설정했어요.
- wip 또는 WIP을 pr title에 적으면 draft로 인식해서 작동하지 않도록 만들었어요. (WIP, work in progress)

다만 작성한다고 바로 할당할 수 있는건 아니고, 
봇 설정이 필요해서 레포지토리에 깔아줬어요. 

참고: https://github.com/organizations/yourssu/settings/installations/102007917

## 2️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
