### PR TITLE
feat: 면접 일정 모드 UX 개선

### DIFF
--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleBlock.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleBlock.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import { AutoSchedule } from '@/query/schedule/schema';
 import { formatTemplates } from '@/utils/date';
 
@@ -5,11 +7,25 @@ interface AutoScheduleBlockProps {
   date: Date;
   isFirstBlock: boolean;
   schedule: AutoSchedule;
+  shouldScrollIntoView?: boolean;
 }
 
-export const AutoScheduleBlock = ({ schedule, date, isFirstBlock }: AutoScheduleBlockProps) => {
+export const AutoScheduleBlock = ({
+  schedule,
+  date,
+  isFirstBlock,
+  shouldScrollIntoView,
+}: AutoScheduleBlockProps) => {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (shouldScrollIntoView && ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [shouldScrollIntoView]);
+
   return (
-    <button className="bg-bg-brandPrimary flex size-full flex-col rounded-lg text-white">
+    <button className="bg-bg-brandPrimary flex size-full flex-col rounded-lg text-white" ref={ref}>
       {isFirstBlock && (
         <>
           <div className="typo-c3_sb_11 flex size-full items-end gap-1.5 px-2">

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleCalendar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleCalendar.tsx
@@ -26,6 +26,11 @@ export const AutoScheduleCalendar = ({
     precision: duration === '1시간' ? '시간' : '분',
   });
 
+  const earliestScheduleTime =
+    scheduleCandidate.schedules.length > 0
+      ? Math.min(...scheduleCandidate.schedules.map((s) => new Date(s.startTime).getTime()))
+      : null;
+
   return (
     <InterviewCalendar month={month} week={week} year={year}>
       {({ date, hour, minute }) => {
@@ -38,6 +43,7 @@ export const AutoScheduleCalendar = ({
               date={targetDate}
               isFirstBlock={duration === '30분' || (duration === '1시간' && minute === 0)}
               schedule={schedule}
+              shouldScrollIntoView={earliestScheduleTime === targetDate.getTime()}
             />
           )
         );

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -9,12 +9,21 @@ import { InterviewPageLayout } from '@/pages/Interview/components/InterviewPageL
 import { useWeekIndicator } from '@/pages/Interview/hooks/useWeekIndicator';
 
 export const AutoScheduleMode = () => {
-  const { handleNextWeek, handlePrevWeek, month, week, year } = useWeekIndicator();
-
   const scheduleCandidates = useAutoScheduleCandidates();
-  const [selectedCandidate, setSelectedCandidate] = useState<AutoScheduleCandidate>(
-    scheduleCandidates[0],
-  );
+  const initialCandidate = scheduleCandidates[0];
+  const initialDateStr =
+    initialCandidate?.schedules.length > 0
+      ? initialCandidate.schedules.reduce((prev, curr) =>
+          new Date(prev.startTime).getTime() < new Date(curr.startTime).getTime() ? prev : curr,
+        ).startTime
+      : undefined;
+
+  const { handleNextWeek, handlePrevWeek, month, week, year, jump } = useWeekIndicator({
+    initialDate: initialDateStr ? new Date(initialDateStr) : undefined,
+  });
+
+  const [selectedCandidate, setSelectedCandidate] =
+    useState<AutoScheduleCandidate>(initialCandidate);
 
   return (
     <InterviewPageLayout
@@ -40,7 +49,17 @@ export const AutoScheduleMode = () => {
         ),
         sidebar: (
           <AutoScheduleSidebar
-            onCandidateChange={setSelectedCandidate}
+            onCandidateChange={(candidate) => {
+              if (candidate.schedules.length > 0) {
+                const earliestSchedule = candidate.schedules.reduce((prev, curr) =>
+                  new Date(prev.startTime).getTime() < new Date(curr.startTime).getTime()
+                    ? prev
+                    : curr,
+                );
+                jump(new Date(earliestSchedule.startTime));
+              }
+              setSelectedCandidate(candidate);
+            }}
             scheduleCandidates={scheduleCandidates}
             selectedCandidate={selectedCandidate}
           />

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
 
 import { Applicant } from '@/query/applicant/schema';
 import { formatTemplates } from '@/utils/date';
@@ -8,6 +9,7 @@ interface ManualScheduleBlockProps {
   date: Date;
   isFirstBlock: boolean;
   onClick: () => void;
+  shouldScrollIntoView?: boolean;
 }
 
 export const ManualScheduleBlock = ({
@@ -15,7 +17,16 @@ export const ManualScheduleBlock = ({
   date,
   isFirstBlock,
   onClick,
+  shouldScrollIntoView,
 }: ManualScheduleBlockProps) => {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (shouldScrollIntoView && ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [shouldScrollIntoView]);
+
   return (
     <button
       className={clsx(
@@ -23,6 +34,7 @@ export const ManualScheduleBlock = ({
         !applicant && 'opacity-20 hover:opacity-60',
       )}
       onClick={onClick}
+      ref={ref}
     >
       {applicant && isFirstBlock && (
         <>

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
@@ -35,6 +35,12 @@ export const ManualScheduleCalendar = ({
     .entries()
     .find(([, { applicantId }]) => applicantId === selectedApplicant.applicantId)?.[0];
 
+  const targetScrollTime =
+    meAlreadySettedAt?.getTime() ??
+    (selectedApplicant.availableTimes.length > 0
+      ? Math.min(...selectedApplicant.availableTimes.map((time) => new Date(time).getTime()))
+      : null);
+
   return (
     <InterviewCalendar month={month} week={week} year={year}>
       {({ date, hour, minute }) => {
@@ -68,6 +74,7 @@ export const ManualScheduleCalendar = ({
                   return;
                 }
               }}
+              shouldScrollIntoView={targetScrollTime === targetDate.getTime()}
             />
           )
         );

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard.tsx
@@ -10,7 +10,9 @@ import { tv } from 'tailwind-variants';
 
 import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
+import { applicantOptions } from '@/query/applicant/options';
 import { partOptions } from '@/query/part/options';
+import { semesterNowOptions } from '@/query/semester/now/options';
 
 interface SelectHeaderProps {
   onOpenChange: (open: boolean) => void;
@@ -102,6 +104,13 @@ export const ManualScheduleSidebarPartCard = () => {
   const [open, setOpen] = useState(false);
   const { partName, onPartChange } = useInterviewPartSelectionContext();
   const { data: parts } = useSuspenseQuery(partOptions());
+  const { data: semesterNow } = useSuspenseQuery(semesterNowOptions());
+  const { data: applicants } = useSuspenseQuery({
+    ...applicantOptions({ semesterId: semesterNow.semesterId }),
+    select: (v) => v.filter(({ state }) => state === '심사 진행 중'),
+  });
+
+  const partsWithApplicants = new Set(applicants.map((a) => a.part));
 
   return (
     <InterviewSidebarCard>
@@ -111,6 +120,7 @@ export const ManualScheduleSidebarPartCard = () => {
           <div className="bg-line-basicMedium h-[1px] w-full" />
           {parts
             .map((v) => v.partName)
+            .filter((v) => partsWithApplicants.has(v))
             .map((v) => (
               <SelectItem
                 key={v}

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -82,8 +82,17 @@ export const ManualScheduleMode = () => {
               week,
             }}
             onSelectedApplicantChange={(v) => {
-              if (v.availableTimes.length > 0) {
-                jump(v.availableTimes[0]);
+              const settedApplicantEntry = completedScheduleMap
+                .entries()
+                .find(([, applicant]) => applicant.applicantId === v.applicantId);
+
+              if (settedApplicantEntry) {
+                jump(settedApplicantEntry[0]);
+              } else if (v.availableTimes.length > 0) {
+                const earliest = Math.min(
+                  ...v.availableTimes.map((time) => new Date(time).getTime()),
+                );
+                jump(new Date(earliest));
               }
               setSelectedApplicant(v);
             }}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- 수동 일정 모드

  - 지원자가 없는 파트는 선택이 안되도록 막았어요.
  - 지원자를 변경했을 때 해당 지원자의 일정 블럭으로 자동 스크롤 되도록 했어요. (날짜 포함)

- 자동 일정 모드

  - 생성된 일정 선택 시 가장 빠른 일정 블럭으로 자동 스크롤 되도록 했어요.
