### PR TITLE
feat: 면접 일정 시간표 다운로드 기능을 구현했어요

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "core-js": "^3.45.1",
     "date-fns": "^4.1.0",
     "es-toolkit": "^1.39.10",
+    "html-to-image": "^1.11.13",
     "ky": "^1.7.4",
     "motion": "^12.23.18",
     "overlay-kit": "^1.8.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       es-toolkit:
         specifier: ^1.39.10
         version: 1.39.10
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       ky:
         specifier: ^1.7.4
         version: 1.8.0
@@ -2468,6 +2471,9 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -6041,6 +6047,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-to-image@1.11.13: {}
 
   husky@9.1.7: {}
 

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -92,7 +92,7 @@ export const Dialog = ({
             >
               <motion.div
                 animate="animate"
-                className="bg-bg-basicDefault rounded-2xl will-change-transform"
+                className="bg-bg-basicDefault max-h-screen max-w-screen overflow-y-auto rounded-2xl will-change-transform"
                 exit="initial"
                 initial="initial"
                 transition={{

--- a/src/hooks/useComponentToPng.ts
+++ b/src/hooks/useComponentToPng.ts
@@ -1,0 +1,34 @@
+import { assert } from 'es-toolkit';
+import { toPng } from 'html-to-image';
+import { useCallback, useRef } from 'react';
+
+import { Prettify } from '@/utils/type';
+
+export type UseComponentToPngOptions = Prettify<Parameters<typeof toPng>[1] & {}>;
+
+export type ComponentToPngConvertFn<T extends HTMLElement> = (
+  option: ((el: T) => UseComponentToPngOptions) | UseComponentToPngOptions,
+) => Promise<string>;
+
+export const useComponentToPng = <T extends HTMLElement = HTMLElement>(
+  globalOptions: UseComponentToPngOptions = {},
+) => {
+  const ref = useRef<T>();
+
+  const refFn = useCallback((el: T) => {
+    ref.current = el;
+  }, []);
+
+  const convert = useCallback<ComponentToPngConvertFn<T>>(
+    (option) => {
+      assert(!!ref.current, 'png로 변환하기 위한 element가 마운트되지 않았어요.');
+
+      const convertOption = typeof option === 'function' ? option(ref.current) : option;
+
+      return toPng(ref.current, { ...globalOptions, ...convertOption });
+    },
+    [globalOptions],
+  );
+
+  return [refFn, convert] as const;
+};

--- a/src/pages/Interview/components/InterviewCalendar/InterviewCalendar.tsx
+++ b/src/pages/Interview/components/InterviewCalendar/InterviewCalendar.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import { InterviewCalendarBody } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendarBody';
 import { InterviewCalendarHead } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendarHead';
 
@@ -8,15 +10,19 @@ interface InterviewCalendarProps {
   year: number;
 }
 
-export const InterviewCalendar = ({ month, week, year, children }: InterviewCalendarProps) => {
-  return (
-    <div className="flex-[1_1_0] overflow-y-auto pl-6">
-      <table className="w-full border-collapse border-spacing-0">
-        <InterviewCalendarHead month={month} week={week} year={year} />
-        <InterviewCalendarBody month={month} week={week} year={year}>
-          {children}
-        </InterviewCalendarBody>
-      </table>
-    </div>
-  );
-};
+export const InterviewCalendar = forwardRef<HTMLTableElement, InterviewCalendarProps>(
+  ({ month, week, year, children }, ref) => {
+    return (
+      <div className="flex-[1_1_0] overflow-y-auto pl-6">
+        <table className="w-full border-collapse border-spacing-0" ref={ref}>
+          <InterviewCalendarHead month={month} week={week} year={year} />
+          <InterviewCalendarBody month={month} week={week} year={year}>
+            {children}
+          </InterviewCalendarBody>
+        </table>
+      </div>
+    );
+  },
+);
+
+InterviewCalendar.displayName = 'InterviewCalendar';

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScehduleCalendar.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScehduleCalendar.tsx
@@ -1,6 +1,7 @@
 import { getHours, getMinutes, isSameDay } from 'date-fns';
 
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
+import { useInterviewScheduleCalendarRefContext } from '@/pages/Interview/components/InterviewScheduleMode/context';
 import { InterviewScheduleBlock } from '@/pages/Interview/components/InterviewScheduleMode/InterviewScheduleBlock';
 import { Schedule } from '@/query/schedule/schema';
 
@@ -17,6 +18,8 @@ export const InterviewScheduleCalendar = ({
   week,
   year,
 }: InterviewScheduleCalendarProps) => {
+  const { ref } = useInterviewScheduleCalendarRefContext();
+
   const getSchedulesForCell = (date: Date, hour: number, minute: number) => {
     const targetTotalMinutes = hour * 60 + minute;
 
@@ -35,7 +38,7 @@ export const InterviewScheduleCalendar = ({
   };
 
   return (
-    <InterviewCalendar month={month} week={week} year={year}>
+    <InterviewCalendar month={month} ref={ref} week={week} year={year}>
       {({ date, hour, minute }) =>
         getSchedulesForCell(date, hour, minute).map((schedule) => (
           <InterviewScheduleBlock

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard.tsx
@@ -43,7 +43,7 @@ export const InterviewSidebarDownloadCard = () => {
     <InterviewSidebarCard>
       <InterviewSidebarCard.Title>면접 일정 저장</InterviewSidebarCard.Title>
       <InterviewSidebarCard.Content>
-        Jpeg로 저장된 면접 일정을 다운로드 할 수 있어요!
+        면접 일정을 이미지로 다운로드 할 수 있어요.
       </InterviewSidebarCard.Content>
       <BoxButton disabled={loading} onClick={onClick} size="small" variant="filledPrimary">
         {loading ? '시간표를 변환하고 있어요...' : '시간표 저장하기'}

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard.tsx
@@ -1,16 +1,52 @@
 import { BoxButton } from '@yourssu/design-system-react';
+import { useLoading } from 'react-simplikit';
 
+import { useAlertDialog } from '@/hooks/useAlertDialog';
+import { useInterviewScheduleCalendarRefContext } from '@/pages/Interview/components/InterviewScheduleMode/context';
 import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
 
 export const InterviewSidebarDownloadCard = () => {
+  const openAlertDialog = useAlertDialog();
+  const [loading, startLoading] = useLoading();
+  const { convert } = useInterviewScheduleCalendarRefContext();
+
+  const onClick = async () => {
+    const png = await startLoading(
+      convert((el) => {
+        const rect = el.getBoundingClientRect();
+        return {
+          width: rect.width,
+          height: rect.height,
+          backgroundColor: 'var(--color-bg-basicDefault)',
+          skipFonts: true, // 폰트 에셋 fetching을 방지해서 html-to-image의 css cross origin 이슈를 막아요.
+        };
+      }),
+    );
+
+    const answer = await openAlertDialog({
+      title: '시간표',
+      content: <img alt="wow" className="w-[520px]" src={png} />,
+      primaryButtonText: '저장하기',
+      secondaryButtonText: '취소',
+      closeableWithOutside: false,
+    });
+
+    if (answer) {
+      const a = document.createElement('a');
+      a.download = '시간표.png';
+      a.href = png;
+      a.click();
+    }
+  };
+
   return (
     <InterviewSidebarCard>
       <InterviewSidebarCard.Title>면접 일정 저장</InterviewSidebarCard.Title>
       <InterviewSidebarCard.Content>
         Jpeg로 저장된 면접 일정을 다운로드 할 수 있어요!
       </InterviewSidebarCard.Content>
-      <BoxButton size="small" variant="filledPrimary">
-        시간표 저장하기
+      <BoxButton disabled={loading} onClick={onClick} size="small" variant="filledPrimary">
+        {loading ? '시간표를 변환하고 있어요...' : '시간표 저장하기'}
       </BoxButton>
     </InterviewSidebarCard>
   );

--- a/src/pages/Interview/components/InterviewScheduleMode/context.ts
+++ b/src/pages/Interview/components/InterviewScheduleMode/context.ts
@@ -1,0 +1,21 @@
+import { assert } from 'es-toolkit';
+import { createContext, useContext } from 'react';
+
+import { ComponentToPngConvertFn } from '@/hooks/useComponentToPng';
+
+interface InterviewScheduleCalendarRefContextProps {
+  convert: ComponentToPngConvertFn<HTMLTableElement>;
+  ref: (el: HTMLTableElement) => void;
+}
+
+export const InterviewScheduleCalendarRefContext =
+  createContext<InterviewScheduleCalendarRefContextProps | null>(null);
+
+export const useInterviewScheduleCalendarRefContext = () => {
+  const context = useContext(InterviewScheduleCalendarRefContext);
+  assert(
+    !!context,
+    'useInterviewScheduleCalendarRefContext는 InterviewScheduleCalendarRefContext 하위에서 사용해주세요.',
+  );
+  return context;
+};

--- a/src/pages/Interview/components/InterviewScheduleMode/index.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/index.tsx
@@ -1,6 +1,8 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
+import { useComponentToPng } from '@/hooks/useComponentToPng';
 import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageLayout';
+import { InterviewScheduleCalendarRefContext } from '@/pages/Interview/components/InterviewScheduleMode/context';
 import { InterviewScheduleCalendar } from '@/pages/Interview/components/InterviewScheduleMode/InterviewScehduleCalendar';
 import { InterviewScheduleHeader } from '@/pages/Interview/components/InterviewScheduleMode/InterviewScheduleHeader';
 import { InterviewScheduleSidebar } from '@/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar';
@@ -14,25 +16,34 @@ export const InterviewScheduleMode = () => {
 
   const { data: schedules } = useSuspenseQuery(scheduleOptions(partId));
 
+  const [ref, convert] = useComponentToPng<HTMLTableElement>();
+
   return (
-    <InterviewPageLayout
-      slots={{
-        header: (
-          <InterviewScheduleHeader
-            indicator={{
-              month,
-              week,
-              onNextWeek: handleNextWeek,
-              onPrevWeek: handlePrevWeek,
-            }}
-          />
-        ),
-        calendar: (
-          <InterviewScheduleCalendar month={month} schedules={schedules} week={week} year={year} />
-        ),
-        sidebar: <InterviewScheduleSidebar schedules={schedules} />,
-      }}
-      title="면접 일정 관리"
-    />
+    <InterviewScheduleCalendarRefContext.Provider value={{ ref, convert }}>
+      <InterviewPageLayout
+        slots={{
+          header: (
+            <InterviewScheduleHeader
+              indicator={{
+                month,
+                week,
+                onNextWeek: handleNextWeek,
+                onPrevWeek: handlePrevWeek,
+              }}
+            />
+          ),
+          calendar: (
+            <InterviewScheduleCalendar
+              month={month}
+              schedules={schedules}
+              week={week}
+              year={year}
+            />
+          ),
+          sidebar: <InterviewScheduleSidebar schedules={schedules} />,
+        }}
+        title="면접 일정 관리"
+      />
+    </InterviewScheduleCalendarRefContext.Provider>
   );
 };

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,0 +1,3 @@
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

https://github.com/user-attachments/assets/0758bbf8-e8d1-4424-8893-edf92884beb1

면접 일정 페이지 > 사이드바의 '면접 일정 저장 카드' 의 다운로드 기능을 구현했어요.

## 2️⃣ 알아두시면 좋아요!

### 컴포넌트를 이미지로 만드는 라이브러리 관련

TMI)

이 기능을 만들기 위해 여러 라이브러리를 돌아다녀봤는데 온전한 녀석이 하나도 없더라고요.

| 라이브러리 | 문제점 | 
| --- | --- |
| html2canvas | 텍스트 렌더링시 line-height를 인식하지 못해서 렌더링이 무너지는 이슈 존재 | 
| satori (jsx를 svg로) | <ul><li>svg 렌더링 엔진이 브라우저를 지원 안해서 엄청 많은 셋업 필요. (배보다 배꼽이 더 큼)</li><li>tailwind를 받기 위해서 className 대신 라이브러리 고유의 attribute로 넘겨줘야 함. 그래서 기존 컴포넌트를 가져와 렌더링하려면 코드 전부 바꿔줘야함.</li></ul> |
| html-to-image | 영문 모를 css cross origin 이슈 등이 있지만 설정으로 커버 가능하고, 이게 제일 렌더링 깔끔하게 해줘서 선택 |
| react-to-image | html-to-image를 리액트 훅으로 래핑한 라이브러리인데 인터페이스가 너무 마음에 안들어서 사용 x |

<br />

### utils/type.ts > Prettify 유틸리티 타입

약간의 잡기술인데, VSCode 상에서 식별자로 덮어씌워진 객체 타입들의 내용을 볼 수 있게 해줍니다.

| as-is | to-be |
| --- | --- |
|  <img width="886" height="202" alt="스크린샷 2026-01-11 20 58 21" src="https://github.com/user-attachments/assets/e87d9582-c4ec-4808-a546-3b71cb52c7b2" /> |<img width="1274" height="439" alt="스크린샷 2026-01-11 20 58 31" src="https://github.com/user-attachments/assets/b5a70635-667c-45ee-befa-ed69b82aeb06" /> |

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
