### PR TITLE
feat: 특수 변수(지원자, 파트명)가 자동으로 채워지도록 구현했어요 (+그 외 ui 수정)

### DIFF
--- a/src/components/CalendarDialog/CalendarDialog.style.ts
+++ b/src/components/CalendarDialog/CalendarDialog.style.ts
@@ -9,7 +9,6 @@ export const CalendarDialogContainer = styled.div`
   display: grid;
   padding: 12px;
   justify-items: center;
-  z-index: 1;
   max-height: 438px;
   gap: 20px;
 `;

--- a/src/components/CalendarDialog/DateField.style.ts
+++ b/src/components/CalendarDialog/DateField.style.ts
@@ -64,6 +64,8 @@ export const StyledContent = styled(DropdownMenu.Content)`
   border: 1px solid ${({ theme }) => theme.semantic.color.lineBasicLight};
   max-height: 300px;
   overflow-y: auto;
+  position: relative;
+  z-index: 50;
 `;
 
 export const StyledItemsContainer = styled.div`

--- a/src/components/SearchedMemberDialog/SearchedMemberDialog.style.ts
+++ b/src/components/SearchedMemberDialog/SearchedMemberDialog.style.ts
@@ -19,6 +19,8 @@ export const StyledContent = styled(Popover.Content)`
   border: 1px solid ${({ theme }) => theme.semantic.color.lineBasicLight};
   background: ${({ theme }) => theme.semantic.color.bgBasicDefault};
   box-shadow: 0 0 10px 0 rgba(110, 118, 135, 0.25);
+  position: relative;
+  z-index: 99;
 `;
 
 export const StyledGroup = styled.div`

--- a/src/components/VariableCard/DateVariableCard.tsx
+++ b/src/components/VariableCard/DateVariableCard.tsx
@@ -1,6 +1,8 @@
 import { Chip, IcCalenderLine, TextField } from '@yourssu/design-system-react';
+import { parse, setYear } from 'date-fns';
+import { ko } from 'date-fns/locale/ko';
 
-import { formatTemplates, parseDate } from '@/utils/date';
+import { formatTemplates } from '@/utils/date';
 
 import { CalendarDialog } from '../CalendarDialog/CalendarDialog';
 import { VariableCard } from './VariableCard';
@@ -34,9 +36,16 @@ export const DateVariableCard = ({ title, dates, onDateChange }: DateVariableCar
           )}
           <CalendarDialog
             onSelect={(selectedDate) =>
-              handleDateSelection(index, formatTemplates['01/01(월) 00:00'](selectedDate))
+              handleDateSelection(
+                index,
+                formatTemplates['01/01(월) 00:00'](setYear(selectedDate, new Date().getFullYear())),
+              )
             }
-            selectedDate={date.value ? parseDate(date.value) : undefined}
+            selectedDate={
+              date.value
+                ? parse(date.value, 'MM/dd(E) HH:mm', new Date(), { locale: ko })
+                : undefined
+            }
             trigger={
               <TextFieldContainer
                 onClick={(e) => {

--- a/src/components/VariableCard/DateVariableCard.tsx
+++ b/src/components/VariableCard/DateVariableCard.tsx
@@ -26,7 +26,7 @@ export const DateVariableCard = ({ title, dates, onDateChange }: DateVariableCar
   return (
     <VariableCard count={count} title={title}>
       {dates.map((date, index) => (
-        <InputContainer key={index}>
+        <InputContainer key={index} style={{ zIndex: dates.length - index, position: 'relative' }}>
           {date.label && (
             <Chip role="input" size="medium" style={{ whiteSpace: 'nowrap' }}>
               {date.label}

--- a/src/components/VariableCard/DateVariableCard.tsx
+++ b/src/components/VariableCard/DateVariableCard.tsx
@@ -1,6 +1,6 @@
 import { Chip, IcCalenderLine, TextField } from '@yourssu/design-system-react';
 
-import { formatTemplates } from '@/utils/date';
+import { formatTemplates, parseDate } from '@/utils/date';
 
 import { CalendarDialog } from '../CalendarDialog/CalendarDialog';
 import { VariableCard } from './VariableCard';
@@ -36,6 +36,7 @@ export const DateVariableCard = ({ title, dates, onDateChange }: DateVariableCar
             onSelect={(selectedDate) =>
               handleDateSelection(index, formatTemplates['01/01(월) 00:00'](selectedDate))
             }
+            selectedDate={date.value ? parseDate(date.value) : undefined}
             trigger={
               <TextFieldContainer
                 onClick={(e) => {

--- a/src/components/VariableChip/VariableChipNode.tsx
+++ b/src/components/VariableChip/VariableChipNode.tsx
@@ -4,7 +4,7 @@ import { NodeViewProps, NodeViewWrapper } from '@tiptap/react';
 
 import { VariableChip } from '@/components/VariableChip/VariableChip';
 import { useOptionalMailVariables } from '@/pages/SendMail/components/MailVariable/MailVariable';
-import { useMailData } from '@/pages/SendMail/hooks/useMailData';
+import { useVariableValue } from '@/pages/SendMail/hooks/useVariableValue';
 
 export interface VariableChipOptions {
   htmlAttributes: Record<string, any>;
@@ -122,7 +122,7 @@ export const VariableChipNode = Node.create<VariableChipOptions>({
 
 const VariableChipNodeView: React.FC<NodeViewProps> = ({ node }) => {
   const context = useOptionalMailVariables();
-  const { getDisplayVariableValue } = useMailData(context?.selectedTemplateId);
+  const { getVariableValue } = useVariableValue();
 
   const { key, type, label, perRecipient } = node.attrs as {
     key: string;
@@ -139,7 +139,7 @@ const VariableChipNodeView: React.FC<NodeViewProps> = ({ node }) => {
     );
   }
 
-  const displayValue = getDisplayVariableValue(key, perRecipient);
+  const displayValue = getVariableValue(key, perRecipient, label);
 
   return (
     <NodeViewWrapper

--- a/src/pages/SendMail/SendMail.tsx
+++ b/src/pages/SendMail/SendMail.tsx
@@ -15,7 +15,7 @@ export const SendMail = () => {
 
   return (
     <SendMailModeProvider>
-      <MailVariableProvider selectedTemplateId={selectedTemplateId}>
+      <MailVariableProvider currentPart={selectedPart}>
         <SendMailPageLayout
           slots={{
             dropdown: (

--- a/src/pages/SendMail/components/MailEditor/MailEditor.tsx
+++ b/src/pages/SendMail/components/MailEditor/MailEditor.tsx
@@ -16,9 +16,12 @@ interface MailEditorProps {
 export const MailEditor = ({ selectedPart, selectedTemplateId }: MailEditorProps) => {
   const { recipients, currentRecipientId, currentRecipientName, setCurrentRecipientId } =
     useRecipientData(selectedPart);
-  const { defaultContent } = useMailData(selectedTemplateId!);
 
-  // 탭 변경 시 컨텍스트 상태 업데이트
+  const { currentContent, handleContentChange } = useMailData(
+    selectedTemplateId,
+    currentRecipientId,
+  );
+
   const handleTabChange = (id: string) => {
     setCurrentRecipientId(id);
   };
@@ -33,9 +36,9 @@ export const MailEditor = ({ selectedPart, selectedTemplateId }: MailEditorProps
       />
       <Suspense fallback={<div>에디터 로딩 중...</div>}>
         <MailEditorContent
-          // 사용자가 수정한 내용이 있으면 그걸 보여주고, 없으면 템플릿 기본값 사용
-          initialContent={defaultContent}
-          key={currentRecipientId} // ID가 바뀔 때마다 에디터를 새로 그려서 내용을 교체함
+          initialContent={currentContent}
+          key={currentRecipientId} // 탭 변경 시 컴포넌트 리렌더링을 위한 key 설정
+          onContentChange={handleContentChange}
           recipientName={currentRecipientName}
         />
       </Suspense>

--- a/src/pages/SendMail/components/MailEditorContent/MailEditorContent.tsx
+++ b/src/pages/SendMail/components/MailEditorContent/MailEditorContent.tsx
@@ -73,11 +73,6 @@ export const MailEditorContent = forwardRef<MailEditorContentRef, MailEditorCont
       ],
       content: initialContent || '',
       editable: true,
-      onCreate: ({ editor }) => {
-        if (onContentChange) {
-          onContentChange(editor.getHTML());
-        }
-      },
       onUpdate: ({ editor }) => {
         if (onContentChange) {
           onContentChange(editor.getHTML());

--- a/src/pages/SendMail/components/MailVariable/MailVariable.tsx
+++ b/src/pages/SendMail/components/MailVariable/MailVariable.tsx
@@ -2,6 +2,7 @@ import { assert } from 'es-toolkit';
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 
 import { RecipientId } from '@/pages/SendMail/mail.type';
+import { Part } from '@/query/part/schema';
 import { VariableState } from '@/types/editor';
 
 interface VariableContextProps {
@@ -12,7 +13,7 @@ interface VariableContextProps {
     updateIndividualValue: (applicantId: RecipientId, key: string, value: string) => void;
   };
   activeApplicantId: RecipientId | undefined;
-  selectedTemplateId: number | undefined;
+  currentPart: Part | undefined;
   variableValue: VariableState;
 }
 
@@ -20,10 +21,10 @@ const VariableContext = createContext<null | VariableContextProps>(null);
 
 export const MailVariableProvider = ({
   children,
-  selectedTemplateId,
+  currentPart,
 }: {
   children: ReactNode;
-  selectedTemplateId: number | undefined;
+  currentPart: Part | undefined;
 }) => {
   const [variableValue, setVariableValue] = useState<VariableState>({
     common: {},
@@ -54,9 +55,18 @@ export const MailVariableProvider = ({
     [],
   );
 
+  if (!currentPart) {
+    return <>{children}</>;
+  }
+
   return (
     <VariableContext.Provider
-      value={{ variableValue, activeApplicantId, selectedTemplateId, actions }}
+      value={{
+        variableValue,
+        activeApplicantId,
+        currentPart,
+        actions,
+      }}
     >
       {children}
     </VariableContext.Provider>

--- a/src/pages/SendMail/hooks/useMailData.ts
+++ b/src/pages/SendMail/hooks/useMailData.ts
@@ -1,18 +1,32 @@
 import { useSuspenseQueries } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
-import { useMailVariables } from '@/pages/SendMail/components/MailVariable/MailVariable';
+import { useOptionalMailVariables } from '@/pages/SendMail/components/MailVariable/MailVariable';
 import { templateOptions } from '@/query/template/options';
 
-export const useMailData = (selectedTemplateId: number | undefined) => {
+export const useMailData = (
+  selectedTemplateId: number | undefined,
+  currentId: string | undefined,
+) => {
   const results = useSuspenseQueries({
     queries: [...(selectedTemplateId ? [templateOptions.detail(selectedTemplateId)] : [])],
   });
   const templateDetail = results[0]?.data;
-  const { variableValue, activeApplicantId } = useMailVariables();
+  const defaultContent = templateDetail?.content || '';
+  const mailVariables = useOptionalMailVariables();
 
+  // 에디터 내용 상태 관리
+  const [editorContents, setEditorContents] = useState<Record<string, string>>({});
+
+  // 변수 값 치환 함수
   const getDisplayVariableValue = useCallback(
     (key: string, perRecipient: boolean) => {
+      if (!mailVariables) {
+        return '';
+      }
+
+      const { variableValue, activeApplicantId } = mailVariables;
+
       if (!variableValue) {
         return '';
       }
@@ -20,19 +34,53 @@ export const useMailData = (selectedTemplateId: number | undefined) => {
       if (perRecipient) {
         const firstId = Object.keys(variableValue.perApplicant)[0];
         const recipientId = activeApplicantId ?? firstId;
-
-        // 값이 없을 경우 빈 문자열 반환
         return recipientId ? (variableValue.perApplicant[String(recipientId)]?.[key] ?? '') : '';
       }
-
       return variableValue.common[key] ?? '';
     },
-    [variableValue, activeApplicantId],
+    [mailVariables],
+  );
+
+  // 현재 보여줄 내용 계산
+  const currentContent = useMemo(() => {
+    if (!currentId) {
+      return defaultContent;
+    }
+    return editorContents[currentId] ?? defaultContent;
+  }, [currentId, editorContents, defaultContent]);
+
+  // 내용 변경 핸들러
+  const handleContentChange = useCallback(
+    (html: string) => {
+      if (!currentId) {
+        return;
+      }
+
+      const saved = editorContents[currentId];
+      const base = saved ?? defaultContent;
+
+      const isEffectivelyEmpty =
+        (base === '' || base === '<p></p>') && (html === '' || html === '<p></p>');
+
+      if (isEffectivelyEmpty || base === html) {
+        return;
+      }
+
+      setEditorContents((prev) => {
+        if (prev[currentId] === html) {
+          return prev;
+        }
+        return { ...prev, [currentId]: html };
+      });
+    },
+    [currentId, defaultContent, editorContents],
   );
 
   return {
-    defaultContent: templateDetail?.content || '',
-    templateVariables: templateDetail?.variables,
+    templateDetail,
+    currentContent,
+    handleContentChange,
     getDisplayVariableValue,
+    defaultContent,
   };
 };

--- a/src/pages/SendMail/hooks/useRecipientData.ts
+++ b/src/pages/SendMail/hooks/useRecipientData.ts
@@ -8,7 +8,8 @@ import { Part } from '@/query/part/schema';
 
 export const useRecipientData = (selectedPart: Part) => {
   const { activeApplicantId, actions } = useMailVariables();
-  const applicants = useSuspenseQuery(applicantOptions({ partId: selectedPart.partId }));
+
+  const { data: applicants } = useSuspenseQuery(applicantOptions({ partId: selectedPart.partId }));
 
   const recipients: Recipient[] = useMemo(
     () =>

--- a/src/pages/SendMail/hooks/useVariableList.ts
+++ b/src/pages/SendMail/hooks/useVariableList.ts
@@ -49,7 +49,11 @@ export const useVariableList = (templateId: number, partId: number) => {
   });
   const { variableValue, actions } = useMailVariables();
 
-  const variableCardData = (template.variables as Variable[]).map((v) =>
+  const templateVariables: Variable[] = template.variables.filter(
+    (v) => v.displayName !== '지원자' && v.displayName !== '파트명',
+  );
+
+  const variableCardData = templateVariables.map((v) =>
     transformToVariableCard(v, applicants, variableValue, actions),
   );
 

--- a/src/pages/SendMail/hooks/useVariableValue.ts
+++ b/src/pages/SendMail/hooks/useVariableValue.ts
@@ -1,0 +1,42 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { useMailVariables } from '@/pages/SendMail/components/MailVariable/MailVariable';
+import { applicantOptions } from '@/query/applicant/options';
+
+export const useVariableValue = () => {
+  const { activeApplicantId, variableValue, currentPart } = useMailVariables();
+
+  const { data: applicants } = useSuspenseQuery(applicantOptions({ partId: currentPart?.partId }));
+
+  // 선택된 ID가 없으면 이 파트의 첫 번째 지원자
+  const currentId =
+    activeApplicantId ?? (applicants?.[0] ? String(applicants[0].applicantId) : undefined);
+
+  // 현재 지원자 찾기
+  const currentApplicant = useMemo(() => {
+    if (!currentId || !applicants) {
+      return null;
+    }
+    return applicants.find((a) => String(a.applicantId) === currentId);
+  }, [currentId, applicants]);
+
+  // 변수 값 채우기
+  const getVariableValue = (key: string, perRecipient: boolean, label: string) => {
+    // 특수 변수 처리(지원자, 파트명)
+    if (label === '지원자') {
+      return currentApplicant?.name ?? label;
+    }
+    if (label === '파트명') {
+      return currentPart?.partName;
+    }
+
+    // 일반 변수 처리
+    if (perRecipient && currentId) {
+      return variableValue.perApplicant[currentId]?.[key];
+    }
+    return variableValue.common[key];
+  };
+
+  return { getVariableValue };
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,5 @@
 import { addDays, DateArg, endOfMonth, endOfWeek, isBefore, startOfWeek } from 'date-fns';
+import { parse } from 'date-fns';
 import { formatWithOptions } from 'date-fns/fp';
 import { enUS, ko } from 'date-fns/locale';
 
@@ -43,4 +44,14 @@ export const isInRange = (
   },
 ) => {
   return isBefore(from, target) && isBefore(target, to);
+};
+
+export const parseDate = (dateString: string) => {
+  if (!dateString) {
+    return undefined;
+  }
+  // 현재 년도 기준
+  const referenceDate = new Date();
+
+  return parse(dateString, 'MM/dd(E) HH:mm', referenceDate, { locale: ko });
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,4 @@
 import { addDays, DateArg, endOfMonth, endOfWeek, isBefore, startOfWeek } from 'date-fns';
-import { parse } from 'date-fns';
 import { formatWithOptions } from 'date-fns/fp';
 import { enUS, ko } from 'date-fns/locale';
 
@@ -44,14 +43,4 @@ export const isInRange = (
   },
 ) => {
   return isBefore(from, target) && isBefore(target, to);
-};
-
-export const parseDate = (dateString: string) => {
-  if (!dateString) {
-    return undefined;
-  }
-  // 현재 년도 기준
-  const referenceDate = new Date();
-
-  return parse(dateString, 'MM/dd(E) HH:mm', referenceDate, { locale: ko });
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

https://github.com/user-attachments/assets/3c83d539-bade-492b-9483-b2e9d39a2f1f


- 특수 변수 자동 치환
  - 지원자, 파트명 - 서버에서 가져오는 고정 정보는 자동으로 값이 채워지도록 구현
- UI 수정
  - 변수 리스트 내 카드 간 z-index 충돌 
  - 캘린더/시간 드롭다운이 화면 밖으로 잘리는 이슈

###  체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
