### PR TITLE
feat: 수동생성모드의 캘린더를 만들고, 지원자 일정을 지정할 수 있도록 했어요

### DIFF
--- a/src/hooks/useDateMap.ts
+++ b/src/hooks/useDateMap.ts
@@ -3,7 +3,7 @@ import { usePreservedReference } from 'react-simplikit';
 
 import { DateMap, DateMapOptions, DateMapSetterEntries, DateMapSetterType } from '@/utils/DateMap';
 
-type UseDateMapAction<T> = {
+export type UseDateMapAction<T> = {
   remove: (key: Date) => void;
   reset: () => void;
   set: (key: Date, value: DateMapSetterType<T>) => void;

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
@@ -6,10 +6,16 @@ import { formatTemplates } from '@/utils/date';
 interface ManualScheduleBlockProps {
   applicant: Applicant | undefined;
   date: Date;
+  isFirstBlock: boolean;
   onClick: () => void;
 }
 
-export const ManualScheduleBlock = ({ applicant, date, onClick }: ManualScheduleBlockProps) => {
+export const ManualScheduleBlock = ({
+  applicant,
+  date,
+  isFirstBlock,
+  onClick,
+}: ManualScheduleBlockProps) => {
   return (
     <button
       className={clsx(
@@ -18,7 +24,7 @@ export const ManualScheduleBlock = ({ applicant, date, onClick }: ManualSchedule
       )}
       onClick={onClick}
     >
-      {applicant && (
+      {applicant && isFirstBlock && (
         <>
           <div className="typo-c3_sb_11 flex size-full items-end gap-1.5 px-2">
             <div>{applicant.name} 님</div>

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
@@ -1,20 +1,35 @@
 import clsx from 'clsx';
 
 import { Applicant } from '@/query/applicant/schema';
+import { formatTemplates } from '@/utils/date';
 
 interface ManualScheduleBlockProps {
   applicant: Applicant | undefined;
+  date: Date;
   onClick: () => void;
 }
 
-export const ManualScheduleBlock = ({ applicant, onClick }: ManualScheduleBlockProps) => {
+export const ManualScheduleBlock = ({ applicant, date, onClick }: ManualScheduleBlockProps) => {
   return (
     <button
       className={clsx(
-        'bg-bg-brandPrimary block size-full cursor-pointer rounded-lg',
+        'bg-bg-brandPrimary flex size-full cursor-pointer flex-col rounded-lg text-white',
         !applicant && 'opacity-20 hover:opacity-60',
       )}
       onClick={onClick}
-    />
+    >
+      {applicant && (
+        <>
+          <div className="typo-c3_sb_11 flex size-full items-end gap-1.5 px-2">
+            <div>{applicant.name} 님</div>
+            <div>{applicant.part}</div>
+          </div>
+          <div className="typo-c3_rg_11 flex size-full items-start gap-1.5 px-2">
+            <div>{formatTemplates['23:59'](date)}</div>
+            <div>유어슈 동아리방</div>
+          </div>
+        </>
+      )}
+    </button>
   );
 };

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
@@ -1,0 +1,20 @@
+import clsx from 'clsx';
+
+import { Applicant } from '@/query/applicant/schema';
+
+interface ManualScheduleBlockProps {
+  applicant: Applicant | undefined;
+  onClick: () => void;
+}
+
+export const ManualScheduleBlock = ({ applicant, onClick }: ManualScheduleBlockProps) => {
+  return (
+    <button
+      className={clsx(
+        'bg-bg-brandPrimary block size-full cursor-pointer rounded-lg',
+        !applicant && 'opacity-20 hover:opacity-60',
+      )}
+      onClick={onClick}
+    />
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
@@ -1,0 +1,17 @@
+import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
+
+interface ManualScheduleCalendarProps {
+  month: number;
+  week: number;
+  year: number;
+}
+
+export const ManualScheduleCalendar = ({ month, week, year }: ManualScheduleCalendarProps) => {
+  return (
+    <InterviewCalendar month={month} week={week} year={year}>
+      {() => {
+        return undefined;
+      }}
+    </InterviewCalendar>
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
@@ -1,16 +1,34 @@
+import { setHours, setMinutes } from 'date-fns';
+
+import { useDateMap } from '@/hooks/useDateMap';
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
+import { ManualScheduleBlock } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock';
+import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleCalendarProps {
   month: number;
+  selectedApplicant: Applicant;
   week: number;
   year: number;
 }
 
-export const ManualScheduleCalendar = ({ month, week, year }: ManualScheduleCalendarProps) => {
+export const ManualScheduleCalendar = ({
+  selectedApplicant,
+  month,
+  week,
+  year,
+}: ManualScheduleCalendarProps) => {
+  const [map] = useDateMap({
+    initialEntries: selectedApplicant.availableTimes.map((time) => [new Date(time), true]),
+    precision: '분',
+  });
+
   return (
     <InterviewCalendar month={month} week={week} year={year}>
-      {() => {
-        return undefined;
+      {({ date, hour, minute }) => {
+        const targetDate = setMinutes(setHours(date, hour), minute);
+        const isAvailable = map.has(targetDate);
+        return isAvailable && <ManualScheduleBlock applicant={undefined} onClick={() => {}} />;
       }}
     </InterviewCalendar>
   );

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
@@ -1,11 +1,14 @@
 import { setHours, setMinutes } from 'date-fns';
 
-import { useDateMap } from '@/hooks/useDateMap';
+import { useDateMap, UseDateMapAction } from '@/hooks/useDateMap';
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
 import { ManualScheduleBlock } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock';
 import { Applicant } from '@/query/applicant/schema';
+import { DateMap } from '@/utils/DateMap';
 
 interface ManualScheduleCalendarProps {
+  completedScheduleMap: DateMap<Applicant>;
+  completedScheduleMapAction: UseDateMapAction<Applicant>;
   month: number;
   selectedApplicant: Applicant;
   week: number;
@@ -14,6 +17,8 @@ interface ManualScheduleCalendarProps {
 
 export const ManualScheduleCalendar = ({
   selectedApplicant,
+  completedScheduleMap,
+  completedScheduleMapAction,
   month,
   week,
   year,
@@ -23,12 +28,45 @@ export const ManualScheduleCalendar = ({
     precision: '분',
   });
 
+  const meAlreadySettedAt = completedScheduleMap
+    .entries()
+    .find(([, { applicantId }]) => applicantId === selectedApplicant.applicantId)?.[0];
+
   return (
     <InterviewCalendar month={month} week={week} year={year}>
       {({ date, hour, minute }) => {
         const targetDate = setMinutes(setHours(date, hour), minute);
         const isAvailable = map.has(targetDate);
-        return isAvailable && <ManualScheduleBlock applicant={undefined} onClick={() => {}} />;
+        const settedApplicantHere = completedScheduleMap.get(targetDate);
+        const settedApplicantHereIsMe =
+          settedApplicantHere?.applicantId === selectedApplicant.applicantId;
+
+        return (
+          (isAvailable || settedApplicantHere) && (
+            <ManualScheduleBlock
+              applicant={settedApplicantHere}
+              date={targetDate}
+              onClick={() => {
+                // 1. 클릭한 블럭에 채워져있는 게 내 일정이라면 지운다
+                if (settedApplicantHereIsMe) {
+                  completedScheduleMapAction.remove(targetDate);
+                  return;
+                }
+                // 2. 내 일정이 다른곳에서 이미 지정되어있다면 클릭한 블럭으로 변경한다
+                if (meAlreadySettedAt) {
+                  completedScheduleMapAction.remove(meAlreadySettedAt);
+                  completedScheduleMapAction.set(targetDate, selectedApplicant);
+                  return;
+                }
+                // 3. 클릭한 블럭에 아무도 채워져있지 않다면 채운다
+                if (!settedApplicantHere) {
+                  completedScheduleMapAction.set(targetDate, selectedApplicant);
+                  return;
+                }
+              }}
+            />
+          )
+        );
       }}
     </InterviewCalendar>
   );

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
@@ -3,6 +3,7 @@ import { setHours, setMinutes } from 'date-fns';
 import { useDateMap, UseDateMapAction } from '@/hooks/useDateMap';
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
 import { ManualScheduleBlock } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock';
+import { useInterviewAutoScheduleContext } from '@/pages/Interview/context';
 import { Applicant } from '@/query/applicant/schema';
 import { DateMap } from '@/utils/DateMap';
 
@@ -23,6 +24,8 @@ export const ManualScheduleCalendar = ({
   week,
   year,
 }: ManualScheduleCalendarProps) => {
+  const { duration } = useInterviewAutoScheduleContext();
+
   const [map] = useDateMap({
     initialEntries: selectedApplicant.availableTimes.map((time) => [new Date(time), true]),
     precision: '분',
@@ -46,6 +49,7 @@ export const ManualScheduleCalendar = ({
             <ManualScheduleBlock
               applicant={settedApplicantHere}
               date={targetDate}
+              isFirstBlock={duration === '30분' || (duration === '1시간' && minute === 0)}
               onClick={() => {
                 // 1. 클릭한 블럭에 채워져있는 게 내 일정이라면 지운다
                 if (settedApplicantHereIsMe) {

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader.tsx
@@ -4,6 +4,7 @@ import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleHeaderProps {
   applicants: Applicant[];
+  completedApplicants: Applicant[];
   indicator: {
     month: number;
     onNextWeek: () => void;
@@ -17,6 +18,7 @@ interface ManualScheduleHeaderProps {
 export const ManualScheduleHeader = ({
   applicants,
   selectedApplicant,
+  completedApplicants,
   onSelectedApplicantChange,
   indicator: { month, week, onNextWeek, onPrevWeek },
 }: ManualScheduleHeaderProps) => {
@@ -32,6 +34,7 @@ export const ManualScheduleHeader = ({
       <InterviewHeaderLayout.Row>
         <ManualScheduleHeaderChipGroup
           applicants={applicants}
+          completedApplicants={completedApplicants}
           onSelectedApplicantChange={onSelectedApplicantChange}
           selectedApplicant={selectedApplicant}
         />

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeaderChipGroup.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeaderChipGroup.tsx
@@ -1,15 +1,17 @@
+import { IcCheckLine } from '@yourssu/design-system-react';
 import { tv } from 'tailwind-variants';
 
 import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleHeaderChipGroupProps {
   applicants: Applicant[];
+  completedApplicants: Applicant[];
   onSelectedApplicantChange: (v: Applicant) => void;
   selectedApplicant: Applicant;
 }
 
 const chip = tv({
-  base: 'typo-b2_rg_15 cursor-pointer rounded-full px-3 py-1.5',
+  base: 'typo-b2_rg_15 flex cursor-pointer items-center gap-0.5 rounded-full px-3 py-1.5',
   variants: {
     active: {
       true: 'bg-chipSelected text-text-brandPrimary font-semibold',
@@ -21,6 +23,7 @@ const chip = tv({
 export const ManualScheduleHeaderChipGroup = ({
   applicants,
   selectedApplicant,
+  completedApplicants,
   onSelectedApplicantChange,
 }: ManualScheduleHeaderChipGroupProps) => {
   return (
@@ -33,6 +36,9 @@ export const ManualScheduleHeaderChipGroup = ({
             key={applicant.name}
             onClick={() => onSelectedApplicantChange(applicant)}
           >
+            {completedApplicants.find((v) => v.applicantId === applicant.applicantId) && (
+              <IcCheckLine size="20px" />
+            )}
             {applicant.name}
           </button>
         ))}

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -32,6 +32,7 @@ export const ManualScheduleMode = () => {
         header: (
           <ManualScheduleHeader
             applicants={applicants}
+            completedApplicants={Array.from(completedScheduleMap.values())}
             indicator={{
               month,
               onNextWeek: handleNextWeek,

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { useDateMap } from '@/hooks/useDateMap';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { ManualScheduleCalendar } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar';
 import { ManualScheduleHeader } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader';
@@ -9,6 +10,7 @@ import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
 import { useAvailableApplicantsInWeek } from '@/pages/Interview/hooks/useAvailableApplicantsInWeek';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 import { applicantOptions } from '@/query/applicant/options';
+import { Applicant } from '@/query/applicant/schema';
 
 export const ManualScheduleMode = () => {
   const { partId } = useInterviewPartSelectionContext();
@@ -23,6 +25,9 @@ export const ManualScheduleMode = () => {
   });
 
   const [selectedApplicant, setSelectedApplicant] = useState(availableApplicants[0]);
+  const [completedScheduleMap, completedScheduleMapAction] = useDateMap<Applicant>({
+    precision: '분',
+  });
 
   return (
     <InterviewPageLayout
@@ -42,6 +47,8 @@ export const ManualScheduleMode = () => {
         ),
         calendar: (
           <ManualScheduleCalendar
+            completedScheduleMap={completedScheduleMap}
+            completedScheduleMapAction={completedScheduleMapAction}
             key={selectedApplicant.applicantId} // 선택한 지원자가 바뀌면 캘린더를 다시 렌더링
             month={month}
             selectedApplicant={selectedApplicant}

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -10,7 +10,6 @@ import {
   useInterviewAutoScheduleContext,
   useInterviewPartSelectionContext,
 } from '@/pages/Interview/context';
-import { useAvailableApplicantsInWeek } from '@/pages/Interview/hooks/useAvailableApplicantsInWeek';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 import { applicantOptions } from '@/query/applicant/options';
 import { Applicant } from '@/query/applicant/schema';
@@ -21,14 +20,8 @@ export const ManualScheduleMode = () => {
   const { year, month, week, handlePrevWeek, handleNextWeek } = useWeekIndicator();
 
   const { data: applicants } = useSuspenseQuery(applicantOptions({ partId }));
-  const availableApplicants = useAvailableApplicantsInWeek({
-    applicants,
-    month,
-    week,
-    year,
-  });
 
-  const [selectedApplicant, setSelectedApplicant] = useState(availableApplicants[0]);
+  const [selectedApplicant, setSelectedApplicant] = useState(applicants[0]);
   const [completedScheduleMap, completedScheduleMapAction] = useDateMap<Applicant>({
     precision: duration === '1시간' ? '시간' : '분',
   });
@@ -38,7 +31,7 @@ export const ManualScheduleMode = () => {
       slots={{
         header: (
           <ManualScheduleHeader
-            applicants={availableApplicants}
+            applicants={applicants}
             indicator={{
               month,
               onNextWeek: handleNextWeek,
@@ -62,8 +55,8 @@ export const ManualScheduleMode = () => {
         ),
         sidebar: (
           <ManualScheduleSidebar
-            completedApplicants={[]}
-            totalApplicantCount={availableApplicants.length}
+            completedApplicants={Array.from(completedScheduleMap.values())}
+            totalApplicantCount={applicants.length}
           />
         ),
       }}

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -17,11 +17,12 @@ import { Applicant } from '@/query/applicant/schema';
 export const ManualScheduleMode = () => {
   const { duration } = useInterviewAutoScheduleContext();
   const { partId } = useInterviewPartSelectionContext();
-  const { year, month, week, handlePrevWeek, handleNextWeek } = useWeekIndicator();
 
   const { data: applicants } = useSuspenseQuery(applicantOptions({ partId }));
-
   const [selectedApplicant, setSelectedApplicant] = useState(applicants[0]);
+  const { year, month, week, handlePrevWeek, handleNextWeek, jump } = useWeekIndicator({
+    initialDate: selectedApplicant?.availableTimes[0],
+  });
   const [completedScheduleMap, completedScheduleMapAction] = useDateMap<Applicant>({
     precision: duration === '1시간' ? '시간' : '분',
   });
@@ -39,7 +40,12 @@ export const ManualScheduleMode = () => {
               onPrevWeek: handlePrevWeek,
               week,
             }}
-            onSelectedApplicantChange={setSelectedApplicant}
+            onSelectedApplicantChange={(v) => {
+              if (v.availableTimes.length > 0) {
+                jump(v.availableTimes[0]);
+              }
+              setSelectedApplicant(v);
+            }}
             selectedApplicant={selectedApplicant}
           />
         ),

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -40,7 +40,15 @@ export const ManualScheduleMode = () => {
             selectedApplicant={selectedApplicant}
           />
         ),
-        calendar: <ManualScheduleCalendar month={month} week={week} year={year} />,
+        calendar: (
+          <ManualScheduleCalendar
+            key={selectedApplicant.applicantId} // 선택한 지원자가 바뀌면 캘린더를 다시 렌더링
+            month={month}
+            selectedApplicant={selectedApplicant}
+            week={week}
+            year={year}
+          />
+        ),
         sidebar: (
           <ManualScheduleSidebar
             completedApplicants={[]}

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -6,13 +6,17 @@ import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageL
 import { ManualScheduleCalendar } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar';
 import { ManualScheduleHeader } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader';
 import { ManualScheduleSidebar } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar';
-import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
+import {
+  useInterviewAutoScheduleContext,
+  useInterviewPartSelectionContext,
+} from '@/pages/Interview/context';
 import { useAvailableApplicantsInWeek } from '@/pages/Interview/hooks/useAvailableApplicantsInWeek';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 import { applicantOptions } from '@/query/applicant/options';
 import { Applicant } from '@/query/applicant/schema';
 
 export const ManualScheduleMode = () => {
+  const { duration } = useInterviewAutoScheduleContext();
   const { partId } = useInterviewPartSelectionContext();
   const { year, month, week, handlePrevWeek, handleNextWeek } = useWeekIndicator();
 
@@ -26,7 +30,7 @@ export const ManualScheduleMode = () => {
 
   const [selectedApplicant, setSelectedApplicant] = useState(availableApplicants[0]);
   const [completedScheduleMap, completedScheduleMapAction] = useDateMap<Applicant>({
-    precision: '분',
+    precision: duration === '1시간' ? '시간' : '분',
   });
 
   return (

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
+import { ManualScheduleCalendar } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar';
 import { ManualScheduleHeader } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader';
 import { ManualScheduleSidebar } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
@@ -39,7 +40,7 @@ export const ManualScheduleMode = () => {
             selectedApplicant={selectedApplicant}
           />
         ),
-        calendar: <div />,
+        calendar: <ManualScheduleCalendar month={month} week={week} year={year} />,
         sidebar: (
           <ManualScheduleSidebar
             completedApplicants={[]}

--- a/src/pages/Interview/hooks/useWeekIndicator.tsx
+++ b/src/pages/Interview/hooks/useWeekIndicator.tsx
@@ -38,5 +38,11 @@ export const useWeekIndicator = ({ initialDate }: UseWeekIndicatorProps = {}) =>
     }
   };
 
-  return { year, month, week, handlePrevWeek, handleNextWeek };
+  const jump = (date: DateArg<Date>) => {
+    setYear(getYear(date));
+    setMonth(getMonth(date) + 1);
+    setWeek(getWeekOfMonth(date) - 1);
+  };
+
+  return { year, month, week, handlePrevWeek, handleNextWeek, jump };
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

| 1시간 단위 일정 | 30분 단위 일정 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/520720dd-f134-40bf-9923-6e66d63b0b82"> | <video src="https://github.com/user-attachments/assets/4dce310a-22d4-4da2-b06d-1e7148364f48"> |

`수동생성` 모드의 캘린더를 구현했어요.

- 지원자들의 희망 일정 블럭을 캘린더에 렌더링해요. 이 블럭을 클릭하면 해당 시간에 지원자 면접 일정을 추가할 수 있어요.

- 면접 시간이 1시간 단위일 때와 30분 단위일 때에 각각 대응해서 일정을 추가할 수 있도록 했어요. (영상 참고)

- 일정이 지정된 지원자들을 헤더와 사이드바에 나타내주도록 했어요.

<br />

### 일정 추가 정책

피그마 상에서 구체적으로 정책이 지정된게 없어서 제가 임의로 구현했어요.

1. 면접 시간이 30분이라면 일정 블럭을 1개씩, 1시간이라면 N시간 단위로 2개씩 선택해요. 
예를 들어 면접 시간이 1시간이라면, 4시 30분을 선택하면 4시-4시30분 블럭과 4시30분-5시 블럭이 선택돼요.

    - 만약 면접 시간이 1시간인데 일정 블럭이 4시-4시30분 블럭밖에 없다면, 4시30분-5시가 불가능하더라도 선택돼요.

2. 일정은 지원자당 1개 시간대만 선택할 수 있어요. 
이미 선택된 상태에서 다른 면접 가능 시간을 선택하면 해당 시간으로 변경돼요.

3. 다른 지원자가 선택한 일정을 덮어쓸 수 없어요.


## 2️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
