### PR TITLE
feat: 메일 페이지의 레이아웃을 공통화하고 상태 관리 컨텍스트를 만들었어요

### DIFF
--- a/src/pages/SendMail/MailDropdownSection/MailDropdownSection.tsx
+++ b/src/pages/SendMail/MailDropdownSection/MailDropdownSection.tsx
@@ -1,0 +1,31 @@
+import { PartDropdown, TemplateDropdown } from '@/components/MailDropdown/MailDropdown';
+import { Part } from '@/query/part/schema';
+
+interface MailDropdownSectionProps {
+  selectedPart: Part | undefined;
+  selectedTemplateId: number | undefined;
+  setSelectedPart: (part: Part | undefined) => void;
+  setSelectedTemplateId: (templateId: number | undefined) => void;
+}
+
+export const MailDropdownSection = ({
+  selectedPart,
+  setSelectedPart,
+  selectedTemplateId,
+  setSelectedTemplateId,
+}: MailDropdownSectionProps) => {
+  return (
+    <div className="flex w-full flex-row gap-[12px]">
+      <PartDropdown
+        disabled={selectedTemplateId !== undefined}
+        onSelectPart={setSelectedPart}
+        selectedPart={selectedPart}
+      />
+      <TemplateDropdown
+        disabled={selectedPart === undefined}
+        onSelectTemplateId={setSelectedTemplateId}
+        selectedTemplateId={selectedTemplateId}
+      />
+    </div>
+  );
+};

--- a/src/pages/SendMail/MailInfoSection/InputChipGroup.tsx
+++ b/src/pages/SendMail/MailInfoSection/InputChipGroup.tsx
@@ -1,0 +1,21 @@
+import { IcCloseFilled } from '@yourssu/design-system-react';
+import { motion } from 'motion/react';
+import { tv } from 'tailwind-variants';
+
+const chip = tv({
+  base: 'bg-chipUnselected text-text-basicSecondary typo-b3_rg_14 flex flex-row items-center justify-center gap-[4px] rounded-full px-3 py-1.5',
+});
+
+export const InputChipGroup = () => {
+  const items: string[] = ['ex1', 'ex2', 'ex3'];
+  return (
+    <div className="flex flex-row items-center gap-2">
+      {items.map((item) => (
+        <motion.div className={chip()} key={item}>
+          {item}
+          <IcCloseFilled height={16} width={16} />
+        </motion.div>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/SendMail/SendMail.tsx
+++ b/src/pages/SendMail/SendMail.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { InputField } from '@/components/InputField/InputField';
 import { MailDropdownSection } from '@/pages/SendMail/MailDropdownSection/MailDropdownSection';
 import { MailEditor } from '@/pages/SendMail/MailEditor/MailEditor';
+import { SendMailModeProvider } from '@/pages/SendMail/SendMailMode/SendMailMode';
 import { SendMailPageLayout } from '@/pages/SendMail/SendMailPageLayout/SendMailPageLayout';
 import { Part } from '@/query/part/schema';
 
@@ -11,27 +12,29 @@ export const SendMail = () => {
   const [selectedTemplateId, setSelectedTemplateId] = useState<number | undefined>(undefined);
 
   return (
-    <SendMailPageLayout
-      slots={{
-        dropdown: (
-          <MailDropdownSection
-            selectedPart={selectedPart}
-            selectedTemplateId={selectedTemplateId}
-            setSelectedPart={setSelectedPart}
-            setSelectedTemplateId={setSelectedTemplateId}
-          />
-        ),
-        info: (
-          <div className="gap-0">
-            <InputField label="보내는 사람" />
-            <InputField label="받는 사람" />
-            <InputField label="숨은 참조" />
-            <InputField label="제목" />
-          </div>
-        ),
-        editor: <MailEditor type="normal" />,
-        sidebar: <div>Sidebar Content</div>,
-      }}
-    />
+    <SendMailModeProvider>
+      <SendMailPageLayout
+        slots={{
+          dropdown: (
+            <MailDropdownSection
+              selectedPart={selectedPart}
+              selectedTemplateId={selectedTemplateId}
+              setSelectedPart={setSelectedPart}
+              setSelectedTemplateId={setSelectedTemplateId}
+            />
+          ),
+          info: (
+            <div className="gap-0">
+              <InputField label="보내는 사람" />
+              <InputField label="받는 사람" />
+              <InputField label="숨은 참조" />
+              <InputField label="제목" />
+            </div>
+          ),
+          editor: <MailEditor type="normal" />,
+          sidebar: <div>Sidebar Content</div>,
+        }}
+      />
+    </SendMailModeProvider>
   );
 };

--- a/src/pages/SendMail/SendMail.tsx
+++ b/src/pages/SendMail/SendMail.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { InputField } from '@/components/InputField/InputField';
 import { PageLayout } from '@/components/layouts/PageLayout';
-import { PartDropdown, TemplateDropdown } from '@/components/MailDropdown/MailDropdown';
+import { MailDropdownSection } from '@/pages/SendMail/MailDropdownSection/MailDropdownSection';
 import { MailEditor } from '@/pages/SendMail/MailEditor/MailEditor';
 import { Part } from '@/query/part/schema';
 
@@ -14,18 +14,12 @@ export const SendMail = () => {
     <PageLayout>
       <div className="flex h-full flex-row">
         <div className="flex w-full flex-col gap-[20px] p-[40px]">
-          <div className="flex w-full flex-row gap-[12px]">
-            <PartDropdown
-              disabled={selectedTemplateId !== undefined}
-              onSelectPart={setSelectedPart}
-              selectedPart={selectedPart}
-            />
-            <TemplateDropdown
-              disabled={selectedPart === undefined}
-              onSelectTemplateId={setSelectedTemplateId}
-              selectedTemplateId={selectedTemplateId}
-            />
-          </div>
+          <MailDropdownSection
+            selectedPart={selectedPart}
+            selectedTemplateId={selectedTemplateId}
+            setSelectedPart={setSelectedPart}
+            setSelectedTemplateId={setSelectedTemplateId}
+          />
           <div className="flex h-full w-full flex-col gap-[20px]">
             <div className="gap-0">
               <InputField label="보내는 사람" />

--- a/src/pages/SendMail/SendMail.tsx
+++ b/src/pages/SendMail/SendMail.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
 import { InputField } from '@/components/InputField/InputField';
-import { PageLayout } from '@/components/layouts/PageLayout';
 import { MailDropdownSection } from '@/pages/SendMail/MailDropdownSection/MailDropdownSection';
 import { MailEditor } from '@/pages/SendMail/MailEditor/MailEditor';
+import { SendMailPageLayout } from '@/pages/SendMail/SendMailPageLayout/SendMailPageLayout';
 import { Part } from '@/query/part/schema';
 
 export const SendMail = () => {
@@ -11,28 +11,27 @@ export const SendMail = () => {
   const [selectedTemplateId, setSelectedTemplateId] = useState<number | undefined>(undefined);
 
   return (
-    <PageLayout>
-      <div className="flex h-full flex-row">
-        <div className="flex w-full flex-col gap-[20px] p-[40px]">
+    <SendMailPageLayout
+      slots={{
+        dropdown: (
           <MailDropdownSection
             selectedPart={selectedPart}
             selectedTemplateId={selectedTemplateId}
             setSelectedPart={setSelectedPart}
             setSelectedTemplateId={setSelectedTemplateId}
           />
-          <div className="flex h-full w-full flex-col gap-[20px]">
-            <div className="gap-0">
-              <InputField label="보내는 사람" />
-              <InputField label="받는 사람" />
-              <InputField label="숨은 참조" />
-              <InputField label="제목" />
-            </div>
-            <div className="flex h-full w-full">
-              <MailEditor type="normal" />
-            </div>
+        ),
+        info: (
+          <div className="gap-0">
+            <InputField label="보내는 사람" />
+            <InputField label="받는 사람" />
+            <InputField label="숨은 참조" />
+            <InputField label="제목" />
           </div>
-        </div>
-      </div>
-    </PageLayout>
+        ),
+        editor: <MailEditor type="normal" />,
+        sidebar: <div>Sidebar Content</div>,
+      }}
+    />
   );
 };

--- a/src/pages/SendMail/SendMailMode/SendMailMode.tsx
+++ b/src/pages/SendMail/SendMailMode/SendMailMode.tsx
@@ -1,0 +1,65 @@
+import { assert } from 'es-toolkit';
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+
+export type SendMailMode = '기본' | '템플릿선택' | '파트선택';
+
+interface SendMailModeContextProps {
+  mode: SendMailMode;
+  onChangePartId: (id: null | number) => void;
+  onChangeTemplateId: (id: null | number) => void;
+  onReset: () => void;
+  selectedPartId: null | number;
+  selectedTemplateId: null | number;
+}
+
+export const SendMailModeContext = createContext<null | SendMailModeContextProps>(null);
+
+export const SendMailModeProvider = ({ children }: { children: ReactNode }) => {
+  const [selectedPartId, setSelectedPartId] = useState<null | number>(null);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<null | number>(null);
+
+  const mode: SendMailMode = useMemo(() => {
+    if (!selectedPartId) {
+      return '기본';
+    }
+    if (!selectedTemplateId) {
+      return '파트선택';
+    }
+    return '템플릿선택';
+  }, [selectedPartId, selectedTemplateId]);
+
+  const onChangePartId = (id: null | number) => {
+    setSelectedPartId(id);
+    setSelectedTemplateId(null);
+  };
+
+  const onChangeTemplateId = (id: null | number) => {
+    setSelectedTemplateId(id);
+  };
+
+  const onReset = () => {
+    setSelectedPartId(null);
+    setSelectedTemplateId(null);
+  };
+
+  return (
+    <SendMailModeContext.Provider
+      value={{
+        mode,
+        selectedPartId,
+        selectedTemplateId,
+        onChangePartId,
+        onChangeTemplateId,
+        onReset,
+      }}
+    >
+      {children}
+    </SendMailModeContext.Provider>
+  );
+};
+
+export const useSendMailModeContext = () => {
+  const context = useContext(SendMailModeContext);
+  assert(!!context, 'useSendMailModeContext는 SendMailModeProvider 하위에서 사용해야해요.');
+  return context;
+};

--- a/src/pages/SendMail/SendMailPageLayout/SendMailPageLayout.tsx
+++ b/src/pages/SendMail/SendMailPageLayout/SendMailPageLayout.tsx
@@ -1,0 +1,27 @@
+import { PageLayout } from '@/components/layouts/PageLayout';
+
+interface SendMailPageLayoutProps {
+  slots: {
+    dropdown: React.ReactNode;
+    editor: React.ReactNode;
+    info: React.ReactNode;
+    sidebar: React.ReactNode;
+  };
+}
+
+export const SendMailPageLayout = ({ slots }: SendMailPageLayoutProps) => {
+  return (
+    <PageLayout>
+      <div className="flex h-full flex-row">
+        <div className="flex h-full w-full flex-col gap-[20px] p-[40px]">
+          {slots.dropdown}
+          {slots.info}
+          <div className="flex h-full">{slots.editor}</div>
+        </div>
+        <div className="border-line-basicMedium w-100 min-w-100 border-t border-l">
+          {slots.sidebar}
+        </div>
+      </div>
+    </PageLayout>
+  );
+};


### PR DESCRIPTION
## 어떤 작업을 했나요? (Summary)

<img width="1440" height="777" alt="스크린샷 2026-01-10 오후 3 10 34" src="https://github.com/user-attachments/assets/fe0c6edf-cd41-47ab-96d7-3aedc2bf1dd3" />

메일 페이지 모드(기본, 파트선택, 템플릿선택)에 따라 레이아웃을 다르게 띄워주도록 컨텍스트를 만들고 레이아웃을 공통화했어요.
- **dropdown:** 파트/템플릿 선택 드롭다운. 모든 모드에서 동일
- **info:** 보내는 사람, 받는 사람, 숨은 참조, 메일 제목이 들어가는 곳. `기본`,`파트선택` | `템플릿선택`으로 조건부 처리 예정
- **editor:** 메일 본문 에디터. `기본` |`파트선택`,`템플릿선택`으로 조건부 처리 예정
- **sidebar:** 메일 변수 리스트를 카드 형식으로 보여주는 사이드바. 모든 모드에서 동일


## 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
