### PR TITLE
feat: 하이어링 매니저는 멤버 테이블 마스킹 및 수정 불가하도록 구현

### DIFF
--- a/src/components/Cell/DepartmentCell.tsx
+++ b/src/components/Cell/DepartmentCell.tsx
@@ -7,11 +7,25 @@ import DepartmentSearchDialog from '@/components/DepartmentSearchDialog/Departme
 import { Tooltip } from '@/components/Tooltip/Tooltip.tsx';
 
 interface DepartmentCellProps extends PropsWithChildren {
+  disabled?: boolean;
   onSelect: (value: number) => void;
   tooltipContent: string;
 }
 
-const DepartmentCell = ({ tooltipContent, children, onSelect }: DepartmentCellProps) => {
+const DepartmentCell = ({
+  tooltipContent,
+  children,
+  onSelect,
+  disabled = false,
+}: DepartmentCellProps) => {
+  if (disabled) {
+    return (
+      <StyledContainer $bold={false} $editable={false}>
+        {children}
+      </StyledContainer>
+    );
+  }
+
   return (
     <Popover.Root>
       <Popover.Anchor>

--- a/src/components/Cell/InputCell.tsx
+++ b/src/components/Cell/InputCell.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from '@/components/Tooltip/Tooltip.tsx';
 interface InputCellProps extends PropsWithChildren {
   bold?: boolean;
   defaultValue: string;
+  disabled?: boolean;
   handleSubmit: (value: string) => void;
   tooltipContent: string;
 }
@@ -19,6 +20,7 @@ const InputCell = ({
   defaultValue,
   handleSubmit,
   bold = false,
+  disabled = false,
 }: InputCellProps) => {
   const [editing, setEditing] = useState(false);
   const { register, setFocus, watch } = useForm({
@@ -28,19 +30,22 @@ const InputCell = ({
   });
 
   useEffect(() => {
-    if (editing) {
+    if (editing && !disabled) {
       setFocus('value');
     }
-  }, [editing, setFocus]);
+  }, [editing, setFocus, disabled]);
 
   const onSubmit = () => {
+    if (disabled) {
+      return;
+    }
     handleSubmit(watch('value'));
     setEditing(false);
   };
 
   return (
-    <Cell bold={bold} editable={true}>
-      {editing ? (
+    <Cell bold={bold} editable={!disabled}>
+      {editing && !disabled ? (
         <StyledInput
           {...register('value')}
           $bold={bold}
@@ -55,11 +60,13 @@ const InputCell = ({
       ) : (
         <>
           <span>{children}</span>
-          <StyledEditIcon onClick={() => setEditing(true)}>
-            <Tooltip content={tooltipContent}>
-              <IcEditLine height={20} width={20} />
-            </Tooltip>
-          </StyledEditIcon>
+          {!disabled && (
+            <StyledEditIcon onClick={() => setEditing(true)}>
+              <Tooltip content={tooltipContent}>
+                <IcEditLine height={20} width={20} />
+              </Tooltip>
+            </StyledEditIcon>
+          )}
         </>
       )}
     </Cell>

--- a/src/components/Cell/PartsCell.tsx
+++ b/src/components/Cell/PartsCell.tsx
@@ -10,14 +10,23 @@ import { useElementWidth } from '@/hooks/useElementWidth.ts';
 import { partOptions } from '@/query/part/options.ts';
 
 interface PartsCellProps extends PropsWithChildren {
+  disabled?: boolean;
   onSelect: (value: string) => void;
   tooltipContent: string;
 }
 
-const PartsCell = ({ tooltipContent, children, onSelect }: PartsCellProps) => {
+const PartsCell = ({ tooltipContent, children, onSelect, disabled = false }: PartsCellProps) => {
   const { data: parts } = useSuspenseQuery(partOptions());
   const options = parts.map((part) => ({ label: part.partName }));
   const { width, ref } = useElementWidth();
+
+  if (disabled) {
+    return (
+      <StyledContainer $bold={false} $editable={false}>
+        {children}
+      </StyledContainer>
+    );
+  }
 
   return (
     <GenericDialog onSelect={onSelect} options={options} width={width}>

--- a/src/components/SearchedMemberDialog/SearchedMemberDialog.tsx
+++ b/src/components/SearchedMemberDialog/SearchedMemberDialog.tsx
@@ -49,7 +49,9 @@ export const SearchedMemberDialog = ({
   // 필터링
   const filteredMembers = useMemo(() => {
     // 제외할 멤버들을 먼저 걸러냄
-    const availableMembers = allMembers.filter((member) => !excludeItems.includes(member.nickname));
+    const availableMembers = allMembers.members.filter(
+      (member) => !excludeItems.includes(member.nickname),
+    );
 
     // 검색어 전처리 (공백 제거 및 소문자 변환)
     const term = currentSearchText.trim().toLowerCase();

--- a/src/components/StateButton/MemberStateButton.tsx
+++ b/src/components/StateButton/MemberStateButton.tsx
@@ -9,8 +9,10 @@ export const MemberStateButton = ({
   selectedValue,
   onStateChange,
   contentProps,
+  disabled = false,
 }: {
   contentProps?: Popover.PopoverContentProps;
+  disabled?: boolean;
   onStateChange: (value: string) => void;
   selectedValue: string;
 }) => {
@@ -20,6 +22,7 @@ export const MemberStateButton = ({
   return (
     <StateButton
       contentProps={contentProps}
+      disabled={disabled}
       onSelect={onStateChange}
       options={options}
       selectedValue={selectedValue}

--- a/src/components/StateButton/RoleStateButton.tsx
+++ b/src/components/StateButton/RoleStateButton.tsx
@@ -9,8 +9,10 @@ export const RoleStateButton = ({
   selectedValue,
   onStateChange,
   contentProps,
+  disabled = false,
 }: {
   contentProps?: Popover.PopoverContentProps;
+  disabled?: boolean;
   onStateChange: (value: string) => void;
   selectedValue: string;
 }) => {
@@ -20,6 +22,7 @@ export const RoleStateButton = ({
   return (
     <StateButton
       contentProps={contentProps}
+      disabled={disabled}
       onSelect={onStateChange}
       options={options}
       selectedValue={selectedValue}

--- a/src/components/StateButton/SemesterStateButton.tsx
+++ b/src/components/StateButton/SemesterStateButton.tsx
@@ -12,8 +12,10 @@ export const SemesterStateButton = ({
   onStateChange,
   size = 'small',
   contentProps,
+  disabled = false,
 }: {
   contentProps?: Popover.PopoverContentProps;
+  disabled?: boolean;
   onStateChange: (value: string) => void;
   selectedValue: string;
   size?: 'medium' | 'small';
@@ -33,6 +35,7 @@ export const SemesterStateButton = ({
   return (
     <StateButton
       contentProps={contentProps}
+      disabled={disabled}
       onSelect={onStateChange}
       options={options}
       rightIcon={<IcArrowsChevronDownLine />}

--- a/src/components/StateButton/StateButton.tsx
+++ b/src/components/StateButton/StateButton.tsx
@@ -12,6 +12,7 @@ export type DialogOption = {
 
 interface StateButtonProps {
   contentProps?: Popover.PopoverContentProps;
+  disabled?: boolean;
   leftIcon?: ReactNode;
   onSelect: (value: string) => void;
   options: DialogOption[];
@@ -32,20 +33,28 @@ export const StateButton = ({
   leftIcon,
   width,
   contentProps,
+  disabled = false,
 }: StateButtonProps) => {
+  const button = (
+    <StyledBoxButton
+      $selectedValue={selectedValue}
+      disabled={disabled}
+      leftIcon={leftIcon}
+      rightIcon={disabled ? undefined : rightIcon}
+      size={size}
+      variant={variant}
+    >
+      {selectedValue}
+    </StyledBoxButton>
+  );
+
+  if (disabled) {
+    return button;
+  }
+
   return (
     <GenericDialog contentProps={contentProps} onSelect={onSelect} options={options} width={width}>
-      <Popover.Trigger asChild>
-        <StyledBoxButton
-          $selectedValue={selectedValue}
-          leftIcon={leftIcon}
-          rightIcon={rightIcon}
-          size={size}
-          variant={variant}
-        >
-          {selectedValue}
-        </StyledBoxButton>
-      </Popover.Trigger>
+      <Popover.Trigger asChild>{button}</Popover.Trigger>
     </GenericDialog>
   );
 };

--- a/src/constants/uri.ts
+++ b/src/constants/uri.ts
@@ -3,4 +3,5 @@ export const MEMBER_URI = {
   비액티브: 'inactive',
   졸업: 'graduated',
   탈퇴: 'withdrawn',
+  수료: 'completed',
 } as const;

--- a/src/pages/Members/components/MemberTable/MemberTable.tsx
+++ b/src/pages/Members/components/MemberTable/MemberTable.tsx
@@ -45,11 +45,12 @@ const MemberTable = ({ state, search, partId }: MemberTableProps) => {
         position: 'center',
       });
     },
-    onError: () => {
+    onError: (e: any) => {
+      const message = e?.response?.data?.message ?? '입력 형식이 올바르지 않습니다.';
       snackbar({
         type: 'error',
         width: '400px',
-        message: '입력 형식이 올바르지 않습니다.',
+        message,
         duration: 3000,
         position: 'center',
       });

--- a/src/pages/Members/components/MemberTable/MemberTable.tsx
+++ b/src/pages/Members/components/MemberTable/MemberTable.tsx
@@ -31,7 +31,7 @@ const MemberTable = ({ state, search, partId }: MemberTableProps) => {
         await queryClient.prefetchQuery(memberOptions(params.state, { partId: null, search: '' }));
       }
 
-      const member = data.find((d) => d.memberId === memberId);
+      const member = data.members.find((d) => d.memberId === memberId);
 
       if (!member) {
         return;
@@ -57,6 +57,7 @@ const MemberTable = ({ state, search, partId }: MemberTableProps) => {
   });
 
   const { data } = useSuspenseQuery(memberOptions(state, { search, partId }));
+  const { members, isSensitiveMasked } = data;
 
   const handlePatchMember: PatchMemberHandler = (memberId, field, value) =>
     patchMemberMutate({
@@ -65,10 +66,10 @@ const MemberTable = ({ state, search, partId }: MemberTableProps) => {
       state,
     });
 
-  const columns = useMemberColumns(state, handlePatchMember);
+  const columns = useMemberColumns(state, isSensitiveMasked, handlePatchMember);
 
   const table = useReactTable({
-    data,
+    data: members,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/src/pages/Members/components/MemberTableFallback/MemberTableFallback.tsx
+++ b/src/pages/Members/components/MemberTableFallback/MemberTableFallback.tsx
@@ -9,7 +9,7 @@ interface MemberTableFallbackProps {
 }
 
 const MemberTableFallback = ({ state }: MemberTableFallbackProps) => {
-  const columns = useMemberColumns(state);
+  const columns = useMemberColumns(state, false);
 
   const table = useReactTable({
     data: [],

--- a/src/pages/SendMail/components/MailInfoSection/AutoFillIMembers.tsx
+++ b/src/pages/SendMail/components/MailInfoSection/AutoFillIMembers.tsx
@@ -58,9 +58,11 @@ export const AutoFillMembers = ({
       return;
     }
 
-    const applicantsData = results[0].data;
-    const partMembersData = results[1].data;
-    const hrMembersData = isSelectedPartHR ? partMembersData : (results[2]?.data ?? []);
+    const applicantsData = results[0].data as unknown as any[];
+    const partMembersData = (results[1].data as unknown as any).members as any[];
+    const hrMembersData = isSelectedPartHR
+      ? partMembersData
+      : ((results[2]?.data as unknown as any)?.members ?? []);
 
     if (applicantsData && partMembersData && !selectedTemplateId) {
       // 1. 현재 컨텍스트에 담긴 '이미 선택된 명단'을 가져옴
@@ -76,7 +78,7 @@ export const AutoFillMembers = ({
         return partReceivers.includes(receiver);
       });
       const filteredBcc = currentBcc.filter((bcc) => {
-        return partBcc.includes(bcc) || hrMembersData.some((hr) => hr.nickname === bcc); // HR 멤버는 항상 유지
+        return partBcc.includes(bcc) || hrMembersData.some((hr: any) => hr.nickname === bcc); // HR 멤버는 항상 유지
       });
 
       // 4. [기존 명단 + 새 명단]을 합치고 중복을 제거

--- a/src/pages/SendMail/hooks/useMailReservation.ts
+++ b/src/pages/SendMail/hooks/useMailReservation.ts
@@ -36,7 +36,7 @@ export const useMailActions = () => {
     }
 
     // 멤버에서 찾기
-    const member = allMembers?.find((m) => m.nickname === name);
+    const member = allMembers?.members.find((m) => m.nickname === name);
     if (member) {
       return member.email;
     }

--- a/src/query/member/hooks/useMemberColumns.tsx
+++ b/src/query/member/hooks/useMemberColumns.tsx
@@ -24,7 +24,11 @@ export type PatchMemberHandler = (
   value: unknown,
 ) => void;
 
-export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMemberHandler) => {
+export const useMemberColumns = (
+  state: MemberState,
+  isSensitiveMasked: boolean,
+  handlePatchMember?: PatchMemberHandler,
+) => {
   const [{ data: partWithIds }, { data: semesters }] = useSuspenseQueries({
     queries: [partOptions(), semesterOptions()],
   });
@@ -176,23 +180,27 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
       ),
       size: 235,
     }),
-    columnHelper.accessor('phoneNumber', {
-      header: '연락처',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue()}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'phoneNumber', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </InputCell>
-      ),
-      size: 175,
-    }),
+    ...(!isSensitiveMasked
+      ? [
+          columnHelper.accessor('phoneNumber', {
+            header: '연락처',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? ''}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'phoneNumber', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? ''}
+              </InputCell>
+            ),
+            size: 175,
+          }),
+        ]
+      : []),
     columnHelper.accessor('department', {
       header: '전공',
       cell: (info) => (
@@ -209,40 +217,44 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
       ),
       size: 260,
     }),
-    columnHelper.accessor('studentId', {
-      header: '학번',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue()}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'studentId', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </InputCell>
-      ),
-      size: 136,
-    }),
-    columnHelper.accessor('birthDate', {
-      header: '생년월일',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue()}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'birthDate', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </InputCell>
-      ),
-      size: 142,
-    }),
+    ...(!isSensitiveMasked
+      ? [
+          columnHelper.accessor('studentId', {
+            header: '학번',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? ''}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'studentId', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? ''}
+              </InputCell>
+            ),
+            size: 136,
+          }),
+          columnHelper.accessor('birthDate', {
+            header: '생년월일',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? ''}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'birthDate', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? ''}
+              </InputCell>
+            ),
+            size: 142,
+          }),
+        ]
+      : []),
     columnHelper.accessor('joinDate', {
       header: '가입일',
       cell: (info) => (
@@ -260,7 +272,7 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
       ),
       size: 142,
     }),
-    ...(state === '액티브'
+    ...(state === '액티브' && !isSensitiveMasked
       ? [
           columnHelper.accessor('membershipFee', {
             header: () => (
@@ -307,13 +319,13 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
           }),
         ]
       : []),
-    ...(state === '비액티브' || state === '졸업'
+    ...((state === '비액티브' || state === '졸업') && !isSensitiveMasked
       ? [
           columnHelper.accessor('activePeriod', {
             header: '활동 기간',
             cell: (info) => {
               const member = info.row.original;
-              if (member.state === '비액티브' || member.state === '졸업') {
+              if ((member.state === '비액티브' || member.state === '졸업') && member.activePeriod) {
                 return (
                   <Cell>
                     <div
@@ -343,7 +355,7 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
           }),
         ]
       : []),
-    ...(state === '비액티브'
+    ...(state === '비액티브' && !isSensitiveMasked
       ? [
           columnHelper.accessor('expectedReturnSemester', {
             header: '복귀 희망 학기',
@@ -366,7 +378,7 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
                           );
                         }
                       }}
-                      selectedValue={member.expectedReturnSemester}
+                      selectedValue={member.expectedReturnSemester ?? ''}
                     />
                   </Cell>
                 );
@@ -376,13 +388,13 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
           }),
         ]
       : []),
-    ...(state === '비액티브'
+    ...(state === '비액티브' && !isSensitiveMasked
       ? [
           columnHelper.accessor('inactivePeriod', {
             header: '비액티브 기간',
             cell: (info) => {
               const member = info.row.original;
-              if (member.state === '비액티브') {
+              if (member.state === '비액티브' && member.inactivePeriod) {
                 return (
                   <Cell>
                     <div
@@ -413,7 +425,7 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
           }),
         ]
       : []),
-    ...(state === '졸업'
+    ...(state === '졸업' && !isSensitiveMasked
       ? [
           columnHelper.accessor('isAdvisorDesired', {
             header: '어드바이저 희망',
@@ -449,22 +461,26 @@ export const useMemberColumns = (state: MemberState, handlePatchMember?: PatchMe
           }),
         ]
       : []),
-    columnHelper.accessor('note', {
-      header: '비고',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue()}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'note', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </InputCell>
-      ),
-      size: 216,
-    }),
-  ];
+    ...(!isSensitiveMasked
+      ? [
+          columnHelper.accessor('note', {
+            header: '비고',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? ''}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'note', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? ''}
+              </InputCell>
+            ),
+            size: 216,
+          }),
+        ]
+      : []),
+  ] as any[];
 };

--- a/src/query/member/hooks/useMemberColumns.tsx
+++ b/src/query/member/hooks/useMemberColumns.tsx
@@ -57,6 +57,7 @@ export const useMemberColumns = (
         const parts = info.getValue();
         return (
           <PartsCell
+            disabled={isSensitiveMasked}
             onSelect={(value) => {
               const included = parts.some((p) => p.part === value);
               if (handlePatchMember) {
@@ -97,6 +98,7 @@ export const useMemberColumns = (
               contentProps={{
                 align: 'start',
               }}
+              disabled={isSensitiveMasked}
               onStateChange={(state) => {
                 if (handlePatchMember) {
                   handlePatchMember(info.row.original.memberId, 'role', state);
@@ -114,6 +116,7 @@ export const useMemberColumns = (
       cell: (info) => (
         <InputCell
           defaultValue={info.getValue()}
+          disabled={isSensitiveMasked}
           handleSubmit={(value) => {
             if (handlePatchMember) {
               handlePatchMember(info.row.original.memberId, 'name', value);
@@ -132,6 +135,7 @@ export const useMemberColumns = (
         <InputCell
           bold={true}
           defaultValue={info.getValue()}
+          disabled={isSensitiveMasked}
           handleSubmit={(value) => {
             if (handlePatchMember) {
               handlePatchMember(info.row.original.memberId, 'nickname', value);
@@ -152,6 +156,7 @@ export const useMemberColumns = (
             contentProps={{
               align: 'start',
             }}
+            disabled={isSensitiveMasked}
             onStateChange={(value) => {
               if (handlePatchMember) {
                 handlePatchMember(info.row.original.memberId, 'state', value);
@@ -168,6 +173,7 @@ export const useMemberColumns = (
       cell: (info) => (
         <InputCell
           defaultValue={info.getValue()}
+          disabled={isSensitiveMasked}
           handleSubmit={(value) => {
             if (handlePatchMember) {
               handlePatchMember(info.row.original.memberId, 'email', value);
@@ -180,31 +186,29 @@ export const useMemberColumns = (
       ),
       size: 235,
     }),
-    ...(!isSensitiveMasked
-      ? [
-          columnHelper.accessor('phoneNumber', {
-            header: '연락처',
-            cell: (info) => (
-              <InputCell
-                defaultValue={info.getValue() ?? ''}
-                handleSubmit={(value) => {
-                  if (handlePatchMember) {
-                    handlePatchMember(info.row.original.memberId, 'phoneNumber', value);
-                  }
-                }}
-                tooltipContent={`${info.row.original.name} 정보 수정`}
-              >
-                {info.getValue() ?? ''}
-              </InputCell>
-            ),
-            size: 175,
-          }),
-        ]
-      : []),
+    columnHelper.accessor('phoneNumber', {
+      header: '연락처',
+      cell: (info) => (
+        <InputCell
+          defaultValue={info.getValue() ?? '010-****-****'}
+          disabled={isSensitiveMasked}
+          handleSubmit={(value) => {
+            if (handlePatchMember) {
+              handlePatchMember(info.row.original.memberId, 'phoneNumber', value);
+            }
+          }}
+          tooltipContent={`${info.row.original.name} 정보 수정`}
+        >
+          {info.getValue() ?? '010-****-****'}
+        </InputCell>
+      ),
+      size: 175,
+    }),
     columnHelper.accessor('department', {
       header: '전공',
       cell: (info) => (
         <DepartmentCell
+          disabled={isSensitiveMasked}
           onSelect={(value) => {
             if (handlePatchMember) {
               handlePatchMember(info.row.original.memberId, 'departmentId', value);
@@ -217,49 +221,48 @@ export const useMemberColumns = (
       ),
       size: 260,
     }),
-    ...(!isSensitiveMasked
-      ? [
-          columnHelper.accessor('studentId', {
-            header: '학번',
-            cell: (info) => (
-              <InputCell
-                defaultValue={info.getValue() ?? ''}
-                handleSubmit={(value) => {
-                  if (handlePatchMember) {
-                    handlePatchMember(info.row.original.memberId, 'studentId', value);
-                  }
-                }}
-                tooltipContent={`${info.row.original.name} 정보 수정`}
-              >
-                {info.getValue() ?? ''}
-              </InputCell>
-            ),
-            size: 136,
-          }),
-          columnHelper.accessor('birthDate', {
-            header: '생년월일',
-            cell: (info) => (
-              <InputCell
-                defaultValue={info.getValue() ?? ''}
-                handleSubmit={(value) => {
-                  if (handlePatchMember) {
-                    handlePatchMember(info.row.original.memberId, 'birthDate', value);
-                  }
-                }}
-                tooltipContent={`${info.row.original.name} 정보 수정`}
-              >
-                {info.getValue() ?? ''}
-              </InputCell>
-            ),
-            size: 142,
-          }),
-        ]
-      : []),
+    columnHelper.accessor('studentId', {
+      header: '학번',
+      cell: (info) => (
+        <InputCell
+          defaultValue={info.getValue() ?? '********'}
+          disabled={isSensitiveMasked}
+          handleSubmit={(value) => {
+            if (handlePatchMember) {
+              handlePatchMember(info.row.original.memberId, 'studentId', value);
+            }
+          }}
+          tooltipContent={`${info.row.original.name} 정보 수정`}
+        >
+          {info.getValue() ?? '********'}
+        </InputCell>
+      ),
+      size: 136,
+    }),
+    columnHelper.accessor('birthDate', {
+      header: '생년월일',
+      cell: (info) => (
+        <InputCell
+          defaultValue={info.getValue() ?? '********'}
+          disabled={isSensitiveMasked}
+          handleSubmit={(value) => {
+            if (handlePatchMember) {
+              handlePatchMember(info.row.original.memberId, 'birthDate', value);
+            }
+          }}
+          tooltipContent={`${info.row.original.name} 정보 수정`}
+        >
+          {info.getValue() ?? '********'}
+        </InputCell>
+      ),
+      size: 142,
+    }),
     columnHelper.accessor('joinDate', {
       header: '가입일',
       cell: (info) => (
         <InputCell
           defaultValue={info.getValue()}
+          disabled={isSensitiveMasked}
           handleSubmit={(value) => {
             if (handlePatchMember) {
               handlePatchMember(info.row.original.memberId, 'joinDate', value);
@@ -298,6 +301,7 @@ export const useMemberColumns = (
                   }}
                 >
                   <Checkbox
+                    disabled={isSensitiveMasked}
                     onChange={(e) => {
                       if (handlePatchMember) {
                         handlePatchMember(
@@ -319,13 +323,21 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...((state === '비액티브' || state === '졸업') && !isSensitiveMasked
+    ...(state === '비액티브' || state === '졸업' || state === '수료'
       ? [
           columnHelper.accessor('activePeriod', {
             header: '활동 기간',
             cell: (info) => {
               const member = info.row.original;
-              if ((member.state === '비액티브' || member.state === '졸업') && member.activePeriod) {
+              if (
+                member.state === '비액티브' ||
+                member.state === '졸업' ||
+                member.state === '수료'
+              ) {
+                const activePeriod = member.activePeriod || {
+                  startSemester: '****-*',
+                  endSemester: '****-*',
+                };
                 return (
                   <Cell>
                     <div
@@ -336,7 +348,7 @@ export const useMemberColumns = (
                       }}
                     >
                       <ActivePeriod size="small" variant="filledSecondary">
-                        {member.activePeriod.startSemester}
+                        {activePeriod.startSemester}
                       </ActivePeriod>
                       ~
                       <ActivePeriod
@@ -344,7 +356,7 @@ export const useMemberColumns = (
                         style={{ pointerEvents: 'none' }}
                         variant="filledSecondary"
                       >
-                        {member.activePeriod.endSemester}
+                        {activePeriod.endSemester}
                       </ActivePeriod>
                     </div>
                   </Cell>
@@ -355,7 +367,7 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...(state === '비액티브' && !isSensitiveMasked
+    ...(state === '비액티브'
       ? [
           columnHelper.accessor('expectedReturnSemester', {
             header: '복귀 희망 학기',
@@ -368,6 +380,7 @@ export const useMemberColumns = (
                       contentProps={{
                         align: 'start',
                       }}
+                      disabled={isSensitiveMasked}
                       onStateChange={(value) => {
                         const semesterId = semesters.find((s) => s.semester === value)?.semesterId;
                         if (semesterId && handlePatchMember) {
@@ -378,7 +391,7 @@ export const useMemberColumns = (
                           );
                         }
                       }}
-                      selectedValue={member.expectedReturnSemester ?? ''}
+                      selectedValue={member.expectedReturnSemester ?? '****-*'}
                     />
                   </Cell>
                 );
@@ -388,13 +401,17 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...(state === '비액티브' && !isSensitiveMasked
+    ...(state === '비액티브'
       ? [
           columnHelper.accessor('inactivePeriod', {
             header: '비액티브 기간',
             cell: (info) => {
               const member = info.row.original;
-              if (member.state === '비액티브' && member.inactivePeriod) {
+              if (member.state === '비액티브') {
+                const inactivePeriod = member.inactivePeriod || {
+                  startSemester: '****-*',
+                  endSemester: '****-*',
+                };
                 return (
                   <Cell>
                     <div
@@ -405,7 +422,7 @@ export const useMemberColumns = (
                       }}
                     >
                       <InactivePeriod disabled size="small" variant="filledSecondary">
-                        {member.inactivePeriod.startSemester}
+                        {inactivePeriod.startSemester}
                       </InactivePeriod>
                       ~
                       <InactivePeriod
@@ -414,7 +431,7 @@ export const useMemberColumns = (
                         style={{ pointerEvents: 'none' }}
                         variant="filledSecondary"
                       >
-                        {member.inactivePeriod.endSemester}
+                        {inactivePeriod.endSemester}
                       </InactivePeriod>
                     </div>
                   </Cell>
@@ -425,7 +442,7 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...(state === '졸업' && !isSensitiveMasked
+    ...((state === '졸업' || state === '수료') && !isSensitiveMasked
       ? [
           columnHelper.accessor('isAdvisorDesired', {
             header: '어드바이저 희망',
@@ -440,6 +457,7 @@ export const useMemberColumns = (
                   }}
                 >
                   <Checkbox
+                    disabled={isSensitiveMasked}
                     onChange={(e) => {
                       if (handlePatchMember) {
                         handlePatchMember(
@@ -461,26 +479,23 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...(!isSensitiveMasked
-      ? [
-          columnHelper.accessor('note', {
-            header: '비고',
-            cell: (info) => (
-              <InputCell
-                defaultValue={info.getValue() ?? ''}
-                handleSubmit={(value) => {
-                  if (handlePatchMember) {
-                    handlePatchMember(info.row.original.memberId, 'note', value);
-                  }
-                }}
-                tooltipContent={`${info.row.original.name} 정보 수정`}
-              >
-                {info.getValue() ?? ''}
-              </InputCell>
-            ),
-            size: 216,
-          }),
-        ]
-      : []),
+    columnHelper.accessor('note', {
+      header: '비고',
+      cell: (info) => (
+        <InputCell
+          defaultValue={info.getValue() ?? '********'}
+          disabled={isSensitiveMasked}
+          handleSubmit={(value) => {
+            if (handlePatchMember) {
+              handlePatchMember(info.row.original.memberId, 'note', value);
+            }
+          }}
+          tooltipContent={`${info.row.original.name} 정보 수정`}
+        >
+          {info.getValue() ?? '********'}
+        </InputCell>
+      ),
+      size: 216,
+    }),
   ] as any[];
 };

--- a/src/query/member/options.ts
+++ b/src/query/member/options.ts
@@ -2,7 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import { api } from '@/apis/api.ts';
 import { MEMBER_URI } from '@/constants/uri.ts';
-import { MemberArraySchema, MemberState } from '@/query/member/schema.ts';
+import { MemberResponseSchema, MemberState } from '@/query/member/schema.ts';
 
 type MemberQueryParams = {
   partId: null | number;
@@ -24,7 +24,7 @@ export const memberOptions = (state: MemberState, params?: MemberQueryParams) =>
         },
       });
       const data = await res.json();
-      return MemberArraySchema.parse(data);
+      return MemberResponseSchema.parse(data);
     },
   });
 };

--- a/src/query/member/schema.ts
+++ b/src/query/member/schema.ts
@@ -56,6 +56,12 @@ const GraduatedMemberSchema = BaseMemberSchema.extend({
   state: z.literal('졸업'),
 });
 
+const CompletedMemberSchema = BaseMemberSchema.extend({
+  activePeriod: PeriodSchema.nullable(),
+  isAdvisorDesired: z.boolean().nullable(),
+  state: z.literal('수료'),
+});
+
 const WithdrawnMemberSchema = BaseMemberSchema.extend({
   state: z.literal('탈퇴'),
 });
@@ -65,6 +71,7 @@ const MemberSchema = z.discriminatedUnion('state', [
   InactiveMemberSchema,
   GraduatedMemberSchema,
   WithdrawnMemberSchema,
+  CompletedMemberSchema,
 ]);
 
 export const PatchMemberSchema = z
@@ -73,6 +80,7 @@ export const PatchMemberSchema = z
   .merge(InactiveMemberSchema)
   .merge(GraduatedMemberSchema)
   .merge(WithdrawnMemberSchema)
+  .merge(CompletedMemberSchema)
   .omit({
     memberId: true,
     state: true,

--- a/src/query/member/schema.ts
+++ b/src/query/member/schema.ts
@@ -14,7 +14,7 @@ const PeriodSchema = z.object({
 
 const MemberRoleSchema = z.enum(['Lead', 'ViceLead', 'Member']);
 
-const MemberStateSchema = z.enum(['액티브', '비액티브', '졸업', '탈퇴']);
+const MemberStateSchema = z.enum(['액티브', '비액티브', '졸업', '탈퇴', '수료']);
 
 const BaseMemberSchema = z.object({
   memberId: z.number(),
@@ -23,12 +23,12 @@ const BaseMemberSchema = z.object({
   name: z.string(),
   nickname: z.string(),
   email: z.email(),
-  phoneNumber: PhoneNumberSchema,
+  phoneNumber: PhoneNumberSchema.nullable(),
   department: z.string(),
-  studentId: z.string(),
-  birthDate: DateSchema,
+  studentId: z.string().nullable(),
+  birthDate: DateSchema.nullable(),
   joinDate: DateSchema,
-  note: z.string(),
+  note: z.string().nullable(),
 });
 
 export const MeSchema = BaseMemberSchema.omit({
@@ -39,20 +39,20 @@ export const MeSchema = BaseMemberSchema.omit({
 });
 
 const ActiveMemberSchema = BaseMemberSchema.extend({
-  membershipFee: z.boolean(),
+  membershipFee: z.boolean().nullable(),
   state: z.literal('액티브'),
 });
 
 const InactiveMemberSchema = BaseMemberSchema.extend({
-  activePeriod: PeriodSchema,
-  expectedReturnSemester: z.string(),
-  inactivePeriod: PeriodSchema,
+  activePeriod: PeriodSchema.nullable(),
+  expectedReturnSemester: z.string().nullable(),
+  inactivePeriod: PeriodSchema.nullable(),
   state: z.literal('비액티브'),
 });
 
 const GraduatedMemberSchema = BaseMemberSchema.extend({
-  activePeriod: PeriodSchema,
-  isAdvisorDesired: z.boolean(),
+  activePeriod: PeriodSchema.nullable(),
+  isAdvisorDesired: z.boolean().nullable(),
   state: z.literal('졸업'),
 });
 
@@ -88,9 +88,12 @@ export const PatchMemberSchema = z
   .omit({ parts: true })
   .partial();
 
-export const MemberRoleArraySchema = z.array(MemberRoleSchema);
+export const MemberResponseSchema = z.object({
+  isSensitiveMasked: z.boolean(),
+  members: z.array(MemberSchema),
+});
 
-export const MemberArraySchema = z.array(MemberSchema);
+export const MemberRoleArraySchema = z.array(MemberRoleSchema);
 
 export const MemberStateArraySchema = z.array(MemberStateSchema);
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

하이어링 매니저는 멤버 테이블에서 일부 필드 마스킹 및 모든 필드 수정이 불가능해요.
이를 구현해줬어요.

- 멤버 정보 요청시 마스킹 관련 필드 `isSensitiveMasked` 필드를 추가해줬어요.
- 하이어링 매니저는 '회비 납부', '어드바이저 희망' 필드를 보여주지 않도록 했어요.
- 하이어링 매니저는 멤버 테이블의 모든 필드를 수정할 수 없도록 했어요. (드롭다운도 안보임)
- 하이어링 매니저는 연락처, 학번, 생년월일, 비고 값들을 볼 수 없도록 마스킹 처리했어요.
- zod 에러 방지를 위해 멤버 상태 스키마 > 수료를 미리 추가해줬어요. 데이터를 보여줄수는 있는데 아직 수정은 불가능해요.