### PR TITLE
feat: 수동생성 모드에서 배정한 일정들을 저장해요

### DIFF
--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
@@ -6,6 +6,7 @@ import { assert } from 'es-toolkit';
 import { useAlertDialog } from '@/hooks/useAlertDialog';
 import {
   useInterviewAutoScheduleContext,
+  useInterviewCalendarModeContext,
   useInterviewPartSelectionContext,
 } from '@/pages/Interview/context';
 import { Applicant } from '@/query/applicant/schema';
@@ -22,8 +23,9 @@ export const ManualScheduleSaveButton = ({
   completedApplicants,
   totalApplicantCount,
 }: ManualScheduleSaveButtonProps) => {
-  const { partName, partId } = useInterviewPartSelectionContext();
   const openAlertDialog = useAlertDialog();
+  const { setCalendarMode } = useInterviewCalendarModeContext();
+  const { partName, partId, onPartChange } = useInterviewPartSelectionContext();
   const { duration } = useInterviewAutoScheduleContext();
   const { mutateAsync: mutatePostSchedule } = useMutation({
     mutationFn: postSchedule,
@@ -62,6 +64,9 @@ export const ManualScheduleSaveButton = ({
         })),
       });
       await invalidateSchedule();
+
+      onPartChange(null);
+      setCalendarMode('면접일정');
     }
   };
 

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
@@ -1,0 +1,73 @@
+import { useMutation } from '@tanstack/react-query';
+import { BoxButton } from '@yourssu/design-system-react';
+import { addHours, addMinutes } from 'date-fns';
+import { assert } from 'es-toolkit';
+
+import { useAlertDialog } from '@/hooks/useAlertDialog';
+import {
+  useInterviewAutoScheduleContext,
+  useInterviewPartSelectionContext,
+} from '@/pages/Interview/context';
+import { Applicant } from '@/query/applicant/schema';
+import { useInvalidateSchedule } from '@/query/schedule/hooks/useInvalidateSchedule';
+import { deletePartSchedule } from '@/query/schedule/mutations/deletePartSchedule';
+import { postSchedule } from '@/query/schedule/mutations/postSchedule';
+
+interface ManualScheduleSaveButtonProps {
+  completedApplicants: [Date, Applicant][];
+  totalApplicantCount: number;
+}
+
+export const ManualScheduleSaveButton = ({
+  completedApplicants,
+  totalApplicantCount,
+}: ManualScheduleSaveButtonProps) => {
+  const { partName, partId } = useInterviewPartSelectionContext();
+  const openAlertDialog = useAlertDialog();
+  const { duration } = useInterviewAutoScheduleContext();
+  const { mutateAsync: mutatePostSchedule } = useMutation({
+    mutationFn: postSchedule,
+  });
+  const { mutateAsync: mutateDeletePartSchedule } = useMutation({
+    mutationFn: deletePartSchedule,
+  });
+  const invalidateSchedule = useInvalidateSchedule(partId);
+
+  const onSaveSchedule = async () => {
+    if (completedApplicants.length < totalApplicantCount) {
+      openAlertDialog({
+        title: '지원자를 모두 배정해주세요',
+        content: '아직 면접 시간이 배정되지 않은 지원자가 있어요.',
+        primaryButtonText: '확인',
+      });
+      return;
+    }
+
+    const result = await openAlertDialog({
+      title: '이대로 면접 일정을 저장할까요?',
+      content: `${partName} 팀 면접 시간표`,
+      primaryButtonText: '저장하기',
+      secondaryButtonText: '취소',
+    });
+
+    if (result) {
+      assert(!!partId, '일정을 만들기 위한 partId가 없어요.');
+      await mutateDeletePartSchedule(partId);
+      await mutatePostSchedule({
+        schedules: completedApplicants.map(([date, applicant]) => ({
+          applicantId: applicant.applicantId,
+          partId,
+          startTime: date.toISOString(),
+          endTime: (duration === '1시간' ? addHours(date, 1) : addMinutes(date, 30)).toISOString(),
+        })),
+      });
+      await invalidateSchedule();
+    }
+  };
+
+  return (
+    <BoxButton className="w-full" onClick={onSaveSchedule} size="xlarge" variant="filledPrimary">
+      시간표 저장하기
+    </BoxButton>
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -1,13 +1,11 @@
-import { BoxButton } from '@yourssu/design-system-react';
-
-import { useAlertDialog } from '@/hooks/useAlertDialog';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+import { ManualScheduleSaveButton } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton';
 import { ManualScheduleSidebarPartCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard';
 import { ManualScheduleSidebarProgressCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard';
 import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleSidebarProps {
-  completedApplicants: Applicant[];
+  completedApplicants: [Date, Applicant][];
   totalApplicantCount: number;
 }
 
@@ -15,37 +13,20 @@ export const ManualScheduleSidebar = ({
   completedApplicants,
   totalApplicantCount,
 }: ManualScheduleSidebarProps) => {
-  const openAlertDialog = useAlertDialog();
-
-  const onSaveSchedule = () => {
-    if (completedApplicants.length < totalApplicantCount) {
-      openAlertDialog({
-        title: '지원자를 모두 배정해주세요',
-        content: '아직 면접 시간이 배정되지 않은 지원자가 있어요.',
-        primaryButtonText: '확인',
-      });
-      return;
-    }
-  };
-
   return (
     <InterviewSidebarLayout>
       <InterviewSidebarLayout.CardList>
         <ManualScheduleSidebarPartCard />
         <ManualScheduleSidebarProgressCard
-          completedApplicants={completedApplicants}
+          completedApplicants={completedApplicants.map(([, applicants]) => applicants)}
           totalApplicantCount={totalApplicantCount}
         />
       </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
-        <BoxButton
-          className="w-full"
-          onClick={onSaveSchedule}
-          size="xlarge"
-          variant="filledPrimary"
-        >
-          시간표 저장하기
-        </BoxButton>
+        <ManualScheduleSaveButton
+          completedApplicants={completedApplicants}
+          totalApplicantCount={totalApplicantCount}
+        />
       </InterviewSidebarLayout.BottomArea>
     </InterviewSidebarLayout>
   );

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -1,5 +1,6 @@
 import { BoxButton } from '@yourssu/design-system-react';
 
+import { useAlertDialog } from '@/hooks/useAlertDialog';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
 import { ManualScheduleSidebarPartCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard';
 import { ManualScheduleSidebarProgressCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard';
@@ -14,6 +15,19 @@ export const ManualScheduleSidebar = ({
   completedApplicants,
   totalApplicantCount,
 }: ManualScheduleSidebarProps) => {
+  const openAlertDialog = useAlertDialog();
+
+  const onSaveSchedule = () => {
+    if (completedApplicants.length < totalApplicantCount) {
+      openAlertDialog({
+        title: '지원자를 모두 배정해주세요',
+        content: '아직 면접 시간이 배정되지 않은 지원자가 있어요.',
+        primaryButtonText: '확인',
+      });
+      return;
+    }
+  };
+
   return (
     <InterviewSidebarLayout>
       <InterviewSidebarLayout.CardList>
@@ -24,7 +38,12 @@ export const ManualScheduleSidebar = ({
         />
       </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
-        <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
+        <BoxButton
+          className="w-full"
+          onClick={onSaveSchedule}
+          size="xlarge"
+          variant="filledPrimary"
+        >
           시간표 저장하기
         </BoxButton>
       </InterviewSidebarLayout.BottomArea>

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -62,7 +62,7 @@ export const ManualScheduleMode = () => {
         ),
         sidebar: (
           <ManualScheduleSidebar
-            completedApplicants={Array.from(completedScheduleMap.values())}
+            completedApplicants={completedScheduleMap.entries()}
             totalApplicantCount={applicants.length}
           />
         ),

--- a/src/query/schedule/hooks/useInvalidateSchedule.ts
+++ b/src/query/schedule/hooks/useInvalidateSchedule.ts
@@ -1,0 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { scheduleOptions } from '@/query/schedule/options';
+
+export const useInvalidateSchedule = (partId: null | number) => {
+  const queryClient = useQueryClient();
+
+  return () =>
+    queryClient.invalidateQueries({
+      queryKey: scheduleOptions(partId).queryKey,
+    });
+};

--- a/src/query/schedule/mutations/deletePartSchedule.ts
+++ b/src/query/schedule/mutations/deletePartSchedule.ts
@@ -1,0 +1,5 @@
+import { api } from '@/apis/api';
+
+export const deletePartSchedule = (partId: number) => {
+  return api.delete(`recruiter/schedule/part/${partId}`);
+};

--- a/src/query/schedule/mutations/postSchedule.ts
+++ b/src/query/schedule/mutations/postSchedule.ts
@@ -1,0 +1,16 @@
+import { api } from '@/apis/api';
+
+interface PostScheduleParams {
+  schedules: Array<{
+    applicantId: number;
+    endTime: string;
+    partId: number;
+    startTime: string;
+  }>;
+}
+
+export const postSchedule = (params: PostScheduleParams) => {
+  return api.post('recruiter/schedule', {
+    json: params.schedules,
+  });
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

https://github.com/user-attachments/assets/04eb390b-28e0-409f-90a5-ece452aadd22

- 일정을 생성하는 api (postSchedule), 특정 파트의 모든 일정을 제거하는 api (deletePartSchedule)를 구현했어요.

- 일정을 배정받지 않은 지원자가 있을 때 저장하려하면 다이얼로그를 띄우면서 '저장 액션을 막았어요'.

  - 이게 피그마랑 액션이 다른데, 자동 저장이 있는데 굳이 나머지 일정을 자동으로 채우는 액션이 애매하게 다가와서 알잘딱으로 변경해봤어요. 
  이건 우미가 돌아오면 더 얘기가 필요한 사항입니다.

- 저장을 시도하면, 기존 파트의 모든 일정을 제거하고 새롭게 배정한 지원자들의 일정을 저장해요.

  - 이건 저장 api가 새롭게 저장하고자하는 일정에 이미 기존 일정이 존재하면 400 에러를 던지기 때문에 이렇게 처리했어요.

- 저장이 완료되면 다시 `면접일정` 모드로 초기화해요.

## 2️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
