### PR TITLE
fix: `희망일정` 모드 > 겹치는 일정에 대한 처리 부재 구현

### DIFF
--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesCalendar.tsx
@@ -5,6 +5,7 @@ import { AvailableTimesBlock } from '@/pages/Interview/components/AvailableTimes
 import { useAvailableTimesModeHoverContext } from '@/pages/Interview/components/AvailableTimesMode/context';
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
 import { Applicant } from '@/query/applicant/schema';
+import { DateMapSetterEntries } from '@/utils/DateMap';
 
 interface AvailableTimesCalendarProps {
   availableApplicants: Applicant[];
@@ -12,8 +13,6 @@ interface AvailableTimesCalendarProps {
   week: number;
   year: number;
 }
-
-type AvailableApplicantEntry = [Date, Applicant[]];
 
 export const AvailableTimesCalendar = ({
   month,
@@ -23,8 +22,13 @@ export const AvailableTimesCalendar = ({
 }: AvailableTimesCalendarProps) => {
   const { hoveredChipApplicantId } = useAvailableTimesModeHoverContext();
 
-  const makeAvailableApplicantEntries = (applicant: Applicant): AvailableApplicantEntry[] => {
-    return applicant.availableTimes.map((time) => [new Date(time), [applicant]]);
+  const makeAvailableApplicantEntries = (
+    applicant: Applicant,
+  ): DateMapSetterEntries<Applicant[]> => {
+    return applicant.availableTimes.map((time) => [
+      new Date(time),
+      (prev) => [...(prev ?? []), applicant],
+    ]);
   };
 
   const [map] = useDateMap({

--- a/src/utils/DateMap/DateMap.ts
+++ b/src/utils/DateMap/DateMap.ts
@@ -18,7 +18,7 @@ import {
  * @template T - DateMap이 저장하는 값의 타입이에요. 함수 타입은 허용되지 않아요.
  *
  * @param {DateMapOptions<T>} [options] - DateMap이 어떻게 동작할지 설정하는 옵션이에요.
- * @param {DateMapValueEntries<T>} [options.initialEntries] - DateMap 생성시 추가할 초기 엔트리들의 배열이에요.
+ * @param {DateMapSetterEntries<T>} [options.initialEntries] - DateMap 생성시 추가할 초기 엔트리들의 배열이에요.
  * @param {DateMapPrecisionRange | DateMapPrecisionType} [options.precision] - 날짜를 비교할 때 사용할 정밀도 범위를 지정해요.
  * - 지정하지 않으면, 날짜 전체로 비교해요.
  * - 단일 값으로 지정하면, 해당 정밀도 미만의 값이 모두 무시돼요.

--- a/src/utils/DateMap/type.ts
+++ b/src/utils/DateMap/type.ts
@@ -15,6 +15,6 @@ export type DateMapPrecisionRange = {
 };
 
 export type DateMapOptions<T> = {
-  initialEntries?: DateMapValueEntries<T>;
+  initialEntries?: DateMapSetterEntries<T>;
   precision?: DateMapPrecisionRange | DateMapPrecisionType;
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

`희망일정` 모드에서 지원자가 여러명일 때,
면접 가능 일정이 겹치면 가장 마지막 지원자의 일정만 보여주던 문제를 수정했어요.

| as-is | to-be |
| --- | --- |
| <img width="1145" height="937" alt="스크린샷 2026-01-01 20 23 22" src="https://github.com/user-attachments/assets/421f00cc-7dca-4a4f-818a-2f60e597b19f" />  |  <img width="1124" height="1018" alt="스크린샷 2026-01-01 20 22 37" src="https://github.com/user-attachments/assets/431513bb-77d3-40b2-bf42-7498fc763309" /> |


## 2️⃣ 알아두시면 좋아요!

지원자들의 면접 가능 일정을 DateMap으로 묶어서 관리하고 있었는데,
이 DateMap을 초기화할 때 이미 해당 시간에 추가된 일정들이 있더라도 다른 일정으로 덮어씌우고 있었어요.

ex)
```markdown
A 지원자 가능 일정: 오후 1시 ~ 오후4시
B 지원자 가능 일정: 오후 2시 ~ 오후3시

---

1. DateMap에 A 지원자 일정 넣고 초기화:

{
  오후 1시 ~ 오후 2시: [지원자 A],
  오후 2시 ~ 오후 3시: [지원자 A],
  오후 3시 ~ 오후 4시: [지원자 A],
}

2. DateMap에 B 지원자 일정 넣고 초기화:

{
  오후 1시 ~ 오후 2시: [지원자 A],
  오후 2시 ~ 오후 3시: [지원자 B], // 정상적이라면 여기서 [지원자 A, 지원자 B] 가 되어야 함.
  오후 3시 ~ 오후 4시: [지원자 A],
}

```

이건 DateMap에서 이런 경우를 대비해 
리액트 setter 처럼 값을 변경할 필드에 이미 값이 있을 때 그 값을 받을 수 있도록 구현되어있어서
그 방식으로 변경해서 해결했어요.

 


## 3️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
