### PR TITLE
feat: 자동생성 모드의 사이드바를 구현했어요

### DIFF
--- a/src/pages/Interview/Interview.tsx
+++ b/src/pages/Interview/Interview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { SwitchCase } from 'react-simplikit';
 
 import { usePartFilter } from '@/hooks/usePartFilter';
@@ -34,7 +34,11 @@ export const InterviewPage = () => {
               면접일정: () => <InterviewScheduleMode />,
               희망일정: () => <AvailableTimesMode />,
               수동생성: () => <ManualScheduleMode />,
-              자동생성: () => <AutoScheduleMode />,
+              자동생성: () => (
+                <Suspense>
+                  <AutoScheduleMode />
+                </Suspense>
+              ),
             }}
             value={calendarMode}
           />

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
@@ -1,11 +1,23 @@
 import { BoxButton } from '@yourssu/design-system-react';
 
+import { AutoScheduleThumbnail } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleThumbnail';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+import { AutoSchedule } from '@/query/schedule/schema';
 
-export const AutoScheduleSidebar = () => {
+interface AutoScheduleSidebarProps {
+  scheduleCandidates: AutoSchedule[][];
+}
+
+export const AutoScheduleSidebar = ({ scheduleCandidates }: AutoScheduleSidebarProps) => {
   return (
     <InterviewSidebarLayout>
-      <InterviewSidebarLayout.CardList title="생성된 시간표" />
+      <InterviewSidebarLayout.CardList title="생성된 시간표">
+        <div className="flex flex-col gap-5">
+          {scheduleCandidates.map((scheduleCandidate, i) => (
+            <AutoScheduleThumbnail key={i} schedules={scheduleCandidate} />
+          ))}
+        </div>
+      </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
         <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
           시간표 저장하기

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
@@ -1,22 +1,58 @@
 import { BoxButton } from '@yourssu/design-system-react';
+import clsx from 'clsx';
+import { assert } from 'es-toolkit';
+import { RadioGroup } from 'radix-ui';
 
 import { AutoScheduleThumbnail } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleThumbnail';
+import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
-import { AutoSchedule } from '@/query/schedule/schema';
 
 interface AutoScheduleSidebarProps {
-  scheduleCandidates: AutoSchedule[][];
+  onCandidateChange: (v: AutoScheduleCandidate) => void;
+  scheduleCandidates: AutoScheduleCandidate[];
+  selectedCandidate: AutoScheduleCandidate;
 }
 
-export const AutoScheduleSidebar = ({ scheduleCandidates }: AutoScheduleSidebarProps) => {
+export const AutoScheduleSidebar = ({
+  scheduleCandidates,
+  onCandidateChange,
+  selectedCandidate,
+}: AutoScheduleSidebarProps) => {
+  const onValueChange = (value: string) => {
+    const target = scheduleCandidates.find(({ id }) => value === id);
+    assert(!!target, '생성된 시간표 RadioGroup에 존재하지 않는 시간표가 있어요.');
+    onCandidateChange(target);
+  };
+
   return (
     <InterviewSidebarLayout>
       <InterviewSidebarLayout.CardList title="생성된 시간표">
-        <div className="flex flex-col gap-5">
-          {scheduleCandidates.map((scheduleCandidate, i) => (
-            <AutoScheduleThumbnail key={i} schedules={scheduleCandidate} />
-          ))}
-        </div>
+        <RadioGroup.Root onValueChange={onValueChange} value={selectedCandidate.id}>
+          <div className="flex flex-col gap-5">
+            {scheduleCandidates.map(({ id, schedules }) => {
+              const checked = id === selectedCandidate.id;
+              return (
+                <div className="flex items-center gap-5" key={id}>
+                  <RadioGroup.Item
+                    className={clsx(
+                      'size-5 shrink-0 cursor-pointer rounded-full border bg-white p-1',
+                      checked
+                        ? 'border-button-radioSelected'
+                        : 'border-button-radioUnselected hover:bg-gray200',
+                    )}
+                    id={id}
+                    value={id}
+                  >
+                    <RadioGroup.Indicator className="after:bg-button-radioSelected after:block after:size-full after:rounded-full" />
+                  </RadioGroup.Item>
+                  <label className="block w-full cursor-pointer" htmlFor={id}>
+                    <AutoScheduleThumbnail schedules={schedules} />
+                  </label>
+                </div>
+              );
+            })}
+          </div>
+        </RadioGroup.Root>
       </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
         <BoxButton className="w-full" size="xlarge" variant="filledPrimary">

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
@@ -1,0 +1,16 @@
+import { BoxButton } from '@yourssu/design-system-react';
+
+import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+
+export const AutoScheduleSidebar = () => {
+  return (
+    <InterviewSidebarLayout>
+      <InterviewSidebarLayout.CardList title="생성된 시간표" />
+      <InterviewSidebarLayout.BottomArea>
+        <BoxButton className="w-full" size="xlarge" variant="filledPrimary">
+          시간표 저장하기
+        </BoxButton>
+      </InterviewSidebarLayout.BottomArea>
+    </InterviewSidebarLayout>
+  );
+};

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleThumbnail.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleThumbnail.tsx
@@ -1,0 +1,55 @@
+import clsx from 'clsx';
+import { addMinutes, compareAsc, getHours, getMonth, getWeek, getYear } from 'date-fns';
+import { range } from 'es-toolkit';
+import { useMemo } from 'react';
+
+import { useCalendarWeekDates } from '@/hooks/useCalendarWeekDates';
+import { useDateMap } from '@/hooks/useDateMap';
+import { useInterviewAutoScheduleContext } from '@/pages/Interview/context';
+import { AutoSchedule } from '@/query/schedule/schema';
+
+interface AutoScheduleThumbnailProps {
+  schedules: AutoSchedule[];
+}
+
+export const AutoScheduleThumbnail = ({ schedules }: AutoScheduleThumbnailProps) => {
+  const { duration } = useInterviewAutoScheduleContext();
+  const sortedSchedules = schedules.toSorted((a, b) => compareAsc(a.startTime, b.startTime));
+
+  const [map] = useDateMap({
+    initialEntries: sortedSchedules.map((v) => [new Date(v.startTime), v]),
+    precision: duration === '1시간' ? '시간' : '분',
+  });
+
+  const weekDates = useCalendarWeekDates({
+    month: getMonth(sortedSchedules[0].startTime) + 1,
+    week: getWeek(sortedSchedules[0].startTime) - 1,
+    year: getYear(sortedSchedules[0].startTime),
+  });
+
+  const hourRange = useMemo(() => {
+    const lowerBoundTime = sortedSchedules[0].startTime;
+    const upperBoundTime = sortedSchedules[sortedSchedules.length - 1].endTime;
+    const padding = 1;
+    return {
+      startHour: getHours(lowerBoundTime) - padding,
+      endHour: getHours(upperBoundTime) + padding + 1,
+    };
+  }, [sortedSchedules]);
+
+  return (
+    <div className="border-line-basicMedium grid w-full grid-cols-7 gap-0.5 rounded-xl border bg-white">
+      {range(hourRange.startHour * 60, hourRange.endHour * 60, 30).map((minutes) => {
+        return weekDates.map((date) => {
+          const targetDate = addMinutes(date, minutes);
+          const schedule = map.get(targetDate);
+          return (
+            <div className="h-5 w-full">
+              <div className={clsx('size-full', !!schedule && 'bg-bg-brandPrimary rounded-xs')} />
+            </div>
+          );
+        });
+      })}
+    </div>
+  );
+};

--- a/src/pages/Interview/components/AutoScheduleMode/hooks/useAutoScheduleCandidates.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/hooks/useAutoScheduleCandidates.tsx
@@ -1,0 +1,33 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { assert } from 'es-toolkit';
+import { useMemo } from 'react';
+
+import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
+import {
+  useInterviewAutoScheduleContext,
+  useInterviewPartSelectionContext,
+} from '@/pages/Interview/context';
+import { autoScheduleOptions } from '@/query/schedule/auto/options';
+
+export const useAutoScheduleCandidates = (): AutoScheduleCandidate[] => {
+  const { duration, strategy } = useInterviewAutoScheduleContext();
+  const { partId } = useInterviewPartSelectionContext();
+
+  assert(!!partId, 'partId가 없어요.');
+
+  const { data } = useSuspenseQuery(
+    autoScheduleOptions({
+      size: 5,
+      partId,
+      duration: duration === '1시간' ? 60 : 30,
+      strategy: strategy === '밀집형' ? 'MIN' : 'MAX',
+    }),
+  );
+
+  return useMemo(() => {
+    return data.map((v) => ({
+      id: crypto.randomUUID(),
+      schedules: v,
+    }));
+  }, [data]);
+};

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -1,4 +1,5 @@
 import { AutoScheduleHeader } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleHeader';
+import { AutoScheduleSidebar } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 
@@ -19,8 +20,9 @@ export const AutoScheduleMode = () => {
           />
         ),
         calendar: <div />,
-        sidebar: <div />,
+        sidebar: <AutoScheduleSidebar />,
       }}
+      variants="sidebar-expand"
     />
   );
 };

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -1,10 +1,31 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { assert } from 'es-toolkit';
+
 import { AutoScheduleHeader } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleHeader';
 import { AutoScheduleSidebar } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
+import {
+  useInterviewAutoScheduleContext,
+  useInterviewPartSelectionContext,
+} from '@/pages/Interview/context';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
+import { autoScheduleOptions } from '@/query/schedule/auto/options';
 
 export const AutoScheduleMode = () => {
+  const { duration, strategy } = useInterviewAutoScheduleContext();
+  const { partId } = useInterviewPartSelectionContext();
   const { handleNextWeek, handlePrevWeek, month, week } = useWeekIndicator();
+
+  assert(!!partId, 'partId가 없어요.');
+
+  const { data } = useSuspenseQuery(
+    autoScheduleOptions({
+      size: 5,
+      partId,
+      duration: duration === '1시간' ? 60 : 30,
+      strategy: strategy === '밀집형' ? 'MIN' : 'MAX',
+    }),
+  );
 
   return (
     <InterviewPageLayout
@@ -20,7 +41,7 @@ export const AutoScheduleMode = () => {
           />
         ),
         calendar: <div />,
-        sidebar: <AutoScheduleSidebar />,
+        sidebar: <AutoScheduleSidebar scheduleCandidates={data} />,
       }}
       variants="sidebar-expand"
     />

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -1,30 +1,18 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { assert } from 'es-toolkit';
+import { useState } from 'react';
 
 import { AutoScheduleHeader } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleHeader';
 import { AutoScheduleSidebar } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar';
+import { useAutoScheduleCandidates } from '@/pages/Interview/components/AutoScheduleMode/hooks/useAutoScheduleCandidates';
+import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
-import {
-  useInterviewAutoScheduleContext,
-  useInterviewPartSelectionContext,
-} from '@/pages/Interview/context';
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
-import { autoScheduleOptions } from '@/query/schedule/auto/options';
 
 export const AutoScheduleMode = () => {
-  const { duration, strategy } = useInterviewAutoScheduleContext();
-  const { partId } = useInterviewPartSelectionContext();
   const { handleNextWeek, handlePrevWeek, month, week } = useWeekIndicator();
 
-  assert(!!partId, 'partId가 없어요.');
-
-  const { data } = useSuspenseQuery(
-    autoScheduleOptions({
-      size: 5,
-      partId,
-      duration: duration === '1시간' ? 60 : 30,
-      strategy: strategy === '밀집형' ? 'MIN' : 'MAX',
-    }),
+  const scheduleCandidates = useAutoScheduleCandidates();
+  const [selectedCandidate, setSelectedCandidate] = useState<AutoScheduleCandidate>(
+    scheduleCandidates[0],
   );
 
   return (
@@ -41,7 +29,13 @@ export const AutoScheduleMode = () => {
           />
         ),
         calendar: <div />,
-        sidebar: <AutoScheduleSidebar scheduleCandidates={data} />,
+        sidebar: (
+          <AutoScheduleSidebar
+            onCandidateChange={setSelectedCandidate}
+            scheduleCandidates={scheduleCandidates}
+            selectedCandidate={selectedCandidate}
+          />
+        ),
       }}
       variants="sidebar-expand"
     />

--- a/src/pages/Interview/components/AutoScheduleMode/type.ts
+++ b/src/pages/Interview/components/AutoScheduleMode/type.ts
@@ -1,0 +1,8 @@
+import { UUID } from 'crypto';
+
+import { AutoSchedule } from '@/query/schedule/schema';
+
+export type AutoScheduleCandidate = {
+  id: UUID;
+  schedules: AutoSchedule[];
+};

--- a/src/pages/Interview/components/InterviewHeaderLayout.tsx
+++ b/src/pages/Interview/components/InterviewHeaderLayout.tsx
@@ -50,8 +50,8 @@ const Indicator = ({ onNextWeek, onPrevWeek, date, disabled }: IndicatorProps) =
 
 export const InterviewHeaderLayout = ({ children }: React.PropsWithChildren) => {
   return (
-    <div className="border-line-basicMedium min-h-[48px] w-full border-b">
-      <div className="flex h-full w-[70%] flex-col pl-[45px]">{children}</div>
+    <div className="min-h-[48px] w-full">
+      <div className="flex h-full flex-col pl-[45px]">{children}</div>
     </div>
   );
 };

--- a/src/pages/Interview/components/InterviewPageLayout.tsx
+++ b/src/pages/Interview/components/InterviewPageLayout.tsx
@@ -9,18 +9,36 @@ interface InterviewPageLayoutProps {
     sidebar: React.ReactNode;
   };
   title?: string;
+  variants?: 'default' | 'sidebar-expand';
 }
 
 export const InterviewPageLayout = ({
   title,
   slots: { calendar, sidebar, header },
+  variants = 'default',
 }: React.PropsWithChildren<InterviewPageLayoutProps>) => {
+  if (variants === 'sidebar-expand') {
+    return (
+      <PageLayout title={title}>
+        <div className="flex w-full flex-[1_1_0]">
+          <div className="border-line-basicMedium flex w-full flex-col border-t pt-2">
+            <div className="border-line-basicMedium border-b pr-6">{header}</div>
+            <div className="flex flex-col pt-12 pr-6">{calendar}</div>
+          </div>
+          <div className="border-line-basicMedium w-100 min-w-100 border-t border-l">{sidebar}</div>
+        </div>
+      </PageLayout>
+    );
+  }
+
   return (
     <PageLayout title={title}>
-      {header}
+      <div className="border-line-basicMedium border-b">
+        <div className="w-[70%] pr-6">{header}</div>
+      </div>
       <div className="flex flex-[1_1_0] overflow-hidden">
         <div className="flex w-[70%] min-w-0 flex-col pt-12 pr-6">{calendar}</div>
-        <div className="flex-1">{sidebar}</div>
+        <div className="border-line-basicMedium flex-1 border-l">{sidebar}</div>
       </div>
     </PageLayout>
   );

--- a/src/pages/Interview/components/InterviewSidebarLayout.tsx
+++ b/src/pages/Interview/components/InterviewSidebarLayout.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React from 'react';
 
 const BottomArea = ({ children }: React.PropsWithChildren<unknown>) => {
@@ -8,8 +9,21 @@ const BottomArea = ({ children }: React.PropsWithChildren<unknown>) => {
   );
 };
 
-const CardList = ({ children }: React.PropsWithChildren<unknown>) => {
-  return <div className="flex flex-[1_1_0] flex-col gap-2.5 px-5 py-12">{children}</div>;
+const CardList = ({ title, children }: React.PropsWithChildren<{ title?: string }>) => {
+  return (
+    <div className="flex min-h-0 flex-[1_1_0] flex-col">
+      {title && (
+        <div className="border-line-basicMedium typo-t4_sb_18 sticky top-0 border-b bg-white px-4 py-3 text-center">
+          {title}
+        </div>
+      )}
+      <div className="min-h-0 flex-[1_1_0] overflow-y-auto">
+        <div className={clsx('flex flex-col gap-2.5 px-5', title ? 'py-5' : 'py-12')}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export const InterviewSidebarLayout = ({ children }: React.PropsWithChildren<unknown>) => {

--- a/src/query/schedule/auto/options.ts
+++ b/src/query/schedule/auto/options.ts
@@ -1,0 +1,31 @@
+import { queryOptions } from '@tanstack/react-query';
+import z from 'zod';
+
+import { api } from '@/apis/api.ts';
+import { AutoScheduleArraySchema } from '@/query/schedule/schema';
+
+interface Option {
+  duration: 30 | 60; // 면접 시간을 분 단위로 넣어줘요.
+  partId: number;
+  size: number; // 시간표 후보군을 몇 개 던져줄지 정해요.
+  strategy: 'MAX' | 'MIN'; // 일정의 분산 정도를 정해요. MAX로 지정하면 최대한 분산되게, MIN이면 최대한 몰려있게 생성해요.
+}
+
+export const autoScheduleOptions = ({ partId, ...option }: Option) => {
+  return queryOptions({
+    queryKey: ['schedules', 'auto', partId],
+    queryFn: async () => {
+      const data = await api
+        .get(`recruiter/schedule/auto/${partId}`, {
+          searchParams: option,
+        })
+        .json();
+      /* 
+        시간표 자동생성 API는 여러개의 후보군을 던져줘요.
+        각 후보군에 대한 스키마가 `AutoScheduleArraySchema` 라서,
+        z.array(AutoScheduleArraySchema)로 응답 밸리데이션을 수행해요. 
+      */
+      return z.array(AutoScheduleArraySchema).parse(data);
+    },
+  });
+};

--- a/src/query/schedule/schema.ts
+++ b/src/query/schedule/schema.ts
@@ -10,6 +10,16 @@ export const ScheduleSchema = z.object({
   endTime: z.string(),
 });
 
+export const AutoScheduleSchema = z.object({
+  applicantId: z.number(),
+  applicantName: z.string(),
+  part: z.enum(partNames),
+  startTime: z.string(),
+  endTime: z.string(),
+});
+
 export const ScheduleArraySchema = z.array(ScheduleSchema);
+export const AutoScheduleArraySchema = z.array(AutoScheduleSchema);
 
 export type Schedule = z.infer<typeof ScheduleSchema>;
+export type AutoSchedule = z.infer<typeof AutoScheduleSchema>;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

피그마: https://www.figma.com/design/HjonnCf2jKCRgw3DlzQf1v/Yourssu-Scouter?node-id=2229-66768&m=dev

자동생성 API 스웨거 참고: https://api.scouter.yourssu.com/swagger-ui/index.html#/%EB%A9%B4%EC%A0%91%20%EC%9D%BC%EC%A0%95/getAutoSchedules



https://github.com/user-attachments/assets/32551fcb-ea9b-43b7-af78-ff914e79e8e5


자동생성 모드의 사이드바를 만들기 위해 
기존 레이아웃의 UI 커버리지를 높이도록 개선하고,
생성된 시간표 후보들의 간소화 뷰를 볼 수 있는 사이드바를 구현했어요.


## 2️⃣ 알아두시면 좋아요!


- 간소화 뷰는 일정의 특정 한주차만 보여줘요.

  - 만약 일정이 여러개의 주차에 걸쳐서 만들어졌다면, 간소화 뷰에 보이는건 가장 빠른 주차만 보여요.
  
  - 간소화 뷰는 모든 일정을 보여주지만,  09시부터 22시까지 모든 시간을 보여주지는 않아요. 
  일정상 가장 빠른 시간과 늦은 시간을 계산해서 해당 시간 내의 일정만 렌더링하도록 구현했어요.

- 간소화 뷰에서 시간표 후보를 선택할 수 있도록 radix ui 의 RadioGroup을 사용해서 구현했어요.

- 상태로 관리되는 시간표 후보들의 고유성을 판단하기 위해 따로 uuid를 주입하는 useAutoScheduleCandidates 훅을 만들었어요.

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
