### PR TITLE
feat: 자동생성 모드로의 진입점을 구현했어요

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^18.3.1",
     "react-error-boundary": "^5.0.0",
     "react-hook-form": "^7.54.2",
+    "react-icons": "^5.5.0",
     "react-router": "^7.1.3",
     "react-simplikit": "^0.0.46",
     "styled-components": "^6.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.55.0(react@18.3.1)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@18.3.1)
       react-router:
         specifier: ^7.1.3
         version: 7.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3114,6 +3117,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -6674,6 +6682,10 @@ snapshots:
       react: 18.3.1
 
   react-hook-form@7.55.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-icons@5.5.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/src/pages/Interview/Interview.tsx
+++ b/src/pages/Interview/Interview.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { SwitchCase } from 'react-simplikit';
 
 import { usePartFilter } from '@/hooks/usePartFilter';
+import { AutoScheduleMode } from '@/pages/Interview/components/AutoScheduleMode';
 import { AvailableTimesMode } from '@/pages/Interview/components/AvailableTimesMode';
 import { InterviewScheduleMode } from '@/pages/Interview/components/InterviewScheduleMode';
 import { ManualScheduleMode } from '@/pages/Interview/components/ManualScheduleMode';
@@ -33,7 +34,7 @@ export const InterviewPage = () => {
               면접일정: () => <InterviewScheduleMode />,
               희망일정: () => <AvailableTimesMode />,
               수동생성: () => <ManualScheduleMode />,
-              자동생성: () => <div />,
+              자동생성: () => <AutoScheduleMode />,
             }}
             value={calendarMode}
           />

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -1,0 +1,13 @@
+import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
+
+export const AutoScheduleMode = () => {
+  return (
+    <InterviewPageLayout
+      slots={{
+        header: <div />,
+        calendar: <div />,
+        sidebar: <div />,
+      }}
+    />
+  );
+};

--- a/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
+++ b/src/pages/Interview/components/AvailableTimesMode/AvailableTimesSidebar.tsx
@@ -7,13 +7,14 @@ import {
   useInterviewCalendarModeContext,
   useInterviewPartSelectionContext,
 } from '@/pages/Interview/context';
+import { CalendarModeType } from '@/pages/Interview/type';
 
 export const AvailableTimesSidebar = () => {
   const { partName } = useInterviewPartSelectionContext();
   const { setCalendarMode } = useInterviewCalendarModeContext();
   const openAlertDialog = useAlertDialog();
 
-  const onManualScheduleModeButtonClick = () => {
+  const onScheduleModeButtonClick = (mode: Extract<CalendarModeType, '수동생성' | '자동생성'>) => {
     if (!partName) {
       openAlertDialog({
         title: '파트를 선택해주세요',
@@ -28,7 +29,7 @@ export const AvailableTimesSidebar = () => {
       return;
     }
 
-    setCalendarMode('수동생성');
+    setCalendarMode(mode);
   };
 
   return (
@@ -40,13 +41,18 @@ export const AvailableTimesSidebar = () => {
         <div className="grid grid-cols-2 gap-3">
           <BoxButton
             className="w-full"
-            onClick={onManualScheduleModeButtonClick}
+            onClick={() => onScheduleModeButtonClick('수동생성')}
             size="xlarge"
             variant="filledSecondary"
           >
             일정 수동 생성
           </BoxButton>
-          <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
+          <BoxButton
+            className="w-full"
+            onClick={() => onScheduleModeButtonClick('자동생성')}
+            size="xlarge"
+            variant="filledPrimary"
+          >
             일정 자동 생성
           </BoxButton>
         </div>

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader.tsx
@@ -1,5 +1,6 @@
 import { InterviewHeaderLayout } from '@/pages/Interview/components/InterviewHeaderLayout';
 import { ManualScheduleHeaderChipGroup } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleHeaderChipGroup';
+import { ScheduleModeToggleButton } from '@/pages/Interview/components/ScheduleModeToggleButton';
 import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleHeaderProps {
@@ -30,6 +31,7 @@ export const ManualScheduleHeader = ({
           onNextWeek={onNextWeek}
           onPrevWeek={onPrevWeek}
         />
+        <ScheduleModeToggleButton />
       </InterviewHeaderLayout.Row>
       <InterviewHeaderLayout.Row>
         <ManualScheduleHeaderChipGroup

--- a/src/pages/Interview/components/ScheduleModeToggleButton.tsx
+++ b/src/pages/Interview/components/ScheduleModeToggleButton.tsx
@@ -1,0 +1,36 @@
+import { BoxButton } from '@yourssu/design-system-react';
+import { assert } from 'es-toolkit';
+import { CgArrowsExchange } from 'react-icons/cg';
+
+import { useAlertDialog } from '@/hooks/useAlertDialog';
+import { useInterviewCalendarModeContext } from '@/pages/Interview/context';
+
+export const ScheduleModeToggleButton = () => {
+  const { calendarMode, setCalendarMode } = useInterviewCalendarModeContext();
+  assert(
+    calendarMode === '수동생성' || calendarMode === '자동생성',
+    'ScheduleModeToggleButton은 수동생성/자동생성 모드에서만 사용할 수 있어요.',
+  );
+
+  const openAlertDialog = useAlertDialog();
+
+  const nextMode = calendarMode === '수동생성' ? '자동생성' : '수동생성';
+
+  const onClick = async () => {
+    const answer = await openAlertDialog({
+      title: `시간표 ${nextMode} 모드로 변경할까요?`,
+      content: '변경한 내용은 저장되지 않아요.',
+      primaryButtonText: '변경하기',
+      secondaryButtonText: '취소',
+    });
+    if (answer) {
+      setCalendarMode(nextMode);
+    }
+  };
+
+  return (
+    <BoxButton leftIcon={<CgArrowsExchange />} onClick={onClick} size="small" variant="outlined">
+      시간표 {nextMode} 하기
+    </BoxButton>
+  );
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

자동생성 모드를 구현하기 전, 진입점을 구현했어요.

총 두 군데에서 진입점이 필요했는데요,

1. 희망일정 모드에서 자동생성 버튼을 눌러 진입

<img width="600" alt="스크린샷 2026-01-04 17 39 57" src="https://github.com/user-attachments/assets/206ba510-759e-4ec7-bbae-fde88b41de59" />

<br />

2. 수동생성 모드에서 모드 토글 버튼을 눌러서 자동생성 모드 진입


https://github.com/user-attachments/assets/6cad0dbb-6639-46ca-a50a-c2185874c58e

이 두 진입점을 구현해줬어요.




## 2️⃣ 알아두시면 좋아요!

의존성으로 [react-icons](https://react-icons.github.io/react-icons/)를 설치해줬는데, YDS에는 없는 아이콘이 필요해서 설치해줬어요.

tree-shaking도 되서 번들 사이즈는 크게 걱정안해도 됩니다.

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
