### PR TITLE
feat: 파트 선택 여부에 따라 지원자 다이얼로그 다르게 뜨게 변경

### DIFF
--- a/src/pages/SendMail/components/MailInfoSection/ApplicantInputField.tsx
+++ b/src/pages/SendMail/components/MailInfoSection/ApplicantInputField.tsx
@@ -2,14 +2,21 @@ import { useRef, useState } from 'react';
 
 import { SearchedApplicantDialog } from '@/components/SearchedMemberDialog/SearchedApplicantDialog';
 import { InputChipGroup } from '@/pages/SendMail/components/MailInfoSection/InputChipGroup';
+import { Part } from '@/query/part/schema';
 
 interface ApplicantInputFieldProps {
   items: string[];
   label: string;
   onItemsUpdate: (items: string[]) => void;
+  selectedPart?: Part;
 }
 
-export const ApplicantInputField = ({ items, label, onItemsUpdate }: ApplicantInputFieldProps) => {
+export const ApplicantInputField = ({
+  items,
+  label,
+  onItemsUpdate,
+  selectedPart,
+}: ApplicantInputFieldProps) => {
   const [inputValue, setInputValue] = useState('');
   const [isActive, setIsActive] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -43,6 +50,7 @@ export const ApplicantInputField = ({ items, label, onItemsUpdate }: ApplicantIn
             onSearchTextChange={setInputValue} // 검색어 변경 핸들러 전달
             onSelect={handleSelect}
             searchText={inputValue} // 외부 검색어 전달
+            selectedPart={selectedPart}
             trigger={
               <input
                 className="typo-b1_rg_16 text-text-basicPrimary h-[36px] w-full flex-1 border-0 bg-transparent p-0 outline-none focus:ring-0"

--- a/src/pages/SendMail/components/MailInfoSection/AutoFillIMembers.tsx
+++ b/src/pages/SendMail/components/MailInfoSection/AutoFillIMembers.tsx
@@ -71,10 +71,18 @@ export const AutoFillMembers = ({
       const partReceivers = applicantsData.map((a) => a.name);
       const partBcc = [...partMembersData, ...hrMembersData].map((m) => m.nickname);
 
-      // 3. [기존 명단 + 새 명단]을 합치고 중복을 제거
+      // 3. 해당 파트가 아닌 지원자, 멤버는 삭제
+      const filteredReceivers = currentReceivers.filter((receiver) => {
+        return partReceivers.includes(receiver);
+      });
+      const filteredBcc = currentBcc.filter((bcc) => {
+        return partBcc.includes(bcc) || hrMembersData.some((hr) => hr.nickname === bcc); // HR 멤버는 항상 유지
+      });
+
+      // 4. [기존 명단 + 새 명단]을 합치고 중복을 제거
       onMembersUpdate({
-        '받는 사람': uniq([...currentReceivers, ...partReceivers]),
-        '숨은 참조': uniq([...currentBcc, ...partBcc]),
+        '받는 사람': uniq([...filteredReceivers, ...partReceivers]),
+        '숨은 참조': uniq([...filteredBcc, ...partBcc]),
       });
 
       isInitialized.current = true;
@@ -85,7 +93,7 @@ export const AutoFillMembers = ({
     onMembersUpdate,
     mailInfo.receiver,
     mailInfo.bcc,
-    selectedPart.partId,
+    selectedPart.partName,
     selectedTemplateId,
   ]);
 
@@ -100,6 +108,7 @@ export const AutoFillMembers = ({
         items={mailInfo.receiver || []}
         label="받는 사람"
         onItemsUpdate={(items: string[]) => onMembersUpdate({ '받는 사람': items })}
+        selectedPart={selectedPart}
       />
       <MemberInputField
         items={mailInfo.bcc || []}

--- a/src/utils/hangul.ts
+++ b/src/utils/hangul.ts
@@ -1,0 +1,24 @@
+// 초성 검색
+const CHO = [
+  'ㄱ',
+  'ㄲ',
+  'ㄴ',
+  'ㄷ',
+  'ㄸ',
+  'ㄹ',
+  'ㅁ',
+  'ㅂ',
+  'ㅃ',
+  'ㅅ',
+  'ㅆ',
+  'ㅇ',
+  'ㅈ',
+  'ㅉ',
+  'ㅊ',
+  'ㅋ',
+  'ㅌ',
+  'ㅍ',
+  'ㅎ',
+];
+export const getChosung = (str: string) =>
+  str.replace(/[가-힣]/g, (c) => CHO[Math.floor((c.charCodeAt(0) - 44032) / 588)]);


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- 파트 선택 전에는 지원자 다이얼로그에 전체 지원자가, 선택 후에는 해당 파트 지원자만 뜨게 함
- 파트 선택 전 추가한 지원자 중에서 실제로 해당 파트인 지원자만 남게 함
- 파트 선택 다이얼로그에서 초성으로도 정렬 되게 수정  
