### PR TITLE
feat: 인터뷰 페이지에서 겹치는 면접 일정에 대한 평가 방식 개선

### DIFF
--- a/src/pages/Interview/hooks/useConfilctScheduleGroups.tsx
+++ b/src/pages/Interview/hooks/useConfilctScheduleGroups.tsx
@@ -23,7 +23,7 @@ export const useConfilctScheduleGroups = (schedules: Schedule[]): ConflictSchedu
 
       for (let j = i + 1; j < sortedSchedules.length; j++) {
         const target = sortedSchedules[j];
-        if (seed.endTime < target.startTime) {
+        if (seed.endTime <= target.startTime) {
           break;
         }
         group.push(target);


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

면접 일정 끝 시간과 시작 시간이 같아도 안 겹치는 판정으로 개선했어요.

```
as-is: 끝 시간과 시작 시간이 같으면 겹침 판정

ex) 
A 일정 끝: 오후 1시
B 일정 시작: 오후 1시
=> 두 A, B 일정은 겹치는 일정

---
to-be: 끝 시간과 시작 시간이 같아도 괜찮음
```


## 2️⃣ 알아두시면 좋아요!

타겟 브랜치가 interview-page-qa 인데, 요 브랜치에 셀프 QA 반영 내용들을 머지해서 모아둘 예정이예요.

interview-page-qa에 대한 pr은 이 pr이 머지된 이후에 만들어두려고 해요.
