### PR TITLE
feat: 메일 테스트 발송 기능 구현

### DIFF
--- a/src/pages/SendMail/components/MailSidebar/MailSidebar.tsx
+++ b/src/pages/SendMail/components/MailSidebar/MailSidebar.tsx
@@ -4,10 +4,13 @@ import { Suspense } from 'react';
 
 import { MailReservationDialog } from '@/pages/SendMail/components/MailReservationDialog/MailReservationDialog';
 import { VariableList } from '@/pages/SendMail/components/MailSidebar/VariableList';
+import { TestMailDialog } from '@/pages/SendMail/components/TestMailDialog/TestMailDialog';
+import { useMailContentContext, useMailInfoContext } from '@/pages/SendMail/context';
 import { useMailData } from '@/pages/SendMail/hooks/useMailData';
 import { useMailActions } from '@/pages/SendMail/hooks/useMailReservation';
 import { useMailValidation } from '@/pages/SendMail/hooks/useMailValidation';
 import { useRecipientData } from '@/pages/SendMail/hooks/useRecipientData';
+import { useVariableValue } from '@/pages/SendMail/hooks/useVariableValue';
 
 export interface MailSidebarProps {
   onReserveSuccess?: () => void;
@@ -20,6 +23,9 @@ export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSideba
   const { currentContent, defaultContent } = useMailData(templateId, currentRecipientId);
   const { sendReservation } = useMailActions();
   const { snackbar } = useSnackbar();
+  const { mailInfo } = useMailInfoContext();
+  const { mailContent } = useMailContentContext();
+  const { getVariableValue } = useVariableValue();
 
   const { isReadyForReservation } = useMailValidation(templateId);
 
@@ -44,6 +50,36 @@ export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSideba
     ));
   };
 
+  const handleTestMailClick = async () => {
+    const success = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+      <TestMailDialog
+        close={close}
+        content={currentContent}
+        getVariableValue={getVariableValue}
+        isOpen={isOpen}
+        mailContent={mailContent}
+        mailInfo={mailInfo}
+      />
+    ));
+
+    if (success) {
+      snackbar({
+        duration: 3000,
+        message: '테스트 메일을 발송했어요.',
+        position: 'center',
+        type: 'info',
+        width: '400px',
+      });
+    } else {
+      snackbar({
+        duration: 3000,
+        message: '테스트 메일 발송에 실패했어요.',
+        position: 'center',
+        type: 'error',
+      });
+    }
+  };
+
   return (
     <div className="bg-bg-basicLight flex size-full min-h-0 flex-col justify-between">
       <div className="typo-t4_sb_18 bg-bg-basicDefault border-line-basicMedium flex w-full flex-none justify-center border-b-1 px-[16px] py-[12px]">
@@ -57,7 +93,15 @@ export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSideba
         )}
       </div>
       <div className="border-line-basicMedium bg-bg-basicDefault flex-none border-t-1 px-[20px] pt-[16px] pb-[40px]">
-        <div className="w-full [&_button]:w-full">
+        <div className="flex w-full gap-[8px] [&_button]:w-full">
+          <BoxButton
+            disabled={!templateId || !partId || !isReadyForReservation}
+            onClick={handleTestMailClick}
+            size="large"
+            variant="filledSecondary"
+          >
+            메일 테스트하기
+          </BoxButton>
           <BoxButton
             disabled={!templateId || !partId || !isReadyForReservation}
             onClick={handleReservationClick}

--- a/src/pages/SendMail/components/MailSidebar/MailSidebar.tsx
+++ b/src/pages/SendMail/components/MailSidebar/MailSidebar.tsx
@@ -1,4 +1,5 @@
 import { BoxButton, useSnackbar } from '@yourssu/design-system-react';
+import { HTTPError } from 'ky';
 import { overlay } from 'overlay-kit';
 import { Suspense } from 'react';
 
@@ -51,16 +52,18 @@ export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSideba
   };
 
   const handleTestMailClick = async () => {
-    const success = await overlay.openAsync<boolean>(({ isOpen, close }) => (
-      <TestMailDialog
-        close={close}
-        content={currentContent}
-        getVariableValue={getVariableValue}
-        isOpen={isOpen}
-        mailContent={mailContent}
-        mailInfo={mailInfo}
-      />
-    ));
+    const { success, error } = await overlay.openAsync<{ error?: unknown; success: boolean }>(
+      ({ isOpen, close }) => (
+        <TestMailDialog
+          close={close}
+          content={currentContent}
+          getVariableValue={getVariableValue}
+          isOpen={isOpen}
+          mailContent={mailContent}
+          mailInfo={mailInfo}
+        />
+      ),
+    );
 
     if (success) {
       snackbar({
@@ -70,13 +73,26 @@ export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSideba
         type: 'info',
         width: '400px',
       });
-    } else {
-      snackbar({
-        duration: 3000,
-        message: '테스트 메일 발송에 실패했어요.',
-        position: 'center',
-        type: 'error',
-      });
+      return;
+    }
+
+    if (error) {
+      if (error instanceof HTTPError) {
+        const { message } = await error.response.json();
+        snackbar({
+          duration: 3000,
+          message,
+          position: 'center',
+          type: 'error',
+        });
+      } else {
+        snackbar({
+          duration: 3000,
+          message: '테스트 메일 발송에 실패했어요.',
+          position: 'center',
+          type: 'error',
+        });
+      }
     }
   };
 

--- a/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
+++ b/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
@@ -9,7 +9,7 @@ import { meOption } from '@/query/member/me/options';
 import { buildMailRequest } from '@/utils/buildMailRequest';
 
 export interface TestMailDialogProps {
-  close: (v: boolean) => void;
+  close: ({ error, success }: { error?: unknown; success: boolean }) => void;
   content: string;
   getVariableValue: (
     key: string,
@@ -96,15 +96,15 @@ export const TestMailDialog = ({
 
     try {
       await sendTestMail(req.request);
-      close(true);
-    } catch {
-      close(false);
+      close({ success: true });
+    } catch (error) {
+      close({ error, success: false });
     }
   };
 
   return (
-    <Dialog closeableWithOutside onClose={() => close(false)} open={isOpen}>
-      <Dialog.Header onClickCloseButton={() => close(false)}>
+    <Dialog closeableWithOutside onClose={() => close({ success: false })} open={isOpen}>
+      <Dialog.Header onClickCloseButton={() => close({ success: false })}>
         <Dialog.Title>테스트 메일 발송하기</Dialog.Title>
       </Dialog.Header>
 
@@ -136,7 +136,11 @@ export const TestMailDialog = ({
       </Dialog.Content>
 
       <Dialog.ButtonGroup>
-        <Dialog.Button onClick={() => close(false)} size="large" variant="filledSecondary">
+        <Dialog.Button
+          onClick={() => close({ success: false })}
+          size="large"
+          variant="filledSecondary"
+        >
           취소
         </Dialog.Button>
         <Dialog.Button

--- a/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
+++ b/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
@@ -1,0 +1,153 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { TextField } from '@yourssu/design-system-react';
+import { useState } from 'react';
+
+import { Dialog } from '@/components/dialog';
+import { MailContentData, MailInfoData } from '@/pages/SendMail/context';
+import { postMailReservation } from '@/query/mail/mutation/postMailReservation';
+import { meOption } from '@/query/member/me/options';
+import { buildMailRequest } from '@/utils/buildMailRequest';
+
+export interface TestMailDialogProps {
+  close: (v: boolean) => void;
+  content: string;
+  getVariableValue: (
+    key: string,
+    perRecipient: boolean,
+    label: string,
+    targetId?: string,
+  ) => string | undefined;
+  isOpen: boolean;
+  mailContent: MailContentData;
+  mailInfo: MailInfoData;
+}
+
+export const TestMailDialog = ({
+  close,
+  content,
+  getVariableValue,
+  isOpen,
+  mailContent,
+  mailInfo,
+}: TestMailDialogProps) => {
+  const { data: me } = useSuspenseQuery(meOption());
+  const [email, setEmail] = useState(me.email);
+
+  const { mutateAsync: sendTestMail, isPending: loading } = useMutation({
+    mutationFn: postMailReservation,
+  });
+
+  const handleSend = async () => {
+    if (!email) {
+      return;
+    }
+
+    const inlineImageReferences: { contentId: string; fileId: number }[] = [];
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(content, 'text/html');
+
+    // 변수 칩 처리
+    const chips = doc.querySelectorAll('span[data-variable-chip]');
+    chips.forEach((chip) => {
+      const label = chip.getAttribute('data-label') || '';
+      const key = chip.getAttribute('data-key') || '';
+      const isPerRecipient = chip.getAttribute('data-per-recipient') === 'true';
+
+      if (isPerRecipient) {
+        // 사람마다 다른 변수는 '{{변수이름}}' 형태로 유지
+        const textNode = doc.createTextNode(`{{${label}}}`);
+        chip.parentNode?.replaceChild(textNode, chip);
+      } else {
+        // 공통 변수는 실제 값으로 치환
+        const value = getVariableValue(key, false, label) ?? '';
+        const textNode = doc.createTextNode(value);
+        chip.parentNode?.replaceChild(textNode, chip);
+      }
+    });
+
+    const images = doc.querySelectorAll('img');
+    images.forEach((img) => {
+      const fileIdAttr = img.getAttribute('data-file-id');
+      const contentIdAttr = img.getAttribute('data-content-id');
+      if (fileIdAttr && contentIdAttr) {
+        const fileId = parseInt(fileIdAttr, 10);
+        if (!isNaN(fileId)) {
+          inlineImageReferences.push({ contentId: contentIdAttr, fileId });
+        }
+      }
+    });
+
+    const finalBody = doc.body.innerHTML;
+
+    const req = buildMailRequest({
+      inlineImageReferences,
+      mailContent: {
+        ...mailContent,
+        body: finalBody,
+      },
+      mailInfo: {
+        ...mailInfo,
+        cc: [],
+        bcc: [],
+        receiver: [email],
+      },
+      reservedDate: null,
+    });
+
+    try {
+      await sendTestMail(req.request);
+      close(true);
+    } catch {
+      close(false);
+    }
+  };
+
+  return (
+    <Dialog closeableWithOutside onClose={() => close(false)} open={isOpen}>
+      <Dialog.Header onClickCloseButton={() => close(false)}>
+        <Dialog.Title>테스트 메일 발송하기</Dialog.Title>
+      </Dialog.Header>
+
+      <Dialog.Content>
+        <div className="min-w-80">
+          <div className="bg-bg-basicLight mb-2.5 rounded-xl p-4">
+            <div className="text-15 text-text-basicPrimary font-medium">테스트 메일</div>
+            <ul className="text-sm">
+              <li>- 발송까지 최대 1분 정도 소요될 수 있어요.</li>
+              <li>- 받는사람과 숨은참조로는 발송되지 않아요.</li>
+              <li>
+                - 사람마다 다르게 지정되는 변수는{' '}
+                <code className="mx-0.5">
+                  {'{{'}변수이름{'}}'}
+                </code>
+                으로 표시돼요.
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="mb-1 text-sm font-medium">받을 이메일</div>
+            <TextField
+              defaultValue={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="이메일을 입력하세요"
+            />
+          </div>
+        </div>
+      </Dialog.Content>
+
+      <Dialog.ButtonGroup>
+        <Dialog.Button onClick={() => close(false)} size="large" variant="filledSecondary">
+          취소
+        </Dialog.Button>
+        <Dialog.Button
+          disabled={!email || loading}
+          onClick={handleSend}
+          size="large"
+          variant="filledPrimary"
+        >
+          발송
+        </Dialog.Button>
+      </Dialog.ButtonGroup>
+    </Dialog>
+  );
+};

--- a/src/pages/SendMail/context.tsx
+++ b/src/pages/SendMail/context.tsx
@@ -20,7 +20,7 @@ interface MailVariableContextProps {
 }
 
 // 2. 메일 내용 관련 타입 (제목, 본문, 이미지, 파일)
-interface MailContentData {
+export interface MailContentData {
   attachments: AttachmentType[];
   body: Record<string, string>; // 지원자 id, 본문 내용
   bodyFormat: 'HTML' | 'PLAIN_TEXT';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

<img width="503" height="224" alt="스크린샷 2026-03-12 05 47 52" src="https://github.com/user-attachments/assets/aa921558-2c80-4ab3-8ee6-f4c488840209" />
<img width="523" height="453" alt="스크린샷 2026-03-12 05 48 04" src="https://github.com/user-attachments/assets/1ba618c4-16ce-4cf0-9662-da539cbefeeb" />

<br />
<br />

작성한 메일이 어떻게 전송되는지 직접 테스트해볼 수 있어요.

- 즉시 발송되는 형태의 메일이에요.
- 숨은 참조로는 발송되지 않아요.
- 사람마다 다르게 지정하는 변수는 입력한 값이 아니라 변수 이름으로 렌더링돼요.
