### PR TITLE
feat: 수동생성모드 > 사이드바 마크업 작성

### DIFF
--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -1,0 +1,16 @@
+import { BoxButton } from '@yourssu/design-system-react';
+
+import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+
+export const ManualScheduleSidebar = () => {
+  return (
+    <InterviewSidebarLayout>
+      <InterviewSidebarLayout.CardList />
+      <InterviewSidebarLayout.BottomArea>
+        <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
+          시간표 저장하기
+        </BoxButton>
+      </InterviewSidebarLayout.BottomArea>
+    </InterviewSidebarLayout>
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -2,12 +2,26 @@ import { BoxButton } from '@yourssu/design-system-react';
 
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
 import { ManualScheduleSidebarPartCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard';
+import { ManualScheduleSidebarProgressCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard';
+import { Applicant } from '@/query/applicant/schema';
 
-export const ManualScheduleSidebar = () => {
+interface ManualScheduleSidebarProps {
+  completedApplicants: Applicant[];
+  totalApplicantCount: number;
+}
+
+export const ManualScheduleSidebar = ({
+  completedApplicants,
+  totalApplicantCount,
+}: ManualScheduleSidebarProps) => {
   return (
     <InterviewSidebarLayout>
       <InterviewSidebarLayout.CardList>
         <ManualScheduleSidebarPartCard />
+        <ManualScheduleSidebarProgressCard
+          completedApplicants={completedApplicants}
+          totalApplicantCount={totalApplicantCount}
+        />
       </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
         <BoxButton className="w-full" size="xlarge" variant="filledPrimary">

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -1,11 +1,14 @@
 import { BoxButton } from '@yourssu/design-system-react';
 
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+import { ManualScheduleSidebarPartCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard';
 
 export const ManualScheduleSidebar = () => {
   return (
     <InterviewSidebarLayout>
-      <InterviewSidebarLayout.CardList />
+      <InterviewSidebarLayout.CardList>
+        <ManualScheduleSidebarPartCard />
+      </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
         <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
           시간표 저장하기

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard.tsx
@@ -1,0 +1,17 @@
+import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
+import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
+
+export const ManualScheduleSidebarPartCard = () => {
+  const { partName } = useInterviewPartSelectionContext();
+
+  return (
+    <InterviewSidebarCard>
+      <InterviewSidebarCard.Title>입력중인 파트</InterviewSidebarCard.Title>
+      <InterviewSidebarCard.Content>
+        <div className="typo-b2_rg_15 bg-chipUnselected inline-block rounded-full px-3 py-1.5">
+          {partName}
+        </div>
+      </InterviewSidebarCard.Content>
+    </InterviewSidebarCard>
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard.tsx
@@ -1,0 +1,35 @@
+import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
+import { Applicant } from '@/query/applicant/schema';
+
+interface ManualScheduleSidebarProgressCardProps {
+  completedApplicants: Applicant[];
+  totalApplicantCount: number;
+}
+
+export const ManualScheduleSidebarProgressCard = ({
+  completedApplicants,
+  totalApplicantCount,
+}: ManualScheduleSidebarProgressCardProps) => {
+  return (
+    <InterviewSidebarCard>
+      <InterviewSidebarCard.Title>
+        입력완료 지원자{' '}
+        <span className="text-text-brandPrimary">
+          ( {completedApplicants.length} / {totalApplicantCount} )
+        </span>
+      </InterviewSidebarCard.Title>
+      <InterviewSidebarCard.Content>
+        {completedApplicants.length
+          ? completedApplicants.map(({ name, applicantId }) => (
+              <div
+                className="typo-b2_rg_15 bg-chipUnselected inline-block rounded-full px-3 py-1.5"
+                key={applicantId}
+              >
+                {name}
+              </div>
+            ))
+          : '지원자의 일정을 지정해주세요.'}
+      </InterviewSidebarCard.Content>
+    </InterviewSidebarCard>
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -40,7 +40,12 @@ export const ManualScheduleMode = () => {
           />
         ),
         calendar: <div />,
-        sidebar: <ManualScheduleSidebar />,
+        sidebar: (
+          <ManualScheduleSidebar
+            completedApplicants={[]}
+            totalApplicantCount={availableApplicants.length}
+          />
+        ),
       }}
     />
   );

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { ManualScheduleHeader } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader';
+import { ManualScheduleSidebar } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
 import { useAvailableApplicantsInWeek } from '@/pages/Interview/hooks/useAvailableApplicantsInWeek';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
@@ -39,7 +40,7 @@ export const ManualScheduleMode = () => {
           />
         ),
         calendar: <div />,
-        sidebar: <div />,
+        sidebar: <ManualScheduleSidebar />,
       }}
     />
   );


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

피그마: https://www.figma.com/design/HjonnCf2jKCRgw3DlzQf1v/Yourssu-Scouter?node-id=2200-30511&m=dev

<img width="1272" height="1219" alt="스크린샷 2026-01-01 17 25 26" src="https://github.com/user-attachments/assets/762938e1-4e3a-4cef-9e55-afe17369c933" />

- `수동생성` 모드에서의 사이드바 마크업을 작성했어요.

  - 아직 상태 연결이라던지 기능 자체를 구현하지는 않았고, 적절한 상태를 넘겨주면 UI를 렌더링하는 마크업 부분만 작성했어요.

- '입력중인 파트' 카드 컴포넌트를 만들었어요.
- '입력완료 지원자' 카드 컴포넌트를 만들었어요.
  - 일정을 아직 아무 지원자에게도 지정하지 않았으면 피그마처럼 'none' 칩을 보여주는 대신, '지원자의 일정을 지정해주세요' 텍스트를 렌더링하도록 했어요.

## 2️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
