### PR TITLE
fix: 개인 변수 없는 메일도 수신자별 개별 예약으로 저장하도록 수정

### DIFF
--- a/src/pages/SendMail/hooks/useMailReservation.ts
+++ b/src/pages/SendMail/hooks/useMailReservation.ts
@@ -114,7 +114,7 @@ export const useMailActions = () => {
     const reservationTimeIso = reservationTime.toISOString();
 
     // 각 detail에 대해, 수신자별 body를 구하고 동일 여부에 따라 PUT 또는 삭제+재생성으로 분기
-    const putsToMake: { detail: MailDetail; body: string; emails: string[] }[] = [];
+    const putsToMake: { body: string; detail: MailDetail; emails: string[] }[] = [];
     const detailsToSplit: MailDetail[] = [];
 
     for (const detail of toUpdate) {
@@ -239,25 +239,39 @@ export const useMailActions = () => {
       return;
     }
 
-    const targetMailBody = replaceChips(rawBody);
-    const { resultHtml: finalBody, inlineImageReferences } = extractInlineImages(targetMailBody);
+    const sendPromises = mailInfo.receiver.map(async (receiverName) => {
+      const targetApplicant = allApplicants.find(
+        (a) => a.name === receiverName || a.email === receiverName,
+      );
+      const targetId = targetApplicant ? String(targetApplicant.applicantId) : undefined;
+      const targetEmail = targetApplicant?.email || receiverName;
 
-    const requestBody = buildMailRequest({
-      inlineImageReferences,
-      mailInfo: {
-        receiver: mailInfo.receiver.map(convertNameToEmail),
-        cc: mailInfo.cc.map(convertNameToEmail),
-        bcc: mailInfo.bcc.map(convertNameToEmail),
-        subject: mailInfo.subject,
-      },
-      mailContent: {
-        ...mailContent,
-        body: finalBody,
-      },
-      reservedDate: reservedDate || null,
-    }).request;
+      let specificBody = defaultBody;
+      if (targetId === currentRecipientId) {
+        specificBody = rawBody;
+      } else if (targetId && mailContent.body[targetId]) {
+        specificBody = mailContent.body[targetId];
+      }
 
-    await executeSend(requestBody);
+      const targetMailBody = replaceChips(specificBody, targetId);
+      const { resultHtml: finalBody, inlineImageReferences } = extractInlineImages(targetMailBody);
+
+      return executeSend(
+        buildMailRequest({
+          inlineImageReferences,
+          mailInfo: {
+            receiver: [targetEmail],
+            cc: mailInfo.cc.map(convertNameToEmail),
+            bcc: mailInfo.bcc.map(convertNameToEmail),
+            subject: mailInfo.subject,
+          },
+          mailContent: { ...mailContent, body: finalBody },
+          reservedDate: reservedDate || null,
+        }).request,
+      );
+    });
+
+    await Promise.all(sendPromises);
   };
   return { sendReservation, updateReservation, isPending };
 };


### PR DESCRIPTION
- 이슈: 지원자, 파트명과 같은 기본 변수는 메일 작성 시 자동 치환 > 해당 메일에 변수가 없다고 판단 > 모든 수신자에 대해 현재 열려 있는 탭을 기준으로 모두가 똑같은 mailBody를 갖게 됨
- 개인화 유무 상관없이 항상 수신자 1개당 메일 예약 1개 생성하도록 변경
- 현재 지원자 ID를 기준으로 본문 저장
