### PR TITLE
feat: 링크 변수의 렌더링 스타일 지정

### DIFF
--- a/src/components/VariableChip/VariableChipNode.tsx
+++ b/src/components/VariableChip/VariableChipNode.tsx
@@ -136,7 +136,18 @@ const VariableValueContent: React.FC<NodeViewProps> = ({ node }) => {
   return (
     <NodeViewWrapper as="span" className="variable-chip-node" style={{ display: 'inline-block' }}>
       {displayValue ? (
-        <span className="text-text-basicPrimary bg-transparent px-0">{displayValue}</span>
+        type === 'link' ? (
+          <a
+            href={displayValue.startsWith('http') ? displayValue : `https://${displayValue}`}
+            rel="noreferrer"
+            style={{ color: '#1155cc', textDecoration: 'underline' }}
+            target="_blank"
+          >
+            {displayValue}
+          </a>
+        ) : (
+          <span className="text-text-basicPrimary bg-transparent px-0">{displayValue}</span>
+        )
       ) : (
         <VariableChip label={label} size="small" type={type as any} />
       )}

--- a/src/components/VariableChip/VariableChipNode.tsx
+++ b/src/components/VariableChip/VariableChipNode.tsx
@@ -138,9 +138,10 @@ const VariableValueContent: React.FC<NodeViewProps> = ({ node }) => {
       {displayValue ? (
         type === 'link' ? (
           <a
+            contentEditable={false}
             href={displayValue.startsWith('http') ? displayValue : `https://${displayValue}`}
             rel="noreferrer"
-            style={{ color: '#1155cc', textDecoration: 'underline' }}
+            style={{ color: '#1155cc' }}
             target="_blank"
           >
             {displayValue}

--- a/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
+++ b/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
@@ -60,8 +60,20 @@ export const TestMailDialog = ({
       } else {
         // 공통 변수는 실제 값으로 치환
         const value = getVariableValue(key, false, label) ?? '';
-        const textNode = doc.createTextNode(value);
-        chip.parentNode?.replaceChild(textNode, chip);
+        const type = chip.getAttribute('data-type');
+        if (type === 'LINK' && value.trim()) {
+          const a = doc.createElement('a');
+          a.href = value.startsWith('http') ? value : `https://${value}`;
+          a.style.color = '#1155cc';
+          a.style.textDecoration = 'underline';
+          a.textContent = value;
+          a.target = '_blank';
+          a.rel = 'noreferrer';
+          chip.parentNode?.replaceChild(a, chip);
+        } else {
+          const textNode = doc.createTextNode(value);
+          chip.parentNode?.replaceChild(textNode, chip);
+        }
       }
     });
 

--- a/src/pages/SendMail/hooks/useMailReservation.ts
+++ b/src/pages/SendMail/hooks/useMailReservation.ts
@@ -59,15 +59,24 @@ export const useMailActions = () => {
       const keyMatch = match.match(/data-key="([^"]*)"/);
       const perRecipientMatch = match.match(/data-per-recipient="([^"]*)"/);
       const labelMatch = match.match(/data-label="([^"]*)"/);
+      const typeMatch = match.match(/data-type="([^"]*)"/);
 
       const key = keyMatch?.[1] || '';
       const isIndividual = perRecipientMatch?.[1] === 'true';
       const label = labelMatch?.[1] || '';
+      const type = typeMatch?.[1] || '';
 
       const value = getVariableValue(key, isIndividual, label, targetId);
 
       // 값이 있으면 치환, 없으면 칩 원본 그대로 반환
-      return typeof value === 'string' && value.trim() !== '' ? value : match;
+      if (typeof value === 'string' && value.trim() !== '') {
+        if (type === 'LINK') {
+          const href = value.startsWith('http') ? value : `https://${value}`;
+          return `<a href="${href}" target="_blank" rel="noreferrer" style="color: #1155cc; text-decoration: underline;">${value}</a>`;
+        }
+        return value;
+      }
+      return match;
     });
   };
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

<img width="1511" height="767" alt="스크린샷 2026-03-12 06 06 21" src="https://github.com/user-attachments/assets/dd657a5e-d646-41ca-a6db-b27b1d460cee" />

<br />
<br />

링크 변수를 에디터에 렌더링하면 스타일을 부여하도록 했어요.

- 이 스타일은 에디터에서만 보여지고, 실제 메일 전송시에는 반영되지 않아요.
- 에디터 툴바에 의한 색상 및 볼드처리, 언더라인, 취소선 처리는 못하도록 강제했어요. (크기, 폰트, 기울임 변경은 가능)