### PR TITLE
feat: MailTab에서 정렬 순서 정할 수 있도록 sortOrder prop 추가

### DIFF
--- a/src/pages/SendMail/MailPage.tsx
+++ b/src/pages/SendMail/MailPage.tsx
@@ -34,10 +34,16 @@ export const MailPage = () => {
               <MailTab
                 emptyText="예약된 메일이 없습니다."
                 onCompose={() => setIsComposing(true)}
+                sortOrder="asc"
                 statuses={['SCHEDULED', 'PENDING_SEND']}
               />
             ) : (
-              <MailTab emptyText="전송 완료된 메일이 없습니다." onCompose={() => setIsComposing(true)} readOnly statuses={['SENT']} />
+              <MailTab
+                emptyText="전송 완료된 메일이 없습니다."
+                onCompose={() => setIsComposing(true)}
+                readOnly
+                statuses={['SENT']}
+              />
             )}
           </div>
         )}

--- a/src/pages/SendMail/components/MailTab/MailTab.tsx
+++ b/src/pages/SendMail/components/MailTab/MailTab.tsx
@@ -17,6 +17,7 @@ interface MailTabProps {
   emptyText: string;
   onCompose?: () => void;
   readOnly?: boolean; // 메일 예약 목록을 읽기 전용으로 보여줄지 여부
+  sortOrder?: 'asc' | 'desc';
   statuses: MailItem['status'][];
 }
 
@@ -25,6 +26,7 @@ export const MailTab = ({
   emptyText,
   onCompose,
   readOnly,
+  sortOrder = 'desc',
   statuses,
 }: MailTabProps) => {
   const methods = useForm({ defaultValues: { search: '' } });
@@ -74,9 +76,11 @@ export const MailTab = ({
       if (aFailed !== bFailed) {
         return aFailed ? -1 : 1;
       }
-      return new Date(b[0].reservationTime).getTime() - new Date(a[0].reservationTime).getTime();
+      const timeA = new Date(a[0].reservationTime).getTime();
+      const timeB = new Date(b[0].reservationTime).getTime();
+      return sortOrder === 'asc' ? timeA - timeB : timeB - timeA;
     });
-  }, [filteredMails]);
+  }, [filteredMails, sortOrder]);
 
   const hasAnyMails = mails.some((mail) => statuses.includes(mail.status));
 


### PR DESCRIPTION
- 제곧내
- `예약됨`은 임박순, `전송 완료`는 최신순으로 정렬
