### PR TITLE
feat: 메일함에서 첨부파일 확인할 수 있도록 구현

### DIFF
--- a/src/pages/SendMail/components/MailEditorContent/MailEditorContent.tsx
+++ b/src/pages/SendMail/components/MailEditorContent/MailEditorContent.tsx
@@ -149,7 +149,7 @@ export const MailEditorContent = forwardRef<MailEditorContentRef, MailEditorCont
         <EditorWrapper>
           <StyledEditorContent editor={editor} />
         </EditorWrapper>
-        {!readOnly && <MailToolbar editor={editor} />}
+        <MailToolbar editor={editor} readOnly={readOnly} />
       </div>
     );
   },

--- a/src/pages/SendMail/components/MailToolbar/MailToolbar.style.ts
+++ b/src/pages/SendMail/components/MailToolbar/MailToolbar.style.ts
@@ -17,12 +17,12 @@ export const ToolbarContainer = styled.div`
   max-width: 100%;
 `;
 
-export const AttachmentList = styled.div`
+export const AttachmentList = styled.div<{ $readOnly?: boolean }>`
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   padding: 8px 16px;
-  padding-top: 0;
+  padding-top: ${({ $readOnly }) => ($readOnly ? '8px' : '0')};
   border-top: 1px solid ${({ theme }) => theme.primitive.color.gray100};
 `;
 

--- a/src/pages/SendMail/components/MailToolbar/MailToolbar.tsx
+++ b/src/pages/SendMail/components/MailToolbar/MailToolbar.tsx
@@ -33,12 +33,28 @@ import {
 
 interface MailToolbarProps {
   editor: Editor | null;
+  readOnly?: boolean;
 }
 
-export const MailToolbar = ({ editor }: MailToolbarProps) => {
+export const MailToolbar = ({ editor, readOnly }: MailToolbarProps) => {
   const { mailContent, actions } = useMailContentContext();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
+
+  if (readOnly) {
+    if (mailContent.attachments.length === 0) { return null; }
+    return (
+      <ToolbarWrapper>
+        <AttachmentList $readOnly>
+          {mailContent.attachments.map((file) => (
+            <AttachmentChip key={file.fileId}>
+              <span>{file.name}</span>
+            </AttachmentChip>
+          ))}
+        </AttachmentList>
+      </ToolbarWrapper>
+    );
+  }
 
   if (!editor) {
     return null;

--- a/src/pages/SendMail/context.tsx
+++ b/src/pages/SendMail/context.tsx
@@ -103,15 +103,17 @@ export const MailVariableProvider = ({
 export const MailContentProvider = ({
   children,
   initialBody,
+  initialAttachments,
 }: {
   children: ReactNode;
+  initialAttachments?: AttachmentType[];
   initialBody?: Record<string, string>;
 }) => {
   const [mailContent, setMailContent] = useState<MailContentData>({
     body: initialBody ?? {},
     bodyFormat: 'HTML',
     inlineImages: [],
-    attachments: [],
+    attachments: initialAttachments ?? [],
   });
   const [reservationTime, setReservationTime] = useState<Date | null>(null);
 

--- a/src/query/mail/schema.ts
+++ b/src/query/mail/schema.ts
@@ -2,15 +2,21 @@ import { z } from 'zod';
 
 const MailStateType = ['SCHEDULED', 'SENT', 'PENDING_SEND'] as const;
 
+const AttachmentReferenceSchema = z.object({
+  fileId: z.number(),
+  fileName: z.string(),
+  contentType: z.string(),
+  storageKey: z.string(),
+});
+
 const BaseMailItemSchema = z.object({
   mailId: z.number(),
   reservationId: z.number(),
   reservationTime: z.string(),
   status: z.enum(MailStateType),
   mailSubject: z.string(),
-  senderEmailAddress: z.string().email(),
+  senderEmailAddress: z.string(),
   primaryReceiverEmailAddress: z.string(),
-  hasAttachments: z.boolean(),
 });
 
 // 목록 조회
@@ -23,13 +29,13 @@ export const MailDetailSchema = z.object({
   reservationTime: z.string(),
   status: z.enum(MailStateType),
   mailSubject: z.string(),
-  senderEmailAddress: z.string().email(),
+  senderEmailAddress: z.string(),
   mailBody: z.string(),
   bodyFormat: z.string(),
   receiverEmailAddresses: z.array(z.string()),
   ccEmailAddresses: z.array(z.string()),
   bccEmailAddresses: z.array(z.string()),
-  hasAttachments: z.boolean(),
+  attachmentReferences: z.array(AttachmentReferenceSchema).default([]),
 });
 
 export const MailListSchema = z.object({


### PR DESCRIPTION
- 백엔드 메일 예약 단건 조회에 attachmentReferences 응답 추가
- 추가된 응답에 맞게 스키마 수정
- 메일함에서도 첨부파일 볼 수 있도록 구현

### 참고
- 테스트 메일은 현재 메일함에서 정상적으로 확인 불가능
- useRecipientData가 수신자를 allApplicants에서만 조회하는데, 테스트 메일 수신자는 멤버여서 매칭이 안 됨 -> 메일 내용이 제대로 안보임
- 추후 테스트 메일을 메일 예약 요청 말고 단발성으로 즉시 발송하는 방법으로 변경 예정이라, 그때 자연스럽게 해결될 것으로 예상