### PR TITLE
feat: 자동생성모드에서 선택한 일정으로 캘린더를 렌더링해요

### DIFF
--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleBlock.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleBlock.tsx
@@ -1,0 +1,27 @@
+import { AutoSchedule } from '@/query/schedule/schema';
+import { formatTemplates } from '@/utils/date';
+
+interface AutoScheduleBlockProps {
+  date: Date;
+  isFirstBlock: boolean;
+  schedule: AutoSchedule;
+}
+
+export const AutoScheduleBlock = ({ schedule, date, isFirstBlock }: AutoScheduleBlockProps) => {
+  return (
+    <button className="bg-bg-brandPrimary flex size-full flex-col rounded-lg text-white">
+      {isFirstBlock && (
+        <>
+          <div className="typo-c3_sb_11 flex size-full items-end gap-1.5 px-2">
+            <div>{schedule.applicantName} 님</div>
+            <div>{schedule.part}</div>
+          </div>
+          <div className="typo-c3_rg_11 flex size-full items-start gap-1.5 px-2">
+            <div>{formatTemplates['23:59'](date)}</div>
+            <div>유어슈 동아리방</div>
+          </div>
+        </>
+      )}
+    </button>
+  );
+};

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleCalendar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleCalendar.tsx
@@ -1,0 +1,47 @@
+import { setHours, setMinutes } from 'date-fns';
+
+import { useDateMap } from '@/hooks/useDateMap';
+import { AutoScheduleBlock } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleBlock';
+import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
+import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
+import { useInterviewAutoScheduleContext } from '@/pages/Interview/context';
+
+interface AutoScheduleCalendarProps {
+  month: number;
+  scheduleCandidate: AutoScheduleCandidate;
+  week: number;
+  year: number;
+}
+
+export const AutoScheduleCalendar = ({
+  scheduleCandidate,
+  month,
+  week,
+  year,
+}: AutoScheduleCalendarProps) => {
+  const { duration } = useInterviewAutoScheduleContext();
+
+  const [map] = useDateMap({
+    initialEntries: scheduleCandidate.schedules.map((v) => [new Date(v.startTime), v]),
+    precision: duration === '1시간' ? '시간' : '분',
+  });
+
+  return (
+    <InterviewCalendar month={month} week={week} year={year}>
+      {({ date, hour, minute }) => {
+        const targetDate = setMinutes(setHours(date, hour), minute);
+        const schedule = map.get(targetDate);
+
+        return (
+          !!schedule && (
+            <AutoScheduleBlock
+              date={targetDate}
+              isFirstBlock={duration === '30분' || (duration === '1시간' && minute === 0)}
+              schedule={schedule}
+            />
+          )
+        );
+      }}
+    </InterviewCalendar>
+  );
+};

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { AutoScheduleCalendar } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleCalendar';
 import { AutoScheduleHeader } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleHeader';
 import { AutoScheduleSidebar } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar';
 import { useAutoScheduleCandidates } from '@/pages/Interview/components/AutoScheduleMode/hooks/useAutoScheduleCandidates';
@@ -8,7 +9,7 @@ import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageL
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 
 export const AutoScheduleMode = () => {
-  const { handleNextWeek, handlePrevWeek, month, week } = useWeekIndicator();
+  const { handleNextWeek, handlePrevWeek, month, week, year } = useWeekIndicator();
 
   const scheduleCandidates = useAutoScheduleCandidates();
   const [selectedCandidate, setSelectedCandidate] = useState<AutoScheduleCandidate>(
@@ -28,7 +29,15 @@ export const AutoScheduleMode = () => {
             }}
           />
         ),
-        calendar: <div />,
+        calendar: (
+          <AutoScheduleCalendar
+            key={selectedCandidate.id} // 선택한 시간표가 바뀌면 캘린더를 다시 렌더링해요
+            month={month}
+            scheduleCandidate={selectedCandidate}
+            week={week}
+            year={year}
+          />
+        ),
         sidebar: (
           <AutoScheduleSidebar
             onCandidateChange={setSelectedCandidate}

--- a/src/pages/Interview/components/InterviewPageLayout.tsx
+++ b/src/pages/Interview/components/InterviewPageLayout.tsx
@@ -23,7 +23,7 @@ export const InterviewPageLayout = ({
         <div className="flex w-full flex-[1_1_0]">
           <div className="border-line-basicMedium flex w-full flex-col border-t pt-2">
             <div className="border-line-basicMedium border-b pr-6">{header}</div>
-            <div className="flex flex-col pt-12 pr-6">{calendar}</div>
+            <div className="flex flex-[1_1_0] flex-col pt-12 pr-6">{calendar}</div>
           </div>
           <div className="border-line-basicMedium w-100 min-w-100 border-t border-l">{sidebar}</div>
         </div>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

https://github.com/user-attachments/assets/39a0588a-ccef-43dc-92af-92193ffaeaf4

제곧내입니다. 따로 설명할 맥락은 없네용

## 2️⃣ 알아두시면 좋아요!

[fix: 인터뷰 페이지 레이아웃 > 사이드바 확장 방식이 캘린더 영역을 가지지 못하던 문제 수정](https://github.com/yourssu/Yourssu-Scouter-Frontend/commit/7c0570bdb4a0a12f87c6b3c1cc8bf2c5678e3070) 

같은 경우는 레이아웃의 `sidebar-expand` 방식에서 캘린더 영역을 잡아주지 못하던 문제를 놓쳤어서 수정해줬어요.

## 3️⃣ 추후 작업

사이드바의 '시간표 저장하기' 버튼으로 선택한 일정을 뮤테이션 해야해요

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
