### PR TITLE
feat: 면접 장소 관련 기능 전부 구현 + 현재 시간 이전 일정 피드백 기능

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,0 +1,2364 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Scouter API",
+    "description": "Changelog v1.1.2\n- Mail Templates: 변수 키 형식을 var-{UUID} 형식으로 통일\n- Mail Templates: VariableType에 APPLICANT, PARTNAME 추가 (type으로 자동 채움/사용자 입력 구분)\n\nChangelog v1.1.1\n- Members: POST /members/include-from-applicants(및 /{semesterString}) 생성 시 201 Created + Location 헤더, 생성 0건 시 200 OK\n- Applicants: POST /applicants/include-from-forms(및 /semesters/{semesterId}) 201 Created + Location 헤더\n",
+    "version": "v1.1.2"
+  },
+  "servers": [{ "url": "https://api.dev.scouter.yourssu.com", "description": "production server" }],
+  "security": [{ "oauth2": [] }],
+  "paths": {
+    "/recruiter/schedule/part/{partId}": {
+      "put": {
+        "tags": ["면접 일정"],
+        "summary": "파트 스케줄 수정 API",
+        "description": "특정 파트의 스케줄을 전체 수정합니다.",
+        "operationId": "updateByPart",
+        "parameters": [
+          {
+            "name": "partId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/CreateScheduleCommand" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": { "description": "OK", "content": {} },
+          "404": { "description": "파트/지원자를 찾을 수 없음", "content": {} }
+        }
+      },
+      "delete": {
+        "tags": ["면접 일정"],
+        "summary": "파트별 스케줄 삭제 API",
+        "description": "특정 파트의 모든 면접 스케줄을 삭제합니다.",
+        "operationId": "deleteByPart",
+        "parameters": [
+          {
+            "name": "partId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/DeleteByPartResponse" } }
+            }
+          },
+          "404": {
+            "description": "파트를 찾을 수 없음",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/DeleteByPartResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/mails/templates/{templateId}": {
+      "get": {
+        "tags": ["메일"],
+        "summary": "메일 템플릿 상세 조회",
+        "description": "특정 메일 템플릿의 상세 내용을 조회합니다. (편집용)",
+        "operationId": "readDetail",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "description": "템플릿 ID",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/ReadMailTemplateDetailResponse" } }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["메일"],
+        "summary": "메일 템플릿 수정",
+        "description": "특정 메일 템플릿을 수정합니다. 전체 메일 템플릿의 내용을 보내야 합니다.\n\n**변수 규칙:**\n- 모든 변수 키는 `var-{UUID}` 형식이어야 합니다 (예: `var-550e8400-e29b-41d4-a716-446655440000`)",
+        "operationId": "update",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateMailTemplateRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/CreateMailTemplateResponse" } }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["메일"],
+        "summary": "메일 템플릿 삭제",
+        "description": "특정 메일 템플릿을 삭제합니다. 해당 메일 템플릿이 없을 시 404를 반환합니다.",
+        "operationId": "delete",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "No Content", "content": {} },
+          "404": { "description": "Not Found - 템플릿을 찾을 수 없음", "content": {} }
+        }
+      }
+    },
+    "/withdrawal": {
+      "post": {
+        "tags": ["인증/인가"],
+        "summary": "회원 탈퇴",
+        "operationId": "withdraw",
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/WithdrawalRequest" } }
+          },
+          "required": true
+        },
+        "responses": { "204": { "description": "NO_CONTENT", "content": {} } }
+      }
+    },
+    "/semesters": {
+      "get": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "학기 전체 조회",
+        "description": "생성된 전체 학기 정보를 조회합니다.",
+        "operationId": "readAll",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadSemesterResponse" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "학기 생성",
+        "description": "연도, 학기 조합으로 학기를 생성합니다.",
+        "operationId": "create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateSemesterRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/refresh-token": {
+      "post": {
+        "tags": ["인증/인가"],
+        "summary": "토큰 재발급",
+        "description": "Authorization 헤더는 무시되며, 바디의 refreshToken(순수 JWT)만 사용합니다.",
+        "operationId": "refreshToken",
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TokenRefreshRequest" } }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/TokenRefreshResponse" } }
+            }
+          },
+          "401": {
+            "description": "Auth-001 (리프레시 토큰이 아닙니다. 등)",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/TokenRefreshResponse" } }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/recruiter/schedule": {
+      "get": {
+        "tags": ["면접 일정"],
+        "summary": "면접 스케줄 조회 API",
+        "description": "면접 스케줄 조회 API 입니다. 추후 partID를 입력하지 않으면 전체 조회가 되도록 변경 예정",
+        "operationId": "getSchedules",
+        "parameters": [
+          {
+            "name": "partId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadScheduleResponse" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["면접 일정"],
+        "summary": "면접 스케줄 추가 API",
+        "description": "면접 스케줄을 추가하는 API 입니다.",
+        "operationId": "createSchedules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/CreateScheduleRequest" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": { "201": { "description": "CREATED", "content": {} } }
+      }
+    },
+    "/oauth2/login/{oauth2Type}": {
+      "post": {
+        "tags": ["OAUTH2", "인증/인가"],
+        "summary": "로그인",
+        "description": "/oauth2/{oauth2Type}에서 얻은 code를 이용해 로그인을 진행합니다. 등록된 멤버만 로그인할 수 있습니다.",
+        "operationId": "login",
+        "parameters": [
+          {
+            "name": "oauth2Type",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "enum": ["GOOGLE"] }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/OAuth2LoginRequest" } }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "로그인 성공 — 토큰 반환",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/LoginResponse" } } }
+          },
+          "401": {
+            "description": "Member-005 (등록된 멤버가 아닙니다)",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/LoginResponse" } } }
+          }
+        },
+        "security": []
+      }
+    },
+    "/members/include-from-applicants": {
+      "post": {
+        "tags": ["합격자 동기화 API", "유어슈 멤버"],
+        "summary": "지원자 중 합격자 멤버 동기화",
+        "description": "리크루팅 지원자 중 합격자를 멤버에 동기화 합니다.",
+        "operationId": "includeFromApplicants",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MemberSyncResponse" } }
+            }
+          },
+          "201": {
+            "description": "CREATED",
+            "headers": { "Location": { "description": "/members", "style": "simple" } },
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MemberSyncResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/members/include-from-applicants/{semesterString}": {
+      "post": {
+        "tags": ["합격자 동기화 API", "유어슈 멤버"],
+        "operationId": "includeFromApplicants_1",
+        "parameters": [
+          {
+            "name": "semesterString",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MemberSyncResponse" } }
+            }
+          },
+          "201": {
+            "description": "CREATED",
+            "headers": { "Location": { "description": "/members", "style": "simple" } },
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MemberSyncResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/logout": {
+      "post": {
+        "tags": ["인증/인가"],
+        "summary": "로그아웃",
+        "operationId": "logout",
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/LogoutRequest" } }
+          },
+          "required": true
+        },
+        "responses": { "204": { "description": "NO_CONTENT", "content": {} } }
+      }
+    },
+    "/applicants": {
+      "get": {
+        "tags": ["리크루팅 지원자"],
+        "summary": "지원자 목록 조회",
+        "description": "지원자 목록을 검색, 필터링을 통해 얻습니다. 필터링에 필요한 정보는 각 api에서 얻어야 합니다.",
+        "operationId": "readAll_1",
+        "parameters": [
+          { "name": "name", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "state", "in": "query", "required": false, "schema": { "type": "string" } },
+          {
+            "name": "semesterId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadApplicantResponse" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["리크루팅 지원자"],
+        "summary": "지원자 추가 API",
+        "operationId": "create_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateApplicantRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "CREATED",
+            "headers": {
+              "Location": { "description": "/applicants/{applicantId}", "style": "simple" }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
+    "/applicants/include-from-forms": {
+      "post": {
+        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
+        "summary": "구글폼 응답을 지원자 목록에 업데이트",
+        "description": "현재 로그인 되어있는 사용자의 계정을 이용해 지원자의 구글폼 응답을 동기화 합니다.",
+        "operationId": "includeFromForms",
+        "responses": {
+          "201": {
+            "description": "CREATED",
+            "headers": { "Location": { "description": "/applicants", "style": "simple" } },
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/ApplicantSyncResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/applicants/include-from-forms/semesters/{semesterId}": {
+      "post": {
+        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
+        "operationId": "includeFromFormsBySemesterAndPart",
+        "parameters": [
+          {
+            "name": "semesterId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "CREATED",
+            "headers": { "Location": { "description": "/applicants", "style": "simple" } },
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/ApplicantSyncResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/mails/templates": {
+      "get": {
+        "tags": ["메일"],
+        "summary": "메일 템플릿 목록 조회",
+        "description": "현재 등록된 전체 메일 템플릿을 조회합니다.",
+        "operationId": "readAll_2",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": 0 }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": 20 }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "default": "updatedAt,desc" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageResponseReadMailTemplateSummaryResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["메일"],
+        "summary": "메일 템플릿 생성",
+        "description": "제목과 양식을 지정해 새로운 메일 템플릿을 생성합니다.\n\n**변수 규칙:**\n- 모든 변수 키는 `var-{UUID}` 형식이어야 합니다 (예: `var-550e8400-e29b-41d4-a716-446655440000`)\n- 메일 본문에서 변수는 `{{var-{UUID}}}` 형식으로 사용합니다\n\n**변수 타입:**\n- **사용자 입력 변수**: PERSON, DATE, LINK, TEXT\n- **자동 채움 변수**: APPLICANT, PARTNAME",
+        "operationId": "create_2",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateMailTemplateRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/CreateMailTemplateResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/mails/reservation": {
+      "post": {
+        "tags": ["메일"],
+        "summary": "메일 전송 예약",
+        "description": "application/json으로 요청합니다. 파일은 사전에 /api/mails/files/* API로 업로드/확정한 뒤, 예약 시 fileId 참조만 전달합니다.",
+        "operationId": "reserveMail",
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/MailReserveRequest" } }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": { "description": "예약 성공", "content": {} },
+          "400": {
+            "description": "잘못된 요청 (bodyFormat 오류, fileId 검증 실패 등)",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/ExceptionResponse" } } }
+          }
+        }
+      }
+    },
+    "/api/mails/files/presign": {
+      "post": {
+        "tags": ["메일"],
+        "summary": "메일 파일 업로드용 presigned URL 발급",
+        "operationId": "createPresignedUploadUrls",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MailFilePresignRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MailFilePresignResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/mails/files/confirm": {
+      "post": {
+        "tags": ["메일"],
+        "summary": "업로드 완료 파일 등록",
+        "operationId": "confirmUploads",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MailFileConfirmRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MailFileConfirmResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/recruiter/schedule/{scheduleId}/location": {
+      "patch": {
+        "tags": ["면접 일정"],
+        "summary": "면접 장소 변경 API",
+        "description": "스케줄 ID를 기준으로 면접 장소 대분류와 세부장소를 수정합니다.",
+        "operationId": "updateLocation",
+        "parameters": [
+          {
+            "name": "scheduleId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateScheduleLocationRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": { "description": "OK", "content": {} },
+          "404": { "description": "스케줄을 찾을 수 없음", "content": {} }
+        }
+      }
+    },
+    "/members/withdrawn/{memberId}": {
+      "patch": {
+        "tags": ["유어슈 멤버"],
+        "summary": "탈퇴 멤버 정보 수정",
+        "description": "변경되지 않은 정보는 보내면 안됩니다.",
+        "operationId": "updateWithdrawnById",
+        "parameters": [
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateWithdrawnMemberRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/members/inactive/{memberId}": {
+      "patch": {
+        "tags": ["유어슈 멤버"],
+        "summary": "비액티브 멤버 정보 수정",
+        "description": "변경되지 않은 정보는 보내면 안됩니다.",
+        "operationId": "updateInactiveById",
+        "parameters": [
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateInactiveMemberRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/members/graduated/{memberId}": {
+      "patch": {
+        "tags": ["유어슈 멤버"],
+        "summary": "졸업 멤버 정보 수정",
+        "description": "변경되지 않은 정보는 보내면 안됩니다.",
+        "operationId": "updateGraduatedById",
+        "parameters": [
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateGraduatedMemberRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/members/active/{memberId}": {
+      "patch": {
+        "tags": ["유어슈 멤버"],
+        "summary": "액티브 멤버 정보 수정",
+        "description": "변경되지 않은 정보는 보내면 안됩니다.",
+        "operationId": "updateActiveById",
+        "parameters": [
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateActiveMemberRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/applicants/{applicantId}": {
+      "get": {
+        "tags": ["리크루팅 지원자"],
+        "summary": "지원자 단일 조회",
+        "description": "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자의 세부정보를 확인합니다.",
+        "operationId": "readById",
+        "parameters": [
+          {
+            "name": "applicantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/ReadApplicantResponse" } }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["리크루팅 지원자"],
+        "summary": "지원자 삭제",
+        "description": "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자를 삭제합니다.",
+        "operationId": "deleteById",
+        "parameters": [
+          {
+            "name": "applicantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": { "204": { "description": "NO_CONTENT", "content": {} } }
+      },
+      "patch": {
+        "tags": ["리크루팅 지원자"],
+        "summary": "지원자 정보 수정",
+        "description": "변경할 지원자 정보의 값을 보냅니다. 변경되지 않은 값은 보내면 안 됩니다.",
+        "operationId": "updateById",
+        "parameters": [
+          {
+            "name": "applicantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateApplicantRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/validate-token": {
+      "get": {
+        "tags": ["인증/인가"],
+        "summary": "AccessToken 유효성 검사",
+        "operationId": "validateToken",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/ValidateTokenResponse" } }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/semesters/now": {
+      "get": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "현재 학기 조회",
+        "description": "현재 학기에 해당하는 정보를 조회합니다.",
+        "operationId": "readByDate",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/ReadSemesterResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/recruiter/schedule/auto/{partId}": {
+      "get": {
+        "tags": ["면접 일정"],
+        "summary": "면접 스케줄 자동 생성 API",
+        "description": "\n            백트래킹 알고리즘을 사용하여 면접 스케줄을 자동 생성합니다.\n            - 같은 파트의 같은 시간에는 중복 배정하지 않습니다.\n            - 모든 지원자를 배정할 수 없는 경우 400 에러를 반환합니다.\n            - 지원자가 많을 경우 응답 시간이 길어질 수 있습니다.\n            - **주의**: 저장은 되지 않으며, 미리보기 용도입니다.\n        ",
+        "operationId": "getAutoSchedules",
+        "parameters": [
+          {
+            "name": "partId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "request",
+            "in": "query",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/AutoScheduleRequest" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/AutoScheduleResponse" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parts": {
+      "get": {
+        "tags": ["구분/파트"],
+        "summary": "파트(팀) 목록 조회",
+        "description": "Head lead, Finance 등 파트 목록을 조회합니다.",
+        "operationId": "readAll_3",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadPartsResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth2/{oauth2Type}": {
+      "get": {
+        "tags": ["OAUTH2", "인증/인가"],
+        "summary": "OAuth2 로그인 페이지 리다이렉트",
+        "description": "여기에서는 리다이렉트가 되지 않습니다. Authorize 이용.",
+        "operationId": "redirectAuthCodeRequestUrl",
+        "parameters": [
+          {
+            "name": "oauth2Type",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "enum": ["GOOGLE"] }
+          }
+        ],
+        "responses": { "200": { "description": "OK", "content": {} } },
+        "security": []
+      }
+    },
+    "/members/withdrawn": {
+      "get": {
+        "tags": ["유어슈 멤버"],
+        "summary": "탈퇴 멤버 목록 조회/검색",
+        "operationId": "readAllWithdrawn",
+        "parameters": [
+          { "name": "search", "in": "query", "required": false, "schema": { "type": "string" } },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadWithdrawnMemberResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/states": {
+      "get": {
+        "tags": ["유어슈 멤버"],
+        "summary": "멤버 상태 목록 조회",
+        "description": "액티브, 비액티브, 졸업, 탈퇴 등 상태를 조회합니다.",
+        "operationId": "readAllMemberStates",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "type": "array", "items": { "type": "string" } } } }
+          }
+        }
+      }
+    },
+    "/members/roles": {
+      "get": {
+        "tags": ["유어슈 멤버"],
+        "summary": "멤버 역할 목록 조회",
+        "description": "Lead, Vice Lead, Member 등 역할을 조회합니다.",
+        "operationId": "readAllMemberRoles",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "type": "array", "items": { "type": "string" } } } }
+          }
+        }
+      }
+    },
+    "/members/me": {
+      "get": {
+        "tags": ["내 정보"],
+        "summary": "내 정보 조회",
+        "description": "액세스 토큰으로 현재 로그인한 사용자의 멤버 정보와 프로필 이미지를 조회합니다.",
+        "operationId": "getMe",
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/MeResponse" } } }
+          },
+          "401": {
+            "description": "Member-005 (등록된 멤버가 아닙니다)",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/MeResponse" } } }
+          }
+        }
+      }
+    },
+    "/members/lastUpdatedTime": {
+      "get": {
+        "tags": ["합격자 동기화 API", "유어슈 멤버"],
+        "summary": "마지막 동기화 시간 조회",
+        "description": "유어슈 멤버의 마지막 동기화 시간을 조회합니다.",
+        "operationId": "lastSyncTime",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/LastMemberSyncTimeResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/members/inactive": {
+      "get": {
+        "tags": ["유어슈 멤버"],
+        "summary": "비액티브 멤버 목록 조회/검색",
+        "operationId": "readAllInActive",
+        "parameters": [
+          { "name": "search", "in": "query", "required": false, "schema": { "type": "string" } },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadInactiveMemberResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/graduated": {
+      "get": {
+        "tags": ["유어슈 멤버"],
+        "summary": "졸업 멤버 목록 조회/검색",
+        "operationId": "readAllGraduated",
+        "parameters": [
+          { "name": "search", "in": "query", "required": false, "schema": { "type": "string" } },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadGraduatedMemberResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/active": {
+      "get": {
+        "tags": ["유어슈 멤버"],
+        "summary": "액티브 멤버 목록 조회/검색",
+        "operationId": "readAllActive",
+        "parameters": [
+          { "name": "search", "in": "query", "required": false, "schema": { "type": "string" } },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadActiveMemberResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/divisions": {
+      "get": {
+        "tags": ["구분/파트"],
+        "summary": "멤버 구분 목록 조회",
+        "description": "운영, 개발, 디자인 등 각 구분의 목록을 조회합니다.",
+        "operationId": "readAll_4",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadDivisionResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/departments": {
+      "get": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "전체 학과 조회",
+        "description": "전체 학과 정보를 조회합니다.",
+        "operationId": "readAll_5",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadDepartmentsResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/colleges": {
+      "get": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "전체 단과대 조회",
+        "description": "전체 단과대의 정보를 조회합니다.",
+        "operationId": "readAll_6",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadCollegeResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/colleges/{collegeId}/departments": {
+      "get": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "단과대 소속 학과 조회",
+        "description": "특정 단과대에 소속된 전체 학과 정보를 조회합니다.",
+        "operationId": "readAllByCollegeId",
+        "parameters": [
+          {
+            "name": "collegeId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReadDepartmentsResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applicants/states": {
+      "get": {
+        "tags": ["리크루팅 지원자"],
+        "summary": "지원자 상태 목록 조회",
+        "description": "전체 지원자의 가능한 상태 목록을 확인합니다. 현재 지원자와는 관련이 없습니다.",
+        "operationId": "readAllMemberStates_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "type": "string" } },
+                "example": [
+                  "심사 진행 중",
+                  "서류 불합",
+                  "면접 불합",
+                  "인큐베이팅 불합",
+                  "최종 합격"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applicants/lastUpdatedTime": {
+      "get": {
+        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
+        "summary": "마지막 동기화 시간 조회",
+        "operationId": "lastSyncTime_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/LastApplicantSyncTimeResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/mails/images/{fileId}": {
+      "get": {
+        "tags": ["메일"],
+        "summary": "메일 이미지 조회 (302 Redirect)",
+        "description": "업로드된 이미지 파일의 S3 presigned GET URL을 생성하고, 해당 URL로 302 리다이렉트합니다.\n\n**공개 엔드포인트:**\n- 인증 없이 접근 가능합니다.\n- storageKey를 통해 파일 접근을 검증합니다.\n\n**사용 방법:**\n- `<img src=\"/api/mails/images/{fileId}?storageKey=xxx\">` 형태로 HTML에서 직접 사용 가능합니다.\n- 브라우저 주소창에서 직접 호출하면 이미지가 표시됩니다.\n\n**Swagger UI 제한:**\n- Swagger UI는 302 응답을 자동으로 따라가며, S3 도메인과의 CORS 차이로 인해 정상 동작하더라도 에러로 표시될 수 있습니다.\n- 테스트 시에는 브라우저 주소창에서 직접 호출하거나 curl을 사용해 주세요.\n\n**Presigned URL:**\n- 생성된 URL은 10분간 유효합니다.",
+        "operationId": "redirectToImage",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "파일 ID",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "storageKey",
+            "in": "query",
+            "description": "S3 스토리지 키",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "302": { "description": "Found - S3 presigned URL로 리다이렉트" },
+          "403": { "description": "Forbidden - storageKey가 일치하지 않음" },
+          "404": { "description": "Not Found - 파일을 찾을 수 없거나 삭제된 파일" }
+        }
+      }
+    },
+    "/api/mails/files": {
+      "get": {
+        "tags": ["메일"],
+        "summary": "내 메일 파일 목록 조회",
+        "operationId": "readFiles",
+        "parameters": [
+          {
+            "name": "usage",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["INLINE", "ATTACHMENT"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": { "schema": { "$ref": "#/components/schemas/MailFileListResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/semesters/{semesterId}": {
+      "delete": {
+        "tags": ["학과/학기/단과대"],
+        "summary": "학기 삭제",
+        "description": "특정 학기 정보를 삭제합니다.",
+        "operationId": "deleteById_1",
+        "parameters": [
+          {
+            "name": "semesterId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    },
+    "/api/mails/files/{fileId}": {
+      "delete": {
+        "tags": ["메일"],
+        "summary": "내 메일 파일 삭제",
+        "operationId": "deleteFile",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": { "200": { "description": "OK", "content": {} } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateScheduleCommand": {
+        "type": "object",
+        "properties": {
+          "applicantId": { "type": "integer", "format": "int64" },
+          "startTime": { "type": "string", "format": "date-time" },
+          "endTime": { "type": "string", "format": "date-time" },
+          "partId": { "type": "integer", "format": "int64" },
+          "locationType": {
+            "type": "string",
+            "enum": ["CLUB_ROOM", "CLASS_ROOM", "ONLINE", "ETC"]
+          },
+          "locationDetail": { "type": "string" }
+        },
+        "required": ["applicantId", "endTime", "locationType", "partId", "startTime"]
+      },
+      "AttachmentReferenceRequest": {
+        "type": "object",
+        "description": "첨부파일 참조 정보",
+        "properties": {
+          "fileId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "업로드된 파일 ID",
+            "example": 11
+          }
+        },
+        "required": ["fileId"]
+      },
+      "CreateMailTemplateRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "메일 템플릿 제목",
+            "example": "합격 안내 메일",
+            "minLength": 1
+          },
+          "bodyHtml": {
+            "type": "string",
+            "description": "메일 본문 HTML. 변수는 {{var-{UUID}}} 형식으로 사용",
+            "example": "<p>안녕하세요 {{var-550e8400-e29b-41d4-a716-446655440000}}님</p>",
+            "maxLength": 100000,
+            "minLength": 0
+          },
+          "variables": {
+            "type": "array",
+            "description": "템플릿 변수 목록",
+            "items": { "$ref": "#/components/schemas/TemplateVariableRequest" }
+          },
+          "inlineImageReferences": {
+            "type": "array",
+            "description": "인라인 이미지 참조 목록",
+            "items": { "$ref": "#/components/schemas/InlineImageReferenceRequest" }
+          },
+          "attachmentReferences": {
+            "type": "array",
+            "description": "첨부파일 참조 목록",
+            "items": { "$ref": "#/components/schemas/AttachmentReferenceRequest" }
+          }
+        },
+        "required": [
+          "attachmentReferences",
+          "bodyHtml",
+          "inlineImageReferences",
+          "title",
+          "variables"
+        ]
+      },
+      "InlineImageReferenceRequest": {
+        "type": "object",
+        "description": "인라인 이미지 참조 정보",
+        "properties": {
+          "fileId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "업로드된 파일 ID",
+            "example": 10
+          },
+          "contentId": {
+            "type": "string",
+            "description": "본문에서 사용하는 cid 값",
+            "example": "cid_logo"
+          }
+        },
+        "required": ["contentId", "fileId"]
+      },
+      "TemplateVariableRequest": {
+        "type": "object",
+        "description": "템플릿 변수 정보",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "변수 키. var-{UUID} 형식이어야 함 (예: var-550e8400-e29b-41d4-a716-446655440000)",
+            "example": "var-550e8400-e29b-41d4-a716-446655440000",
+            "pattern": "^var-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          },
+          "type": {
+            "type": "string",
+            "description": "변수 타입. PERSON, DATE, LINK, TEXT는 사용자 입력 변수. APPLICANT, PARTNAME은 자동 채움 변수",
+            "enum": ["PERSON", "DATE", "LINK", "TEXT", "APPLICANT", "PARTNAME"],
+            "example": "TEXT"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "변수 표시 이름",
+            "example": "면접 일시"
+          },
+          "perRecipient": {
+            "type": "boolean",
+            "description": "수신자별로 다른 값 입력 여부",
+            "example": true
+          }
+        },
+        "required": ["displayName", "key", "perRecipient", "type"]
+      },
+      "CreateMailTemplateResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "title": { "type": "string" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "title", "updatedAt"]
+      },
+      "WithdrawalRequest": {
+        "type": "object",
+        "properties": { "refreshToken": { "type": "string", "minLength": 1 } },
+        "required": ["refreshToken"]
+      },
+      "CreateSemesterRequest": {
+        "type": "object",
+        "properties": {
+          "year": { "type": "integer", "format": "int32" },
+          "term": { "type": "integer", "format": "int32" }
+        },
+        "required": ["term", "year"]
+      },
+      "TokenRefreshRequest": {
+        "type": "object",
+        "properties": { "refreshToken": { "type": "string", "minLength": 1 } },
+        "required": ["refreshToken"]
+      },
+      "TokenRefreshResponse": {
+        "type": "object",
+        "properties": {
+          "tokenType": { "type": "string" },
+          "accessToken": { "type": "string" },
+          "refreshToken": { "type": "string" }
+        },
+        "required": ["accessToken", "refreshToken", "tokenType"]
+      },
+      "CreateScheduleRequest": {
+        "type": "object",
+        "properties": {
+          "applicantId": { "type": "integer", "format": "int64" },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-11-10T10:00:00Z",
+            "pattern": "yyyy-MM-ddTHH:mm:ssZ"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-11-10T10:30:00Z",
+            "pattern": "yyyy-MM-ddTHH:mm:ssZ"
+          },
+          "partId": { "type": "integer", "format": "int64" },
+          "locationType": {
+            "type": "string",
+            "description": "동방 | 강의실 | 비대면 | 기타",
+            "example": "동방",
+            "minLength": 1
+          },
+          "locationDetail": { "type": "string" }
+        },
+        "required": ["applicantId", "endTime", "locationType", "partId", "startTime"]
+      },
+      "OAuth2LoginRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationCode": { "type": "string", "minLength": 1 },
+          "redirectUri": { "type": "string" }
+        },
+        "required": ["authorizationCode"]
+      },
+      "LoginResponse": {
+        "type": "object",
+        "description": "로그인 응답",
+        "properties": {
+          "tokenType": { "type": "string", "description": "토큰 타입", "example": "Bearer" },
+          "accessToken": { "type": "string", "description": "액세스 토큰" },
+          "refreshToken": { "type": "string", "description": "리프레시 토큰" }
+        },
+        "required": ["accessToken", "refreshToken", "tokenType"]
+      },
+      "MemberSyncResponse": {
+        "type": "object",
+        "properties": {
+          "failureMessages": { "type": "array", "items": { "type": "string" } },
+          "createdCount": { "type": "integer", "format": "int32" }
+        },
+        "required": ["createdCount", "failureMessages"]
+      },
+      "LogoutRequest": {
+        "type": "object",
+        "properties": { "refreshToken": { "type": "string", "minLength": 1 } },
+        "required": ["refreshToken"]
+      },
+      "CreateApplicantRequest": {
+        "type": "object",
+        "properties": {
+          "partId": { "type": "integer", "format": "int64" },
+          "name": { "type": "string", "minLength": 1 },
+          "state": {
+            "type": "string",
+            "description": "심사 진행 중 | 서류 불합 | 면접 불합 | 인큐베이팅 불합 | 최종 합격",
+            "example": "심사 진행 중",
+            "minLength": 1
+          },
+          "applicationDate": {
+            "type": "string",
+            "format": "date",
+            "example": "2025-11-10",
+            "pattern": "yyyy-MM-dd"
+          },
+          "email": { "type": "string", "format": "email" },
+          "phoneNumber": { "type": "string", "minLength": 1, "pattern": "^010-\\d{4}-\\d{4}$" },
+          "departmentId": { "type": "integer", "format": "int64" },
+          "studentId": { "type": "string", "minLength": 1 },
+          "semesterId": { "type": "integer", "format": "int64" },
+          "age": { "type": "string", "minLength": 1 },
+          "academicSemester": { "type": "string", "minLength": 1, "pattern": "^\\d-\\d$" },
+          "availableTimes": {
+            "type": "array",
+            "items": { "type": "string", "format": "date-time" }
+          }
+        },
+        "required": [
+          "academicSemester",
+          "age",
+          "applicationDate",
+          "availableTimes",
+          "departmentId",
+          "email",
+          "name",
+          "partId",
+          "phoneNumber",
+          "semesterId",
+          "state",
+          "studentId"
+        ]
+      },
+      "ApplicantSyncResponse": {
+        "type": "object",
+        "properties": {
+          "successes": { "type": "array", "items": { "type": "string" } },
+          "failures": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["failures", "successes"]
+      },
+      "MailReserveRequest": {
+        "type": "object",
+        "description": "메일 예약 요청",
+        "properties": {
+          "receiverEmailAddresses": {
+            "type": "array",
+            "description": "수신자 이메일 주소 목록",
+            "example": ["user@example.com"],
+            "items": { "type": "string" }
+          },
+          "ccEmailAddresses": {
+            "type": "array",
+            "description": "참조(CC) 이메일 주소 목록",
+            "example": [],
+            "items": { "type": "string" }
+          },
+          "bccEmailAddresses": {
+            "type": "array",
+            "description": "숨은참조(BCC) 이메일 주소 목록",
+            "example": [],
+            "items": { "type": "string" }
+          },
+          "mailSubject": { "type": "string", "description": "메일 제목", "example": "면접 안내" },
+          "mailBody": {
+            "type": "string",
+            "description": "메일 본문",
+            "example": "<p>안녕하세요</p>"
+          },
+          "bodyFormat": {
+            "type": "string",
+            "description": "본문 형식",
+            "enum": ["HTML", "PLAIN_TEXT"],
+            "example": "HTML"
+          },
+          "reservationTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "예약 발송 시간 (ISO 8601, UTC)",
+            "example": "2026-02-06T02:00:00Z"
+          },
+          "inlineImageReferences": {
+            "type": "array",
+            "description": "인라인 이미지 참조 목록",
+            "items": { "$ref": "#/components/schemas/InlineImageReferenceRequest" }
+          },
+          "attachmentReferences": {
+            "type": "array",
+            "description": "첨부파일 참조 목록",
+            "items": { "$ref": "#/components/schemas/AttachmentReferenceRequest" }
+          }
+        },
+        "required": [
+          "attachmentReferences",
+          "bodyFormat",
+          "inlineImageReferences",
+          "mailBody",
+          "mailSubject",
+          "receiverEmailAddresses",
+          "reservationTime"
+        ]
+      },
+      "ExceptionResponse": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "status": { "type": "integer", "format": "int32" },
+          "errorCode": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "required": ["errorCode", "message", "status", "timestamp"]
+      },
+      "FileSpec": {
+        "type": "object",
+        "properties": {
+          "fileName": { "type": "string", "description": "파일명", "example": "guide.pdf" },
+          "contentType": {
+            "type": "string",
+            "description": "파일 MIME 타입",
+            "example": "application/pdf"
+          },
+          "usage": {
+            "type": "string",
+            "description": "파일 용도",
+            "enum": ["INLINE", "ATTACHMENT"]
+          }
+        },
+        "required": ["contentType", "fileName", "usage"]
+      },
+      "MailFilePresignRequest": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": "array",
+            "description": "업로드 대상 파일 목록",
+            "items": { "$ref": "#/components/schemas/FileSpec" }
+          }
+        },
+        "required": ["files"]
+      },
+      "MailFilePresignResponse": {
+        "type": "object",
+        "properties": {
+          "uploads": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/PresignedUpload" }
+          }
+        },
+        "required": ["uploads"]
+      },
+      "PresignedUpload": {
+        "type": "object",
+        "properties": {
+          "s3Key": { "type": "string" },
+          "putUrl": { "type": "string" },
+          "expiresAt": { "type": "string", "format": "date-time" },
+          "contentType": { "type": "string" }
+        },
+        "required": ["contentType", "expiresAt", "putUrl", "s3Key"]
+      },
+      "File": {
+        "type": "object",
+        "properties": {
+          "s3Key": {
+            "type": "string",
+            "description": "S3 저장 키",
+            "example": "mail-files/inline/1/uuid-logo.png"
+          },
+          "fileName": { "type": "string", "description": "파일명", "example": "logo.png" },
+          "contentType": {
+            "type": "string",
+            "description": "파일 MIME 타입",
+            "example": "image/png"
+          },
+          "usage": {
+            "type": "string",
+            "description": "파일 용도",
+            "enum": ["INLINE", "ATTACHMENT"]
+          }
+        },
+        "required": ["contentType", "fileName", "s3Key", "usage"]
+      },
+      "MailFileConfirmRequest": {
+        "type": "object",
+        "properties": {
+          "files": { "type": "array", "items": { "$ref": "#/components/schemas/File" } }
+        },
+        "required": ["files"]
+      },
+      "MailFileConfirmResponse": {
+        "type": "object",
+        "properties": {
+          "files": { "type": "array", "items": { "$ref": "#/components/schemas/MailFileSummary" } }
+        },
+        "required": ["files"]
+      },
+      "MailFileSummary": {
+        "type": "object",
+        "properties": {
+          "fileId": { "type": "integer", "format": "int64" },
+          "usage": { "type": "string", "enum": ["INLINE", "ATTACHMENT"] },
+          "fileName": { "type": "string" },
+          "contentType": { "type": "string" },
+          "s3Key": { "type": "string" },
+          "used": { "type": "boolean" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["contentType", "fileId", "fileName", "s3Key", "usage", "used"]
+      },
+      "UpdateScheduleLocationRequest": {
+        "type": "object",
+        "properties": {
+          "locationType": {
+            "type": "string",
+            "description": "동방 | 강의실 | 비대면 | 기타",
+            "example": "동방",
+            "minLength": 1
+          },
+          "locationDetail": { "type": "string" }
+        },
+        "required": ["locationType"]
+      },
+      "UpdateWithdrawnMemberRequest": {
+        "type": "object",
+        "properties": {
+          "partIds": { "type": "array", "items": { "type": "integer", "format": "int64" } },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "departmentId": { "type": "integer", "format": "int64" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date", "example": "2003-09-23" },
+          "joinDate": { "type": "string", "format": "date", "example": "2024-01-01" },
+          "note": { "type": "string" }
+        }
+      },
+      "UpdateInactiveMemberRequest": {
+        "type": "object",
+        "properties": {
+          "partIds": { "type": "array", "items": { "type": "integer", "format": "int64" } },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "departmentId": { "type": "integer", "format": "int64" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date", "example": "2003-09-23" },
+          "joinDate": { "type": "string", "format": "date", "example": "2024-01-01" },
+          "expectedReturnSemesterId": { "type": "integer", "format": "int64" },
+          "note": { "type": "string" }
+        }
+      },
+      "UpdateGraduatedMemberRequest": {
+        "type": "object",
+        "properties": {
+          "partIds": { "type": "array", "items": { "type": "integer", "format": "int64" } },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "departmentId": { "type": "integer", "format": "int64" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date", "example": "2003-09-23" },
+          "joinDate": { "type": "string", "format": "date", "example": "2024-01-01" },
+          "isAdvisorDesired": { "type": "boolean" },
+          "note": { "type": "string" }
+        }
+      },
+      "UpdateActiveMemberRequest": {
+        "type": "object",
+        "properties": {
+          "partIds": { "type": "array", "items": { "type": "integer", "format": "int64" } },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "departmentId": { "type": "integer", "format": "int64" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date", "example": "2003-09-23" },
+          "joinDate": { "type": "string", "format": "date", "example": "2024-01-01" },
+          "membershipFee": { "type": "boolean" },
+          "note": { "type": "string" }
+        }
+      },
+      "UpdateApplicantRequest": {
+        "type": "object",
+        "properties": {
+          "partId": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" },
+          "state": {
+            "type": "string",
+            "description": "심사 진행 중 | 서류 불합 | 면접 불합 | 인큐베이팅 불합 | 최종 합격",
+            "example": "심사 진행 중"
+          },
+          "applicationDate": { "type": "string", "format": "date" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string", "pattern": "^010-\\d{4}-\\d{4}$" },
+          "departmentId": { "type": "integer", "format": "int64" },
+          "studentId": { "type": "string" },
+          "semesterId": { "type": "integer", "format": "int64" },
+          "age": { "type": "string" },
+          "academicSemester": { "type": "string", "pattern": "^\\d-\\d$" },
+          "availableTimes": {
+            "type": "array",
+            "items": { "type": "string", "format": "date-time" }
+          }
+        }
+      },
+      "ValidateTokenResponse": {
+        "type": "object",
+        "properties": { "validated": { "type": "boolean" } },
+        "required": ["validated"]
+      },
+      "ReadSemesterResponse": {
+        "type": "object",
+        "properties": {
+          "semesterId": { "type": "integer", "format": "int64" },
+          "semester": { "type": "string" }
+        },
+        "required": ["semester", "semesterId"]
+      },
+      "ReadScheduleResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "applicantId": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" },
+          "part": { "type": "string" },
+          "startTime": { "type": "string", "format": "date-time" },
+          "endTime": { "type": "string", "format": "date-time" },
+          "locationType": { "type": "string" },
+          "locationDetail": { "type": "string" }
+        },
+        "required": ["applicantId", "endTime", "id", "locationType", "name", "part", "startTime"]
+      },
+      "AutoScheduleRequest": {
+        "type": "object",
+        "properties": {
+          "strategy": { "type": "string" },
+          "size": { "type": "integer", "format": "int32", "example": 5 },
+          "duration": { "type": "integer", "format": "int64", "example": 60 }
+        },
+        "required": ["duration", "size", "strategy"]
+      },
+      "AutoScheduleResponse": {
+        "type": "object",
+        "properties": {
+          "applicantId": { "type": "integer", "format": "int64" },
+          "applicantName": { "type": "string" },
+          "part": { "type": "string" },
+          "startTime": { "type": "string", "format": "date-time" },
+          "endTime": { "type": "string", "format": "date-time" }
+        },
+        "required": ["applicantId", "applicantName", "endTime", "part", "startTime"]
+      },
+      "ReadPartsResponse": {
+        "type": "object",
+        "properties": {
+          "partId": { "type": "integer", "format": "int64" },
+          "partName": { "type": "string" }
+        },
+        "required": ["partId", "partName"]
+      },
+      "ReadDivisionAndPartInMemberResponse": {
+        "type": "object",
+        "properties": { "division": { "type": "string" }, "part": { "type": "string" } },
+        "required": ["division", "part"]
+      },
+      "ReadWithdrawnMemberResponse": {
+        "type": "object",
+        "properties": {
+          "memberId": { "type": "integer", "format": "int64" },
+          "parts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse" }
+          },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "department": { "type": "string" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date" },
+          "joinDate": { "type": "string", "format": "date" },
+          "note": { "type": "string" }
+        },
+        "required": [
+          "birthDate",
+          "department",
+          "email",
+          "joinDate",
+          "memberId",
+          "name",
+          "nickname",
+          "note",
+          "parts",
+          "phoneNumber",
+          "role",
+          "state",
+          "studentId"
+        ]
+      },
+      "MeResponse": {
+        "type": "object",
+        "description": "내 정보 응답",
+        "properties": {
+          "profileImageUrl": { "type": "string", "description": "구글 프로필 이미지 URL" },
+          "memberId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "멤버 ID",
+            "example": 1
+          },
+          "name": { "type": "string", "description": "이름", "example": "홍길동" },
+          "email": { "type": "string", "description": "이메일", "example": "hong@soongsil.ac.kr" },
+          "phoneNumber": {
+            "type": "string",
+            "description": "전화번호",
+            "example": "010-1234-5678"
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "description": "생년월일",
+            "example": "2000-01-01"
+          },
+          "department": { "type": "string", "description": "학과", "example": "컴퓨터학부" },
+          "studentId": { "type": "string", "description": "학번", "example": 20210001 },
+          "parts": {
+            "type": "array",
+            "description": "소속 파트 목록",
+            "items": { "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse" }
+          },
+          "role": { "type": "string", "description": "역할", "example": "MEMBER" },
+          "nickname": { "type": "string", "description": "닉네임", "example": "piki(피키)" },
+          "state": { "type": "string", "description": "상태", "example": "활동" },
+          "joinDate": {
+            "type": "string",
+            "format": "date",
+            "description": "가입일",
+            "example": "2024-03-01"
+          },
+          "stateUpdatedTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "상태 변경 시간"
+          },
+          "createdTime": { "type": "string", "format": "date-time", "description": "생성 시간" },
+          "updatedTime": { "type": "string", "format": "date-time", "description": "수정 시간" }
+        },
+        "required": [
+          "birthDate",
+          "createdTime",
+          "department",
+          "email",
+          "joinDate",
+          "memberId",
+          "name",
+          "nickname",
+          "parts",
+          "phoneNumber",
+          "profileImageUrl",
+          "role",
+          "state",
+          "stateUpdatedTime",
+          "studentId",
+          "updatedTime"
+        ]
+      },
+      "LastMemberSyncTimeResponse": {
+        "type": "object",
+        "properties": { "lastUpdatedTime": { "type": "string", "format": "date-time" } }
+      },
+      "ReadInactiveMemberResponse": {
+        "type": "object",
+        "properties": {
+          "memberId": { "type": "integer", "format": "int64" },
+          "parts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse" }
+          },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "department": { "type": "string" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date" },
+          "joinDate": { "type": "string", "format": "date" },
+          "activePeriod": { "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse" },
+          "expectedReturnSemester": { "type": "string" },
+          "inactivePeriod": { "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse" },
+          "note": { "type": "string" }
+        },
+        "required": [
+          "activePeriod",
+          "birthDate",
+          "department",
+          "email",
+          "expectedReturnSemester",
+          "inactivePeriod",
+          "joinDate",
+          "memberId",
+          "name",
+          "nickname",
+          "note",
+          "parts",
+          "phoneNumber",
+          "role",
+          "state",
+          "studentId"
+        ]
+      },
+      "ReadSemesterPeriodInMemberResponse": {
+        "type": "object",
+        "properties": {
+          "startSemester": { "type": "string" },
+          "endSemester": { "type": "string" }
+        },
+        "required": ["endSemester", "startSemester"]
+      },
+      "ReadGraduatedMemberResponse": {
+        "type": "object",
+        "properties": {
+          "memberId": { "type": "integer", "format": "int64" },
+          "parts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse" }
+          },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "department": { "type": "string" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date" },
+          "joinDate": { "type": "string", "format": "date" },
+          "activePeriod": { "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse" },
+          "isAdvisorDesired": { "type": "boolean" },
+          "note": { "type": "string" }
+        },
+        "required": [
+          "activePeriod",
+          "birthDate",
+          "department",
+          "email",
+          "isAdvisorDesired",
+          "joinDate",
+          "memberId",
+          "name",
+          "nickname",
+          "note",
+          "parts",
+          "phoneNumber",
+          "role",
+          "state",
+          "studentId"
+        ]
+      },
+      "ReadActiveMemberResponse": {
+        "type": "object",
+        "properties": {
+          "memberId": { "type": "integer", "format": "int64" },
+          "parts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse" }
+          },
+          "role": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "state": { "type": "string" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "department": { "type": "string" },
+          "studentId": { "type": "string" },
+          "birthDate": { "type": "string", "format": "date" },
+          "joinDate": { "type": "string", "format": "date" },
+          "membershipFee": { "type": "boolean" },
+          "note": { "type": "string" }
+        },
+        "required": [
+          "birthDate",
+          "department",
+          "email",
+          "joinDate",
+          "memberId",
+          "membershipFee",
+          "name",
+          "nickname",
+          "note",
+          "parts",
+          "phoneNumber",
+          "role",
+          "state",
+          "studentId"
+        ]
+      },
+      "ReadDivisionResponse": {
+        "type": "object",
+        "properties": {
+          "divisionId": { "type": "integer", "format": "int64" },
+          "divisionName": { "type": "string" }
+        },
+        "required": ["divisionId", "divisionName"]
+      },
+      "ReadDepartmentsResponse": {
+        "type": "object",
+        "properties": {
+          "departmentId": { "type": "integer", "format": "int64" },
+          "departmentName": { "type": "string" }
+        },
+        "required": ["departmentId", "departmentName"]
+      },
+      "ReadCollegeResponse": {
+        "type": "object",
+        "properties": {
+          "collegeId": { "type": "integer", "format": "int64" },
+          "collegeName": { "type": "string" }
+        },
+        "required": ["collegeId", "collegeName"]
+      },
+      "ReadApplicantResponse": {
+        "type": "object",
+        "properties": {
+          "applicantId": { "type": "integer", "format": "int64" },
+          "division": { "type": "string" },
+          "part": { "type": "string" },
+          "name": { "type": "string" },
+          "state": { "type": "string" },
+          "applicationDate": { "type": "string", "format": "date" },
+          "email": { "type": "string" },
+          "phoneNumber": { "type": "string" },
+          "department": { "type": "string" },
+          "studentId": { "type": "string" },
+          "semester": { "type": "string" },
+          "age": { "type": "string" },
+          "availableTimes": {
+            "type": "array",
+            "items": { "type": "string", "format": "date-time" }
+          }
+        },
+        "required": [
+          "age",
+          "applicantId",
+          "applicationDate",
+          "availableTimes",
+          "department",
+          "division",
+          "email",
+          "name",
+          "part",
+          "phoneNumber",
+          "semester",
+          "state",
+          "studentId"
+        ]
+      },
+      "LastApplicantSyncTimeResponse": {
+        "type": "object",
+        "properties": { "lastUpdatedTime": { "type": "string", "format": "date-time" } }
+      },
+      "PageResponseReadMailTemplateSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReadMailTemplateSummaryResponse" }
+          },
+          "page": { "type": "integer", "format": "int32" },
+          "size": { "type": "integer", "format": "int32" },
+          "totalElements": { "type": "integer", "format": "int64" },
+          "totalPages": { "type": "integer", "format": "int32" }
+        },
+        "required": ["content", "page", "size", "totalElements", "totalPages"]
+      },
+      "ReadMailTemplateSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "title": { "type": "string" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "title", "updatedAt"]
+      },
+      "AttachmentReference": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "업로드된 파일 ID",
+            "example": 11
+          },
+          "fileName": { "type": "string", "description": "파일명", "example": "guide.pdf" },
+          "contentType": {
+            "type": "string",
+            "description": "파일 MIME 타입",
+            "example": "application/pdf"
+          },
+          "storageKey": {
+            "type": "string",
+            "description": "S3 저장 키",
+            "example": "mail-files/attachment/uuid-guide.pdf"
+          }
+        },
+        "required": ["contentType", "fileName", "storageKey"]
+      },
+      "DetailVariable": {
+        "type": "object",
+        "description": "템플릿 변수 정보",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "변수 키. var-{UUID} 형식",
+            "example": "var-550e8400-e29b-41d4-a716-446655440000"
+          },
+          "type": {
+            "type": "string",
+            "description": "변수 타입. PERSON, DATE, LINK, TEXT는 사용자 입력 변수. APPLICANT, PARTNAME은 자동 채움 변수",
+            "enum": ["PERSON", "DATE", "LINK", "TEXT", "APPLICANT", "PARTNAME"],
+            "example": "TEXT"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "변수 표시 이름",
+            "example": "면접 일시"
+          },
+          "perRecipient": {
+            "type": "boolean",
+            "description": "수신자별로 다른 값 입력 여부",
+            "example": true
+          }
+        },
+        "required": ["displayName", "key", "perRecipient", "type"]
+      },
+      "InlineImageReference": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "업로드된 파일 ID",
+            "example": 10
+          },
+          "contentId": {
+            "type": "string",
+            "description": "본문에서 사용하는 cid 값",
+            "example": "cid_logo"
+          },
+          "fileName": { "type": "string", "description": "파일명", "example": "logo.png" },
+          "contentType": {
+            "type": "string",
+            "description": "파일 MIME 타입",
+            "example": "image/png"
+          },
+          "storageKey": {
+            "type": "string",
+            "description": "S3 저장 키",
+            "example": "mail-files/inline/uuid-logo.png"
+          }
+        },
+        "required": ["contentId", "contentType", "fileName", "storageKey"]
+      },
+      "ReadMailTemplateDetailResponse": {
+        "type": "object",
+        "description": "메일 템플릿 상세 정보",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "description": "템플릿 ID", "example": 1 },
+          "title": { "type": "string", "description": "템플릿 제목", "example": "합격 안내 메일" },
+          "bodyHtml": {
+            "type": "string",
+            "description": "메일 본문 HTML",
+            "example": "<p>안녕하세요 {{var-550e8400-e29b-41d4-a716-446655440000}}님</p>"
+          },
+          "variables": {
+            "type": "array",
+            "description": "템플릿 변수 목록",
+            "items": { "$ref": "#/components/schemas/DetailVariable" }
+          },
+          "inlineImageReferences": {
+            "type": "array",
+            "description": "인라인 이미지 참조 목록",
+            "items": { "$ref": "#/components/schemas/InlineImageReference" }
+          },
+          "attachmentReferences": {
+            "type": "array",
+            "description": "첨부파일 참조 목록",
+            "items": { "$ref": "#/components/schemas/AttachmentReference" }
+          },
+          "updatedAt": { "type": "string", "format": "date-time", "description": "최종 수정 시간" }
+        },
+        "required": [
+          "attachmentReferences",
+          "bodyHtml",
+          "id",
+          "inlineImageReferences",
+          "title",
+          "updatedAt",
+          "variables"
+        ]
+      },
+      "MailFileListResponse": {
+        "type": "object",
+        "properties": {
+          "files": { "type": "array", "items": { "$ref": "#/components/schemas/MailFileSummary" } }
+        },
+        "required": ["files"]
+      },
+      "DeleteByPartResponse": {
+        "type": "object",
+        "properties": { "deletedCount": { "type": "integer", "format": "int32" } },
+        "required": ["deletedCount"]
+      }
+    },
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/auth",
+            "tokenUrl": "https://api.dev.scouter.yourssu.com/oauth2/swagger/callback",
+            "refreshUrl": "https://api.dev.scouter.yourssu.com/oauth2/swagger/callback",
+            "scopes": {
+              "openid": "OpenId Connect",
+              "profile": "기본 프로필 정보",
+              "email": "이메일 주소",
+              "https://www.googleapis.com/auth/drive.readonly": "드라이브 읽기 권한",
+              "https://www.googleapis.com/auth/forms.responses.readonly": "구글 폼 응답 읽기 권한",
+              "https://www.googleapis.com/auth/forms.body.readonly": "구글 폼 본문 읽기 권한",
+              "https://www.googleapis.com/auth/gmail.send": "메일 전송 권한"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepare:husky": "husky"
   },
   "dependencies": {
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-visually-hidden": "^1.2.3",
     "@tanstack/react-query": "^5.64.2",
     "@tanstack/react-query-devtools": "^5.71.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-visually-hidden':
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -573,6 +576,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-accessible-icon@1.1.3':
     resolution: {integrity: sha512-givBUIlhucV212j05wJCzXtcUtQnAwoUF9eAyUyOB2YwKHnWyme817trCtAzLjo0OndPr09kbkFe2onKRxLWdg==}
     peerDependencies:
@@ -614,6 +620,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.3':
     resolution: {integrity: sha512-2dvVU4jva0qkNZH6HHWuSz5FN5GeU5tymvCgutF8WaXz9WnD1NgUhy73cqzkjkN4Zkn8lfTPv5JIfrC221W+Nw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -743,6 +762,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.6':
     resolution: {integrity: sha512-7gpgMT2gyKym9Jz2ZhlRXSg2y6cNQIK8d/cqBZ0RBCaps8pFryCWXiUKI+uHGFrhMrbGUP7U6PWgiXzIxoyF3Q==}
     peerDependencies:
@@ -778,8 +810,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.1.3':
     resolution: {integrity: sha512-4XaDlq0bPt7oJwR+0k0clCiCO/7lO7NKZTAaJBYxDNQT/vj4ig0/UvctrRscZaFREpRvUTkpKR96ov1e6jptQg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -878,6 +932,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popover@1.1.7':
     resolution: {integrity: sha512-I38OYWDmJF2kbO74LX8UsFydSHWOJuQ7LxPnTefjxxvdvPLempvAnmsyX9UsBlywcbSGpRH7oMLfkUf+ij4nrw==}
     peerDependencies:
@@ -904,6 +971,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.5':
     resolution: {integrity: sha512-ps/67ZqsFm+Mb6lSPJpfhRLrVL2i2fntgCmGMqqth4eaGUf+knAuuRtWVJrNjUhExgmdRqftSgzpf0DF0n6yXA==}
     peerDependencies:
@@ -917,8 +997,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.3':
     resolution: {integrity: sha512-IrVLIhskYhH3nLvtcBLQFZr61tBG7wx7O3kEmdzcYwRGAEBmBicGGL7ATzNgruYJ3xBTbuzEEq9OXJM3PAX3tA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1167,6 +1273,24 @@ packages:
 
   '@radix-ui/react-use-controllable-state@1.1.1':
     resolution: {integrity: sha512-YnEXIy8/ga01Y1PN0VfaNH//MhA91JlEGVBDxDzROqwrAtG5Yr2QGEPz8A/rJA3C7ZAHryOYGaUv8fLSW2H/mg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4022,6 +4146,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-accessible-icon@1.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-visually-hidden': 1.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4065,6 +4191,15 @@ snapshots:
   '@radix-ui/react-arrow@1.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -4190,6 +4325,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.20
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
   '@radix-ui/react-dismissable-layer@1.1.6(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -4224,10 +4372,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.20
 
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
   '@radix-ui/react-focus-scope@1.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4348,6 +4513,29 @@ snapshots:
       '@types/react': 18.3.20
       '@types/react-dom': 18.3.6(@types/react@18.3.20)
 
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.20)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.6.3(@types/react@18.3.20)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
   '@radix-ui/react-popover@1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -4389,6 +4577,24 @@ snapshots:
       '@types/react': 18.3.20
       '@types/react-dom': 18.3.6(@types/react@18.3.20)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
   '@radix-ui/react-portal@1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4399,7 +4605,27 @@ snapshots:
       '@types/react': 18.3.20
       '@types/react-dom': 18.3.6(@types/react@18.3.20)
 
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
   '@radix-ui/react-presence@1.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
@@ -4681,6 +4907,21 @@ snapshots:
   '@radix-ui/react-use-controllable-state@1.1.1(@types/react@18.3.20)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.20

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSaveButton.tsx
@@ -1,13 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 import { BoxButton } from '@yourssu/design-system-react';
+import { isBefore } from 'date-fns';
 import { assert } from 'es-toolkit';
 
-import { useAlertDialog } from '@/hooks/useAlertDialog';
 import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
 import {
   useInterviewCalendarModeContext,
   useInterviewPartSelectionContext,
 } from '@/pages/Interview/context';
+import { useScheduleConfirmDialog } from '@/pages/Interview/hooks/useScheduleConfirmDialog';
 import { useInvalidateSchedule } from '@/query/schedule/hooks/useInvalidateSchedule';
 import { deletePartSchedule } from '@/query/schedule/mutations/deletePartSchedule';
 import { postSchedule } from '@/query/schedule/mutations/postSchedule';
@@ -21,7 +22,7 @@ export const AutoScheduleSaveButton = ({
   method,
   scheduleCandidate,
 }: AutoScheduleSaveButtonProps) => {
-  const openAlertDialog = useAlertDialog();
+  const { confirmScheduleSave } = useScheduleConfirmDialog();
   const { setCalendarMode } = useInterviewCalendarModeContext();
   const { partName, partId, onPartChange } = useInterviewPartSelectionContext();
   const { mutateAsync: mutatePostSchedule } = useMutation({
@@ -33,30 +34,47 @@ export const AutoScheduleSaveButton = ({
   const invalidateSchedule = useInvalidateSchedule(partId);
 
   const onSaveSchedule = async () => {
-    const result = await openAlertDialog({
-      title: '선택한 시간표를 저장할까요?',
-      content: `${partName} 팀 면접 시간표`,
-      primaryButtonText: '저장하기',
-      secondaryButtonText: '취소',
-    });
+    const now = new Date();
+    const pastSchedules = scheduleCandidate.schedules.filter((s) =>
+      isBefore(new Date(s.startTime), now),
+    );
 
-    if (result) {
-      assert(!!partId, '일정을 만들기 위한 partId가 없어요.');
-      await mutateDeletePartSchedule(partId);
-      await mutatePostSchedule({
-        schedules: scheduleCandidate.schedules.map((schedule) => ({
-          applicantId: schedule.applicantId,
-          endTime: schedule.endTime,
-          locationType: method === '대면' ? '동방' : '비대면',
-          partId,
-          startTime: schedule.startTime,
+    if (pastSchedules.length > 0) {
+      const pastResult = await confirmScheduleSave(
+        partName ?? '',
+        pastSchedules.map((s) => ({
+          applicantId: s.applicantId,
+          applicantName: s.applicantName,
+          endTime: s.endTime,
+          part: s.part,
+          startTime: s.startTime,
         })),
-      });
-      await invalidateSchedule();
-
-      onPartChange(null);
-      setCalendarMode('면접일정');
+      );
+      if (!pastResult) {
+        return;
+      }
+    } else {
+      const result = await confirmScheduleSave(partName ?? '', []);
+      if (!result) {
+        return;
+      }
     }
+
+    assert(!!partId, '일정을 만들기 위한 partId가 없어요.');
+    await mutateDeletePartSchedule(partId);
+    await mutatePostSchedule({
+      schedules: scheduleCandidate.schedules.map((schedule) => ({
+        applicantId: schedule.applicantId,
+        endTime: schedule.endTime,
+        locationType: method === '대면' ? '동방' : '비대면',
+        partId,
+        startTime: schedule.startTime,
+      })),
+    });
+    await invalidateSchedule();
+
+    onPartChange(null);
+    setCalendarMode('면접일정');
   };
 
   return (

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSaveButton.tsx
@@ -13,10 +13,14 @@ import { deletePartSchedule } from '@/query/schedule/mutations/deletePartSchedul
 import { postSchedule } from '@/query/schedule/mutations/postSchedule';
 
 interface AutoScheduleSaveButtonProps {
+  method: '대면' | '비대면';
   scheduleCandidate: AutoScheduleCandidate;
 }
 
-export const AutoScheduleSaveButton = ({ scheduleCandidate }: AutoScheduleSaveButtonProps) => {
+export const AutoScheduleSaveButton = ({
+  method,
+  scheduleCandidate,
+}: AutoScheduleSaveButtonProps) => {
   const openAlertDialog = useAlertDialog();
   const { setCalendarMode } = useInterviewCalendarModeContext();
   const { partName, partId, onPartChange } = useInterviewPartSelectionContext();
@@ -42,9 +46,10 @@ export const AutoScheduleSaveButton = ({ scheduleCandidate }: AutoScheduleSaveBu
       await mutatePostSchedule({
         schedules: scheduleCandidate.schedules.map((schedule) => ({
           applicantId: schedule.applicantId,
+          endTime: schedule.endTime,
+          locationType: method === '대면' ? '동방' : '비대면',
           partId,
           startTime: schedule.startTime,
-          endTime: schedule.endTime,
         })),
       });
       await invalidateSchedule();

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSaveButton.tsx
@@ -14,14 +14,10 @@ import { deletePartSchedule } from '@/query/schedule/mutations/deletePartSchedul
 import { postSchedule } from '@/query/schedule/mutations/postSchedule';
 
 interface AutoScheduleSaveButtonProps {
-  method: '대면' | '비대면';
   scheduleCandidate: AutoScheduleCandidate;
 }
 
-export const AutoScheduleSaveButton = ({
-  method,
-  scheduleCandidate,
-}: AutoScheduleSaveButtonProps) => {
+export const AutoScheduleSaveButton = ({ scheduleCandidate }: AutoScheduleSaveButtonProps) => {
   const { confirmScheduleSave } = useScheduleConfirmDialog();
   const { setCalendarMode } = useInterviewCalendarModeContext();
   const { partName, partId, onPartChange } = useInterviewPartSelectionContext();
@@ -66,7 +62,7 @@ export const AutoScheduleSaveButton = ({
       schedules: scheduleCandidate.schedules.map((schedule) => ({
         applicantId: schedule.applicantId,
         endTime: schedule.endTime,
-        locationType: method === '대면' ? '동방' : '비대면',
+        locationType: '동방',
         partId,
         startTime: schedule.startTime,
       })),

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
@@ -6,20 +6,15 @@ import { AutoScheduleSaveButton } from '@/pages/Interview/components/AutoSchedul
 import { AutoScheduleThumbnail } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleThumbnail';
 import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
-import { ManualScheduleSidebarMethodCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarMethodCard';
 
 interface AutoScheduleSidebarProps {
-  method: '대면' | '비대면';
   onCandidateChange: (v: AutoScheduleCandidate) => void;
-  onChangeMethod: (method: '대면' | '비대면') => void;
   scheduleCandidates: AutoScheduleCandidate[];
   selectedCandidate: AutoScheduleCandidate;
 }
 
 export const AutoScheduleSidebar = ({
-  method,
   onCandidateChange,
-  onChangeMethod,
   scheduleCandidates,
   selectedCandidate,
 }: AutoScheduleSidebarProps) => {
@@ -31,9 +26,6 @@ export const AutoScheduleSidebar = ({
 
   return (
     <InterviewSidebarLayout>
-      <InterviewSidebarLayout.CardList>
-        <ManualScheduleSidebarMethodCard method={method} onChangeMethod={onChangeMethod} />
-      </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.CardList title="생성된 시간표">
         <RadioGroup.Root onValueChange={onValueChange} value={selectedCandidate.id}>
           <div className="flex flex-col gap-5">
@@ -63,7 +55,7 @@ export const AutoScheduleSidebar = ({
         </RadioGroup.Root>
       </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
-        <AutoScheduleSaveButton method={method} scheduleCandidate={selectedCandidate} />
+        <AutoScheduleSaveButton scheduleCandidate={selectedCandidate} />
       </InterviewSidebarLayout.BottomArea>
     </InterviewSidebarLayout>
   );

--- a/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/AutoScheduleSidebar.tsx
@@ -6,16 +6,21 @@ import { AutoScheduleSaveButton } from '@/pages/Interview/components/AutoSchedul
 import { AutoScheduleThumbnail } from '@/pages/Interview/components/AutoScheduleMode/AutoScheduleThumbnail';
 import { AutoScheduleCandidate } from '@/pages/Interview/components/AutoScheduleMode/type';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+import { ManualScheduleSidebarMethodCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarMethodCard';
 
 interface AutoScheduleSidebarProps {
+  method: '대면' | '비대면';
   onCandidateChange: (v: AutoScheduleCandidate) => void;
+  onChangeMethod: (method: '대면' | '비대면') => void;
   scheduleCandidates: AutoScheduleCandidate[];
   selectedCandidate: AutoScheduleCandidate;
 }
 
 export const AutoScheduleSidebar = ({
-  scheduleCandidates,
+  method,
   onCandidateChange,
+  onChangeMethod,
+  scheduleCandidates,
   selectedCandidate,
 }: AutoScheduleSidebarProps) => {
   const onValueChange = (value: string) => {
@@ -26,6 +31,9 @@ export const AutoScheduleSidebar = ({
 
   return (
     <InterviewSidebarLayout>
+      <InterviewSidebarLayout.CardList>
+        <ManualScheduleSidebarMethodCard method={method} onChangeMethod={onChangeMethod} />
+      </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.CardList title="생성된 시간표">
         <RadioGroup.Root onValueChange={onValueChange} value={selectedCandidate.id}>
           <div className="flex flex-col gap-5">
@@ -55,7 +63,7 @@ export const AutoScheduleSidebar = ({
         </RadioGroup.Root>
       </InterviewSidebarLayout.CardList>
       <InterviewSidebarLayout.BottomArea>
-        <AutoScheduleSaveButton scheduleCandidate={selectedCandidate} />
+        <AutoScheduleSaveButton method={method} scheduleCandidate={selectedCandidate} />
       </InterviewSidebarLayout.BottomArea>
     </InterviewSidebarLayout>
   );

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -24,7 +24,6 @@ export const AutoScheduleMode = () => {
 
   const [selectedCandidate, setSelectedCandidate] =
     useState<AutoScheduleCandidate>(initialCandidate);
-  const [interviewMethod, setInterviewMethod] = useState<'대면' | '비대면'>('대면');
 
   return (
     <InterviewPageLayout
@@ -50,7 +49,6 @@ export const AutoScheduleMode = () => {
         ),
         sidebar: (
           <AutoScheduleSidebar
-            method={interviewMethod}
             onCandidateChange={(candidate) => {
               if (candidate.schedules.length > 0) {
                 const earliestSchedule = candidate.schedules.reduce((prev, curr) =>
@@ -62,7 +60,6 @@ export const AutoScheduleMode = () => {
               }
               setSelectedCandidate(candidate);
             }}
-            onChangeMethod={setInterviewMethod}
             scheduleCandidates={scheduleCandidates}
             selectedCandidate={selectedCandidate}
           />

--- a/src/pages/Interview/components/AutoScheduleMode/index.tsx
+++ b/src/pages/Interview/components/AutoScheduleMode/index.tsx
@@ -24,6 +24,7 @@ export const AutoScheduleMode = () => {
 
   const [selectedCandidate, setSelectedCandidate] =
     useState<AutoScheduleCandidate>(initialCandidate);
+  const [interviewMethod, setInterviewMethod] = useState<'대면' | '비대면'>('대면');
 
   return (
     <InterviewPageLayout
@@ -49,6 +50,7 @@ export const AutoScheduleMode = () => {
         ),
         sidebar: (
           <AutoScheduleSidebar
+            method={interviewMethod}
             onCandidateChange={(candidate) => {
               if (candidate.schedules.length > 0) {
                 const earliestSchedule = candidate.schedules.reduce((prev, curr) =>
@@ -60,6 +62,7 @@ export const AutoScheduleMode = () => {
               }
               setSelectedCandidate(candidate);
             }}
+            onChangeMethod={setInterviewMethod}
             scheduleCandidates={scheduleCandidates}
             selectedCandidate={selectedCandidate}
           />

--- a/src/pages/Interview/components/InterviewCalendar/InterviewCalendar.tsx
+++ b/src/pages/Interview/components/InterviewCalendar/InterviewCalendar.tsx
@@ -13,7 +13,7 @@ interface InterviewCalendarProps {
 export const InterviewCalendar = forwardRef<HTMLTableElement, InterviewCalendarProps>(
   ({ month, week, year, children }, ref) => {
     return (
-      <div className="flex-[1_1_0] overflow-y-auto pl-6">
+      <div className="flex-[1_1_0] overflow-y-auto pb-12 pl-6">
         <table className="w-full table-fixed border-collapse border-spacing-0" ref={ref}>
           <InterviewCalendarHead month={month} week={week} year={year} />
           <InterviewCalendarBody month={month} week={week} year={year}>

--- a/src/pages/Interview/components/InterviewPageLayout.tsx
+++ b/src/pages/Interview/components/InterviewPageLayout.tsx
@@ -34,10 +34,10 @@ export const InterviewPageLayout = ({
   return (
     <PageLayout title={title}>
       <div className="border-line-basicMedium border-b">
-        <div className="w-[70%] pr-6">{header}</div>
+        <div className="w-[80%] pr-6">{header}</div>
       </div>
       <div className="flex flex-[1_1_0] overflow-hidden">
-        <div className="flex w-[70%] min-w-0 flex-col pt-12 pr-6">{calendar}</div>
+        <div className="flex w-[80%] min-w-0 flex-col pt-12 pr-6">{calendar}</div>
         <div className="border-line-basicMedium flex-1 border-l">{sidebar}</div>
       </div>
     </PageLayout>

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleBlock.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleBlock.tsx
@@ -32,16 +32,28 @@ export const InterviewScheduleBlock = ({
   schedule,
   isFirstBlock = true,
 }: InterviewScheduleBlockProps) => {
+  const locationLabel = (() => {
+    const { locationType, locationDetail } = schedule;
+    if (locationType === '동방') {
+      return '동아리방';
+    }
+    if (locationType === '비대면') {
+      return locationDetail || '비대면';
+    }
+    return locationDetail || '';
+  })();
+
   return (
     <div className={container({ part: schedule.part })}>
       {isFirstBlock && (
         <>
           <div className="mb-1 truncate">
-            <span className="typo-c1_sb_13">{schedule.name} 님</span>{' '}
-            <span className="typo-c3_sb_11 text-text-basicTertiary">{schedule.part}</span>
+            <span className="typo-c1_sb_13">{schedule.name} 님</span>
+            <span className="typo-c3_sb_11 text-text-basicTertiary ml-1.5">{schedule.part}</span>
           </div>
           <div className="typo-c3_rg_11 text-text-basicTertiary truncate">
-            {formatTemplates['23:59'](schedule.startTime)}
+            <span>{formatTemplates['23:59'](schedule.startTime)}</span>
+            {locationLabel && <span className="ml-1.5">{locationLabel}</span>}
           </div>
         </>
       )}

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
@@ -1,8 +1,12 @@
+import { useMemo } from 'react';
+
+import { InterviewSidebarClassroomCard } from '@/pages/Interview/components/InterviewScheduleMode/InterviewSidebarClassroomCard';
 import { InterviewSidebarConflictCard } from '@/pages/Interview/components/InterviewScheduleMode/InterviewSidebarConflictCard';
 import { InterviewSidebarDownloadCard } from '@/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard';
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
 import { useConfilctScheduleGroups } from '@/pages/Interview/hooks/useConfilctScheduleGroups';
 import { Schedule } from '@/query/schedule/schema';
+import { formatTemplates } from '@/utils/date';
 
 interface InterviewScheduleSidebarProps {
   schedules: Schedule[];
@@ -11,9 +15,24 @@ interface InterviewScheduleSidebarProps {
 export const InterviewScheduleSidebar = ({ schedules }: InterviewScheduleSidebarProps) => {
   const confilctGroups = useConfilctScheduleGroups(schedules);
 
+  const classroomGroups = useMemo(() => {
+    const list = schedules.filter((s) => s.locationType === '강의실');
+    const groups: Record<string, Schedule[]> = {};
+    list.forEach((s) => {
+      const dateStr = formatTemplates['01/01(월)'](s.startTime);
+      if (!groups[dateStr]) {
+        groups[dateStr] = [];
+      }
+      groups[dateStr].push(s);
+    });
+    return Object.values(groups).sort(
+      (a, b) => new Date(a[0].startTime).getTime() - new Date(b[0].startTime).getTime(),
+    );
+  }, [schedules]);
+
   return (
     <InterviewSidebarLayout>
-      {confilctGroups.length > 0 && (
+      {confilctGroups.length > 0 ? (
         <div className="bg-bg-basicDefault border-line-basicMedium flex w-full shrink-0 flex-col items-start gap-1 border-b px-4 py-3">
           <div className="typo-t4_sb_18 flex items-center">
             <span className="text-text-basicSecondary">장소 겹침</span>
@@ -26,11 +45,26 @@ export const InterviewScheduleSidebar = ({ schedules }: InterviewScheduleSidebar
             HR 매니저는 겹치는 장소를 변경해주세요.
           </p>
         </div>
+      ) : (
+        classroomGroups.length > 0 && (
+          <div className="bg-bg-basicDefault border-line-basicMedium flex w-full shrink-0 flex-col items-start gap-1 border-b px-4 py-3">
+            <div className="typo-t4_sb_18 flex items-center">
+              <span className="text-text-basicSecondary">예약할 장소 목록</span>
+            </div>
+            <p className="typo-b2_rg_15 text-text-basicTertiary truncate">
+              HR 매니저는 아래 정보를 바탕으로 장소를 예약해 주세요
+            </p>
+          </div>
+        )
       )}
       <InterviewSidebarLayout.CardList>
-        {confilctGroups.map((group, i) => (
-          <InterviewSidebarConflictCard key={i} schedules={group} />
-        ))}
+        {confilctGroups.length > 0
+          ? confilctGroups.map((group, i) => (
+              <InterviewSidebarConflictCard key={i} schedules={group} />
+            ))
+          : classroomGroups.map((group, i) => (
+              <InterviewSidebarClassroomCard key={i} schedules={group} />
+            ))}
         <InterviewSidebarDownloadCard />
       </InterviewSidebarLayout.CardList>
     </InterviewSidebarLayout>

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
@@ -13,6 +13,20 @@ export const InterviewScheduleSidebar = ({ schedules }: InterviewScheduleSidebar
 
   return (
     <InterviewSidebarLayout>
+      {confilctGroups.length > 0 && (
+        <div className="bg-bg-basicDefault border-line-basicMedium flex w-full shrink-0 flex-col items-start gap-1 border-b px-4 py-3">
+          <div className="typo-t4_sb_18 flex items-center">
+            <span className="text-text-basicSecondary">장소 겹침</span>
+            <span className="text-text-brandSecondary whitespace-pre">
+              {' '}
+              {confilctGroups.length}건
+            </span>
+          </div>
+          <p className="typo-b2_rg_15 text-text-basicTertiary truncate">
+            HR 매니저는 겹치는 장소를 변경해주세요.
+          </p>
+        </div>
+      )}
       <InterviewSidebarLayout.CardList>
         {confilctGroups.map((group, i) => (
           <InterviewSidebarConflictCard key={i} schedules={group} />

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarClassroomCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarClassroomCard.tsx
@@ -9,7 +9,7 @@ import { scheduleOptions } from '@/query/schedule/options';
 import { Schedule } from '@/query/schedule/schema';
 import { formatTemplates } from '@/utils/date';
 
-interface InterviewSidebarConflictCardProps {
+interface InterviewSidebarClassroomCardProps {
   schedules: Schedule[];
 }
 
@@ -95,7 +95,9 @@ function LocationSelect({
   );
 }
 
-export const InterviewSidebarConflictCard = ({ schedules }: InterviewSidebarConflictCardProps) => {
+export const InterviewSidebarClassroomCard = ({
+  schedules,
+}: InterviewSidebarClassroomCardProps) => {
   const queryClient = useQueryClient();
   const [locations, setLocations] = useState<Record<number, ScheduleLocationState>>(() =>
     schedules.reduce(

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarConflictCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarConflictCard.tsx
@@ -1,7 +1,6 @@
-import { IcAlertTriangleFilled } from '@yourssu/design-system-react';
-import { Fragment as ReactFragment } from 'react/jsx-runtime';
+import { IcArrowsChevronDownLine, IcClockFilled } from '@yourssu/design-system-react';
+import { differenceInMinutes } from 'date-fns';
 
-import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
 import { Schedule } from '@/query/schedule/schema';
 import { formatTemplates } from '@/utils/date';
 
@@ -9,34 +8,64 @@ interface InterviewSidebarConflictCardProps {
   schedules: Schedule[];
 }
 
+function formatDuration(startTime: string, endTime: string) {
+  const diff = differenceInMinutes(endTime, startTime);
+  if (diff >= 60) {
+    const hours = Math.floor(diff / 60);
+    const mins = diff % 60;
+    return `${hours}시간${mins > 0 ? ` ${mins}분` : ''}`;
+  }
+  return `${diff}분`;
+}
+
 export const InterviewSidebarConflictCard = ({ schedules }: InterviewSidebarConflictCardProps) => {
+  if (!schedules.length) {
+    return null;
+  }
+
+  const dateStr = formatTemplates['01/01(월)'](schedules[0].startTime);
+
   return (
-    <InterviewSidebarCard>
-      <InterviewSidebarCard.Title
-        leftIcon={<IcAlertTriangleFilled className="text-icon-brandPrimary size-full" />}
-      >
-        겹치는 일정 주의
-      </InterviewSidebarCard.Title>
-      <InterviewSidebarCard.Content>
-        <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-3">
-          {schedules.map((schedule) => (
-            <ReactFragment key={schedule.id}>
-              <div className="typo-b3_sb_14">{schedule.part}</div>
-              <div className="flex w-full items-center gap-2">
-                <div className="typo-b2_rg_15 bg-bg-basicLight rounded-full px-3 py-2">
-                  {schedule.name}
+    <div className="bg-bg-basicDefault border-line-basicMedium flex w-full flex-col gap-4 rounded-[14px] border p-4">
+      <div className="flex w-full items-center justify-between">
+        <p className="typo-b1_sb_16 text-text-basicSecondary truncate">{dateStr}</p>
+      </div>
+
+      <div className="flex w-full flex-col items-center gap-5">
+        {schedules.map((schedule) => (
+          <div className="flex w-full flex-col items-start gap-2" key={schedule.id}>
+            <div className="flex w-full items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="bg-bg-basicLight flex h-8 shrink-0 items-center justify-center rounded-[40px] px-3">
+                  <span className="typo-b3_rg_14 text-text-basicSecondary text-center">
+                    {schedule.name}
+                  </span>
                 </div>
-                <div className="typo-b1_rg_16 bg-bg-basicLight flex-1 rounded-xl p-3">
-                  {formatTemplates['01/01(월) 00:00'](schedule.startTime)}
+                <p className="typo-b3_sb_14 text-text-basicTertiary truncate">{schedule.part}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="typo-b2_rg_15 text-text-basicTertiary truncate">
+                  {formatTemplates['23:59'](schedule.startTime)}~
+                  {formatTemplates['23:59'](schedule.endTime)}
+                </p>
+                <div className="bg-line-basicMedium h-[14px] w-px shrink-0" />
+                <div className="flex shrink-0 items-center gap-1">
+                  <IcClockFilled className="text-text-basicSecondary size-4" />
+                  <p className="typo-b3_sb_14 text-text-basicSecondary">
+                    {formatDuration(schedule.startTime, schedule.endTime)}
+                  </p>
                 </div>
               </div>
-            </ReactFragment>
-          ))}
-        </div>
-      </InterviewSidebarCard.Content>
-      <InterviewSidebarCard.Warning left="유어슈 동아리방">
-        사용이 겹쳐요! 다른 장소를 예약해주세요!
-      </InterviewSidebarCard.Warning>
-    </InterviewSidebarCard>
+            </div>
+            <div className="bg-bg-basicDefault border-line-basicMedium flex h-12 w-full shrink-0 items-center gap-1 rounded-xl border px-4">
+              <p className="typo-b1_sb_16 text-text-basicPrimary flex-1 whitespace-pre-wrap">
+                동아리방
+              </p>
+              <IcArrowsChevronDownLine className="size-5" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarDownloadCard.tsx
@@ -3,7 +3,6 @@ import { useLoading } from 'react-simplikit';
 
 import { useAlertDialog } from '@/hooks/useAlertDialog';
 import { useInterviewScheduleCalendarRefContext } from '@/pages/Interview/components/InterviewScheduleMode/context';
-import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
 
 export const InterviewSidebarDownloadCard = () => {
   const openAlertDialog = useAlertDialog();
@@ -40,14 +39,24 @@ export const InterviewSidebarDownloadCard = () => {
   };
 
   return (
-    <InterviewSidebarCard>
-      <InterviewSidebarCard.Title>면접 일정 저장</InterviewSidebarCard.Title>
-      <InterviewSidebarCard.Content>
-        면접 일정을 이미지로 다운로드 할 수 있어요.
-      </InterviewSidebarCard.Content>
-      <BoxButton disabled={loading} onClick={onClick} size="small" variant="filledPrimary">
+    <div className="bg-bg-basicDefault border-line-basicMedium flex w-full shrink-0 flex-col items-start gap-3 rounded-[14px] border p-4">
+      <div className="flex shrink-0 items-center">
+        <p className="typo-b1_sb_16 text-text-basicSecondary text-center">면접 일정 저장</p>
+      </div>
+      <div className="flex w-full shrink-0 flex-col py-2.5">
+        <p className="typo-b1_rg_16 text-text-basicTertiary truncate text-left">
+          Jpeg로 저장된 면접 일정을 다운로드 할 수 있어요!
+        </p>
+      </div>
+      <BoxButton
+        className="w-full"
+        disabled={loading}
+        onClick={onClick}
+        size="small"
+        variant="filledPrimary"
+      >
         {loading ? '시간표를 변환하고 있어요...' : '시간표 저장하기'}
       </BoxButton>
-    </InterviewSidebarCard>
+    </div>
   );
 };

--- a/src/pages/Interview/components/InterviewSidebarLayout.tsx
+++ b/src/pages/Interview/components/InterviewSidebarLayout.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import React from 'react';
 
 const BottomArea = ({ children }: React.PropsWithChildren<unknown>) => {
@@ -18,9 +17,7 @@ const CardList = ({ title, children }: React.PropsWithChildren<{ title?: string 
         </div>
       )}
       <div className="min-h-0 flex-[1_1_0] overflow-y-auto">
-        <div className={clsx('flex flex-col gap-2.5 px-5', title ? 'py-5' : 'py-12')}>
-          {children}
-        </div>
+        <div className="flex flex-col gap-2.5 px-5 py-5">{children}</div>
       </div>
     </div>
   );

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
@@ -16,11 +16,13 @@ import { postSchedule } from '@/query/schedule/mutations/postSchedule';
 
 interface ManualScheduleSaveButtonProps {
   completedApplicants: [Date, Applicant][];
+  method: '대면' | '비대면';
   totalApplicantCount: number;
 }
 
 export const ManualScheduleSaveButton = ({
   completedApplicants,
+  method,
   totalApplicantCount,
 }: ManualScheduleSaveButtonProps) => {
   const openAlertDialog = useAlertDialog();
@@ -58,9 +60,10 @@ export const ManualScheduleSaveButton = ({
       await mutatePostSchedule({
         schedules: completedApplicants.map(([date, applicant]) => ({
           applicantId: applicant.applicantId,
+          endTime: (duration === '1시간' ? addHours(date, 1) : addMinutes(date, 30)).toISOString(),
+          locationType: method === '대면' ? '동방' : '비대면',
           partId,
           startTime: date.toISOString(),
-          endTime: (duration === '1시간' ? addHours(date, 1) : addMinutes(date, 30)).toISOString(),
         })),
       });
       await invalidateSchedule();

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { BoxButton } from '@yourssu/design-system-react';
-import { addHours, addMinutes } from 'date-fns';
+import { addHours, addMinutes, isBefore } from 'date-fns';
 import { assert } from 'es-toolkit';
 
 import { useAlertDialog } from '@/hooks/useAlertDialog';
@@ -9,6 +9,7 @@ import {
   useInterviewCalendarModeContext,
   useInterviewPartSelectionContext,
 } from '@/pages/Interview/context';
+import { useScheduleConfirmDialog } from '@/pages/Interview/hooks/useScheduleConfirmDialog';
 import { Applicant } from '@/query/applicant/schema';
 import { useInvalidateSchedule } from '@/query/schedule/hooks/useInvalidateSchedule';
 import { deletePartSchedule } from '@/query/schedule/mutations/deletePartSchedule';
@@ -26,6 +27,7 @@ export const ManualScheduleSaveButton = ({
   totalApplicantCount,
 }: ManualScheduleSaveButtonProps) => {
   const openAlertDialog = useAlertDialog();
+  const { confirmScheduleSave } = useScheduleConfirmDialog();
   const { setCalendarMode } = useInterviewCalendarModeContext();
   const { partName, partId, onPartChange } = useInterviewPartSelectionContext();
   const { duration } = useInterviewAutoScheduleContext();
@@ -47,30 +49,55 @@ export const ManualScheduleSaveButton = ({
       return;
     }
 
-    const result = await openAlertDialog({
-      title: '이대로 면접 일정을 저장할까요?',
-      content: `${partName} 팀 면접 시간표`,
-      primaryButtonText: '저장하기',
-      secondaryButtonText: '취소',
-    });
+    const now = new Date();
+    const schedulesToSave = completedApplicants.map(([date, applicant]) => ({
+      applicantId: applicant.applicantId,
+      applicantName: applicant.name,
+      part: applicant.part,
+      endTime: (duration === '1시간' ? addHours(date, 1) : addMinutes(date, 30)).toISOString(),
+      locationType: method === '대면' ? '동방' : ('비대면' as '동방' | '비대면'),
+      partId,
+      startTime: date.toISOString(),
+    }));
 
-    if (result) {
-      assert(!!partId, '일정을 만들기 위한 partId가 없어요.');
-      await mutateDeletePartSchedule(partId);
-      await mutatePostSchedule({
-        schedules: completedApplicants.map(([date, applicant]) => ({
-          applicantId: applicant.applicantId,
-          endTime: (duration === '1시간' ? addHours(date, 1) : addMinutes(date, 30)).toISOString(),
-          locationType: method === '대면' ? '동방' : '비대면',
-          partId,
-          startTime: date.toISOString(),
+    const pastSchedules = schedulesToSave.filter((s) => isBefore(new Date(s.startTime), now));
+
+    if (pastSchedules.length > 0) {
+      const pastResult = await confirmScheduleSave(
+        partName ?? '',
+        pastSchedules.map((s) => ({
+          applicantId: s.applicantId,
+          applicantName: s.applicantName,
+          endTime: s.endTime,
+          part: s.part,
+          startTime: s.startTime,
         })),
-      });
-      await invalidateSchedule();
-
-      onPartChange(null);
-      setCalendarMode('면접일정');
+      );
+      if (!pastResult) {
+        return;
+      }
+    } else {
+      const result = await confirmScheduleSave(partName ?? '', []);
+      if (!result) {
+        return;
+      }
     }
+
+    assert(!!partId, '일정을 만들기 위한 partId가 없어요.');
+    await mutateDeletePartSchedule(partId);
+    await mutatePostSchedule({
+      schedules: schedulesToSave.map((schedule) => ({
+        applicantId: schedule.applicantId,
+        endTime: schedule.endTime,
+        locationType: schedule.locationType,
+        partId,
+        startTime: schedule.startTime,
+      })),
+    });
+    await invalidateSchedule();
+
+    onPartChange(null);
+    setCalendarMode('면접일정');
   };
 
   return (

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -1,6 +1,7 @@
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
 import { ManualScheduleSaveButton } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton';
 import { ManualScheduleSidebarDurationCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarDurationCard';
+import { ManualScheduleSidebarMethodCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarMethodCard';
 import { ManualScheduleSidebarPartCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard';
 import { ManualScheduleSidebarProgressCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
@@ -8,11 +9,15 @@ import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleSidebarProps {
   completedApplicants: [Date, Applicant][];
+  method: '대면' | '비대면';
+  onChangeMethod: (method: '대면' | '비대면') => void;
   totalApplicantCount: number;
 }
 
 export const ManualScheduleSidebar = ({
   completedApplicants,
+  method,
+  onChangeMethod,
   totalApplicantCount,
 }: ManualScheduleSidebarProps) => {
   const { partId } = useInterviewPartSelectionContext();
@@ -20,6 +25,7 @@ export const ManualScheduleSidebar = ({
     <InterviewSidebarLayout>
       <InterviewSidebarLayout.CardList>
         <ManualScheduleSidebarPartCard />
+        <ManualScheduleSidebarMethodCard method={method} onChangeMethod={onChangeMethod} />
         <ManualScheduleSidebarDurationCard />
         {partId && (
           <ManualScheduleSidebarProgressCard

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -37,6 +37,7 @@ export const ManualScheduleSidebar = ({
       <InterviewSidebarLayout.BottomArea>
         <ManualScheduleSaveButton
           completedApplicants={completedApplicants}
+          method={method}
           totalApplicantCount={totalApplicantCount}
         />
       </InterviewSidebarLayout.BottomArea>

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -29,7 +29,7 @@ export const ManualScheduleSidebar = ({
         <ManualScheduleSidebarDurationCard />
         {partId && (
           <ManualScheduleSidebarProgressCard
-            completedApplicants={completedApplicants.map(([, applicants]) => applicants)}
+            completedApplicants={completedApplicants}
             totalApplicantCount={totalApplicantCount}
           />
         )}

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarMethodCard.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarMethodCard.tsx
@@ -1,0 +1,128 @@
+import {
+  IcArrowsChevronDownLine,
+  IcArrowsChevronUpLine,
+  IcCameraFilled,
+  IcCheckFilled,
+  IcUserFilled,
+} from '@yourssu/design-system-react';
+import clsx from 'clsx';
+import { useState } from 'react';
+import { tv } from 'tailwind-variants';
+
+import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
+
+interface SelectHeaderProps {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  value: '대면' | '비대면';
+}
+
+interface SelectItemProps {
+  onSelect: (v: '대면' | '비대면') => void;
+  selected?: boolean;
+  value: '대면' | '비대면';
+}
+
+const item = tv({
+  slots: {
+    container: 'bg-bg-basicDefault flex w-full cursor-pointer items-center justify-between',
+    content: 'hover:bg-gray100/50 flex w-full items-center gap-2 rounded-lg py-1 pr-2 pl-1',
+    icon: 'text-icon-brandPrimary invisible size-4',
+  },
+  variants: {
+    selected: {
+      true: {
+        icon: 'visible',
+      },
+    },
+  },
+});
+
+const METHOD_ICONS = {
+  대면: IcUserFilled,
+  비대면: IcCameraFilled,
+};
+
+const SelectHeader = ({ onOpenChange, open, value }: SelectHeaderProps) => {
+  const ArrowIcon = open ? IcArrowsChevronUpLine : IcArrowsChevronDownLine;
+  const MethodIcon = METHOD_ICONS[value] || IcUserFilled;
+
+  return (
+    <InterviewSidebarCard.Title
+      className="cursor-pointer"
+      onClick={() => onOpenChange(!open)}
+      rightIcon={<ArrowIcon className="text-icon-basicSecondary size-6" />}
+    >
+      <div className="flex w-full flex-1 items-center gap-3">
+        <div className="typo-b1_sb_16 text-text-basicSecondary">면접 방식</div>
+        <div className="flex items-center">
+          <div className="text-icon-brandPrimary size-4">
+            <MethodIcon className="size-full" />
+          </div>
+          <div className="flex items-center justify-center px-2">
+            <p className="typo-b3_rg_14 text-text-brandPrimary">{value}</p>
+          </div>
+        </div>
+      </div>
+    </InterviewSidebarCard.Title>
+  );
+};
+
+const SelectItem = ({ value, selected, onSelect }: SelectItemProps) => {
+  const { container, content, icon } = item();
+  const MethodIcon = METHOD_ICONS[value] || IcUserFilled;
+
+  return (
+    <button className={container()} onClick={() => onSelect(value)}>
+      <div className={content()}>
+        <div className="flex items-center justify-center gap-2 pl-1">
+          <div className="text-icon-basicSecondary size-4">
+            <MethodIcon className="size-full" />
+          </div>
+          <span className="typo-b3_sb_14 text-text-basicSecondary">{value}</span>
+        </div>
+        {selected && (
+          <div className={clsx(icon({ selected }), 'flex flex-[1_1_0] items-center justify-end')}>
+            <IcCheckFilled className="size-4" />
+          </div>
+        )}
+      </div>
+    </button>
+  );
+};
+
+export interface ManualScheduleSidebarMethodCardProps {
+  method: '대면' | '비대면';
+  onChangeMethod: (method: '대면' | '비대면') => void;
+}
+
+export const ManualScheduleSidebarMethodCard = ({
+  method,
+  onChangeMethod,
+}: ManualScheduleSidebarMethodCardProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <InterviewSidebarCard>
+      <SelectHeader onOpenChange={setOpen} open={open} value={method} />
+      {open && (
+        <>
+          <div className="bg-line-basicMedium h-[1px] w-full" />
+          <div className="flex flex-col gap-1">
+            {(['대면', '비대면'] as const).map((v) => (
+              <SelectItem
+                key={v}
+                onSelect={(val) => {
+                  onChangeMethod(val);
+                  setOpen(false);
+                }}
+                selected={method === v}
+                value={v}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </InterviewSidebarCard>
+  );
+};

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard.tsx
@@ -29,7 +29,7 @@ interface SelectItemProps {
 const item = tv({
   slots: {
     container: 'flex w-full cursor-pointer items-center justify-between',
-    content: 'flex w-full items-center gap-2 rounded-lg px-2',
+    content: 'flex w-full items-center gap-2 rounded-lg pr-2',
     title: 'typo-b1_sb_16 text-text-basicSecondary',
     valueContainer: 'flex items-center',
     icon: 'text-icon-brandPrimary invisible size-4',

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard.tsx
@@ -1,8 +1,11 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
 import { InterviewSidebarCard } from '@/pages/Interview/components/InterviewSidebarCard';
 import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleSidebarProgressCardProps {
-  completedApplicants: Applicant[];
+  completedApplicants: [Date, Applicant][];
   totalApplicantCount: number;
 }
 
@@ -13,23 +16,27 @@ export const ManualScheduleSidebarProgressCard = ({
   return (
     <InterviewSidebarCard>
       <InterviewSidebarCard.Title>
-        입력완료 지원자{' '}
+        입력완료{' '}
         <span className="text-text-brandPrimary">
           ( {completedApplicants.length} / {totalApplicantCount} )
         </span>
       </InterviewSidebarCard.Title>
-      <InterviewSidebarCard.Content>
-        {completedApplicants.length
-          ? completedApplicants.map(({ name, applicantId }) => (
-              <div
-                className="typo-b2_rg_15 bg-chipUnselected inline-block rounded-full px-3 py-1.5"
-                key={applicantId}
-              >
+      {completedApplicants.length > 0 ? (
+        <div className="flex w-full flex-col gap-3">
+          {completedApplicants.map(([date, { name, applicantId }]) => (
+            <div className="flex h-10 w-full items-center gap-2" key={applicantId}>
+              <div className="typo-b3_rg_14 bg-chipUnselected text-text-basicSecondary flex items-center rounded-[40px] px-3 py-1.5">
                 {name}
               </div>
-            ))
-          : '지원자의 일정을 지정해주세요.'}
-      </InterviewSidebarCard.Content>
+              <p className="typo-b1_rg_16 text-text-basicPrimary overflow-hidden text-ellipsis whitespace-nowrap">
+                {format(date, 'MM/dd(E) HH:mm', { locale: ko })}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <InterviewSidebarCard.Content>지원자의 일정을 지정해주세요.</InterviewSidebarCard.Content>
+      )}
     </InterviewSidebarCard>
   );
 };

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -57,6 +57,7 @@ export const ManualScheduleMode = () => {
     initialEntries: initialScheduleEntries,
     precision: duration === '1시간' ? '시간' : '분',
   });
+  const [interviewMethod, setInterviewMethod] = useState<'대면' | '비대면'>('대면');
 
   useEffect(() => {
     completedScheduleMapAction.reset();
@@ -118,6 +119,8 @@ export const ManualScheduleMode = () => {
         sidebar: (
           <ManualScheduleSidebar
             completedApplicants={completedScheduleMap.entries()}
+            method={interviewMethod}
+            onChangeMethod={setInterviewMethod}
             totalApplicantCount={applicants.length}
           />
         ),

--- a/src/pages/Interview/hooks/useConfilctScheduleGroups.tsx
+++ b/src/pages/Interview/hooks/useConfilctScheduleGroups.tsx
@@ -6,7 +6,8 @@ import { Schedule } from '@/query/schedule/schema';
 type ConflictScheduleGroup = Schedule[];
 
 export const useConfilctScheduleGroups = (schedules: Schedule[]): ConflictScheduleGroup[] => {
-  const makeKey = (e: Schedule) => `${e.startTime}-${e.endTime}`;
+  const makeKey = (e: Schedule) =>
+    `${e.startTime}-${e.endTime}-${e.locationType}-${e.locationDetail || ''}`;
 
   const isSubset = useCallback((small: Schedule[], large: Schedule[]) => {
     const keySet = new Set(large.map((e) => makeKey(e)));
@@ -26,7 +27,14 @@ export const useConfilctScheduleGroups = (schedules: Schedule[]): ConflictSchedu
         if (seed.endTime <= target.startTime) {
           break;
         }
-        group.push(target);
+
+        const isSameLocation =
+          seed.locationType === target.locationType &&
+          (seed.locationDetail || '') === (target.locationDetail || '');
+
+        if (isSameLocation) {
+          group.push(target);
+        }
       }
 
       const hasConflict = group.length > 1;

--- a/src/pages/Interview/hooks/useScheduleConfirmDialog.tsx
+++ b/src/pages/Interview/hooks/useScheduleConfirmDialog.tsx
@@ -1,0 +1,67 @@
+import { compareAsc } from 'date-fns';
+
+import { useAlertDialog } from '@/hooks/useAlertDialog';
+import { formatTemplates } from '@/utils/date';
+
+interface PastScheduleInfo {
+  applicantId: number;
+  applicantName: string;
+  endTime: string;
+  part: string;
+  startTime: string;
+}
+
+export const useScheduleConfirmDialog = () => {
+  const openAlertDialog = useAlertDialog();
+
+  const confirmScheduleSave = async (partName: string, pastSchedules: PastScheduleInfo[]) => {
+    if (pastSchedules.length > 0) {
+      return await openAlertDialog({
+        title: '현재 시간보다 과거인 일정이 있어요',
+        content: (
+          <div className="flex w-full flex-col gap-4">
+            <span className="typo-b2_rg_15 text-text-basicSecondary">
+              과거인 일정이 포함되어 있어요. 이대로 저장하시겠어요?
+            </span>
+            <div className="flex max-h-[200px] w-full flex-col gap-5 overflow-y-auto">
+              {pastSchedules
+                .toSorted((a, b) => compareAsc(a.startTime, b.startTime))
+                .map((schedule) => (
+                  <div
+                    className="flex w-full items-center justify-between"
+                    key={`${schedule.applicantId}-${schedule.startTime}`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="bg-bg-basicLight flex h-8 shrink-0 items-center justify-center rounded-[40px] px-3">
+                        <span className="typo-b3_rg_14 text-text-basicSecondary text-center">
+                          {schedule.applicantName}
+                        </span>
+                      </div>
+                      <p className="typo-b3_sb_14 text-text-basicTertiary truncate">
+                        {schedule.part}
+                      </p>
+                    </div>
+                    <p className="typo-b2_rg_15 text-text-basicTertiary truncate">
+                      {formatTemplates['01/01(월) 00:00'](new Date(schedule.startTime))} ~{' '}
+                      {formatTemplates['23:59'](new Date(schedule.endTime))}
+                    </p>
+                  </div>
+                ))}
+            </div>
+          </div>
+        ),
+        primaryButtonText: '저장하기',
+        secondaryButtonText: '취소',
+      });
+    }
+
+    return await openAlertDialog({
+      title: '선택한 시간표를 저장할까요?',
+      content: `${partName} 팀 면접 시간표`,
+      primaryButtonText: '저장하기',
+      secondaryButtonText: '취소',
+    });
+  };
+
+  return { confirmScheduleSave };
+};

--- a/src/query/schedule/mutations/patchScheduleLocation.ts
+++ b/src/query/schedule/mutations/patchScheduleLocation.ts
@@ -1,0 +1,14 @@
+import { api } from '@/apis/api';
+import { LocationType } from '@/types/location';
+
+interface PatchScheduleLocationParams {
+  locationDetail?: string;
+  locationType: LocationType;
+  scheduleId: number;
+}
+
+export const patchScheduleLocation = ({ scheduleId, ...body }: PatchScheduleLocationParams) => {
+  return api.patch(`recruiter/schedule/${scheduleId}/location`, {
+    json: body,
+  });
+};

--- a/src/query/schedule/mutations/postSchedule.ts
+++ b/src/query/schedule/mutations/postSchedule.ts
@@ -1,11 +1,12 @@
 import { api } from '@/apis/api';
+import { LocationType } from '@/types/location';
 
 interface PostScheduleParams {
   schedules: Array<{
     applicantId: number;
     endTime: string;
     locationDetail?: string;
-    locationType: '강의실' | '기타' | '동방' | '비대면';
+    locationType: LocationType;
     partId: number;
     startTime: string;
   }>;

--- a/src/query/schedule/mutations/postSchedule.ts
+++ b/src/query/schedule/mutations/postSchedule.ts
@@ -4,6 +4,8 @@ interface PostScheduleParams {
   schedules: Array<{
     applicantId: number;
     endTime: string;
+    locationDetail?: string;
+    locationType: '강의실' | '기타' | '동방' | '비대면';
     partId: number;
     startTime: string;
   }>;

--- a/src/query/schedule/schema.ts
+++ b/src/query/schedule/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { locationTypes } from '@/types/location';
 import { partNames } from '@/types/part';
 
 export const ScheduleSchema = z.object({
@@ -8,6 +9,8 @@ export const ScheduleSchema = z.object({
   part: z.enum(partNames),
   startTime: z.string(),
   endTime: z.string(),
+  locationType: z.enum(locationTypes),
+  locationDetail: z.string().nullable(),
 });
 
 export const AutoScheduleSchema = z.object({

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -1,0 +1,3 @@
+export const locationTypes = ['동방', '비대면', '강의실', '기타'] as const;
+
+export type LocationType = (typeof locationTypes)[number];


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

[피그마](https://www.figma.com/design/HjonnCf2jKCRgw3DlzQf1v/Yourssu-Scouter?node-id=4573-48182&m=dev)에 명시된 모든 면접 장소 관련 UI와 기능을 구현했어요.

### 면접 장소

- 면접 일정 입력 완료 UI 변경 대응
- 캘린더 각 일정 블럭에 장소 렌더링
- 장소 겹침 UI 및 기능 구현 (선택 및 detail 텍스트 작성 가능)
- 강의실의 경우 예약할 장소 목록 렌더링

### 면접 일정 생성
- 면접 일정 생성시 백엔드에 장소 정보를 같이 보내도록 구현 (대면/비대면 선택까지)
- 방식 무관하게 일정 생성시 현재 시간 이전으로 지정된 일정들을 다이얼로그로 노출