### PR TITLE
feat: 스키마와 면접 일정 색상에 회계팀 파트를 추가해요

### DIFF
--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleBlock.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleBlock.tsx
@@ -18,6 +18,7 @@ const container = tv({
       Marketing: 'bg-table-marketingBackground',
       PM: 'bg-table-pmBackground',
       HR: 'bg-table-hrBackground',
+      Finance: 'bg-table-hrBackground',
     } satisfies Record<(typeof partNames)[number], string>,
   },
 });

--- a/src/types/part.ts
+++ b/src/types/part.ts
@@ -1,5 +1,6 @@
 export const partNames = [
   'Product Design',
+  'Finance',
   'Web FE',
   'iOS',
   'Android',


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

회계 팀 면접 일정을 추가하면 스키마 에러가 터지던 문제가 있었는데, 회계 팀이 빠져있었어서 이 문제를 해결해줘요.

색상은 임시로 HR팀과 동일하게 만들어줬어요.