### PR TITLE
feat: 테스트 메일 api를 api/mails/send로 변경

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -224,8 +224,8 @@
               }
             }
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -234,8 +234,8 @@
               }
             }
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -277,8 +277,8 @@
             "description": "수정 성공",
             "content": {}
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -287,8 +287,8 @@
               }
             }
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -320,8 +320,8 @@
             "description": "취소 성공",
             "content": {}
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -330,8 +330,8 @@
               }
             }
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -672,6 +672,42 @@
         }
       }
     },
+    "/internal/dev/member-privacy/privileged/self/enable": {
+      "post": {
+        "tags": ["[DEV] 멤버 민감정보 권한 테스트"],
+        "summary": "나를 권한자로 복원 (테스트용)",
+        "description": "비권한자로 전환한 상태를 해제하고, 다시 민감정보 열람 권한이 있는 상태로 돌립니다.",
+        "operationId": "enablePrivilegeForSelf",
+        "responses": {
+          "204": {
+            "description": "적용됨",
+            "content": {}
+          },
+          "403": {
+            "description": "스카우터 팀원이 아님",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/internal/dev/member-privacy/privileged/self/disable": {
+      "post": {
+        "tags": ["[DEV] 멤버 민감정보 권한 테스트"],
+        "summary": "나를 비권한자로 전환 (테스트용)",
+        "description": "이후 멤버 API 호출 시 내 계정은 민감정보가 마스킹된 응답을 받습니다. 스카우터 팀원만 호출 가능.",
+        "operationId": "disablePrivilegeForSelf",
+        "responses": {
+          "204": {
+            "description": "적용됨",
+            "content": {}
+          },
+          "403": {
+            "description": "스카우터 팀원이 아님",
+            "content": {}
+          }
+        }
+      }
+    },
     "/applicants": {
       "get": {
         "tags": ["리크루팅 지원자"],
@@ -898,6 +934,50 @@
         }
       }
     },
+    "/api/mails/send": {
+      "post": {
+        "tags": ["메일"],
+        "summary": "메일 즉시 발송",
+        "description": "메일을 즉시 발송합니다. DB에 저장하지 않고 바로 발송됩니다. 파일은 사전에 /api/mails/files/* API로 업로드/확정한 뒤, fileId 참조만 전달합니다.",
+        "operationId": "sendMail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MailSendRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "발송 성공",
+            "content": {}
+          },
+          "400": {
+            "description": "잘못된 요청 (bodyFormat 오류, fileId 검증 실패 등)",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExceptionResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "메일 발송 실패 (OAuth 토큰/네트워크 등)",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExceptionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mails/reservation": {
       "get": {
         "tags": ["메일"],
@@ -982,8 +1062,8 @@
               }
             }
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -992,8 +1072,8 @@
               }
             }
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -2125,6 +2205,35 @@
         }
       }
     },
+    "/api/mails/files/download-url": {
+      "get": {
+        "tags": ["메일"],
+        "summary": "메일 파일 다운로드용 presigned URL 발급",
+        "operationId": "createPresignedDownloadUrl",
+        "parameters": [
+          {
+            "name": "storageKey",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MailFileDownloadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/semesters/{semesterId}": {
       "delete": {
         "tags": ["학과/학기/단과대"],
@@ -2621,6 +2730,50 @@
           }
         },
         "required": ["failures", "successes"]
+      },
+      "MailSendRequest": {
+        "type": "object",
+        "description": "메일 즉시 발송 요청",
+        "properties": {
+          "receiverEmailAddresses": {
+            "type": "array",
+            "description": "수신자 이메일 주소 목록",
+            "example": ["user@example.com"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "mailSubject": {
+            "type": "string",
+            "description": "메일 제목",
+            "example": "면접 안내"
+          },
+          "mailBody": {
+            "type": "string",
+            "description": "메일 본문",
+            "example": "<p>안녕하세요</p>"
+          },
+          "bodyFormat": {
+            "type": "string",
+            "description": "본문 형식",
+            "enum": ["HTML", "PLAIN_TEXT"],
+            "example": "HTML"
+          },
+          "attachmentReferences": {
+            "type": "array",
+            "description": "첨부파일 참조 목록",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentReferenceRequest"
+            }
+          }
+        },
+        "required": [
+          "attachmentReferences",
+          "bodyFormat",
+          "mailBody",
+          "mailSubject",
+          "receiverEmailAddresses"
+        ]
       },
       "FileSpec": {
         "type": "object",
@@ -4088,6 +4241,11 @@
             "enum": ["SCHEDULED", "PENDING_SEND", "SENT"],
             "example": "SCHEDULED"
           },
+          "senderEmailAddress": {
+            "type": "string",
+            "description": "발신자 이메일",
+            "example": "sender@example.com"
+          },
           "mailSubject": {
             "type": "string"
           },
@@ -4096,16 +4254,21 @@
             "description": "대표 수신자 이메일 (수신자가 없으면 null)",
             "example": "receiver@example.com"
           },
-          "hasAttachments": {
-            "type": "boolean"
+          "attachmentReferences": {
+            "type": "array",
+            "description": "첨부파일 참조 목록",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentReference"
+            }
           }
         },
         "required": [
-          "hasAttachments",
+          "attachmentReferences",
           "mailId",
           "mailSubject",
           "reservationId",
           "reservationTime",
+          "senderEmailAddress",
           "status"
         ]
       },
@@ -4142,6 +4305,11 @@
             "enum": ["SCHEDULED", "PENDING_SEND", "SENT"],
             "example": "SCHEDULED"
           },
+          "senderEmailAddress": {
+            "type": "string",
+            "description": "발신자 이메일",
+            "example": "sender@example.com"
+          },
           "mailSubject": {
             "type": "string"
           },
@@ -4169,21 +4337,26 @@
               "type": "string"
             }
           },
-          "hasAttachments": {
-            "type": "boolean"
+          "attachmentReferences": {
+            "type": "array",
+            "description": "첨부파일 참조 목록",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentReference"
+            }
           }
         },
         "required": [
+          "attachmentReferences",
           "bccEmailAddresses",
           "bodyFormat",
           "ccEmailAddresses",
-          "hasAttachments",
           "mailBody",
           "mailId",
           "mailSubject",
           "receiverEmailAddresses",
           "reservationId",
           "reservationTime",
+          "senderEmailAddress",
           "status"
         ]
       },
@@ -4235,6 +4408,21 @@
           }
         },
         "required": ["files"]
+      },
+      "MailFileDownloadResponse": {
+        "type": "object",
+        "properties": {
+          "getUrl": {
+            "type": "string",
+            "description": "다운로드용 presigned URL"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "URL 만료 시각"
+          }
+        },
+        "required": ["expiresAt", "getUrl"]
       },
       "DeleteByPartResponse": {
         "type": "object",

--- a/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
+++ b/src/pages/SendMail/components/TestMailDialog/TestMailDialog.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { Dialog } from '@/components/dialog';
 import { MailContentData, MailInfoData } from '@/pages/SendMail/context';
-import { postMailReservation } from '@/query/mail/mutation/postMailReservation';
+import { postMailSend } from '@/query/mail/mutation/postMailSend';
 import { meOption } from '@/query/member/me/options';
 import { buildMailRequest } from '@/utils/buildMailRequest';
 
@@ -34,7 +34,7 @@ export const TestMailDialog = ({
   const [email, setEmail] = useState(me.email);
 
   const { mutateAsync: sendTestMail, isPending: loading } = useMutation({
-    mutationFn: postMailReservation,
+    mutationFn: postMailSend,
   });
 
   const handleSend = async () => {
@@ -119,7 +119,13 @@ export const TestMailDialog = ({
     });
 
     try {
-      await sendTestMail(req.request);
+      await sendTestMail({
+        attachmentReferences: req.request.attachmentReferences,
+        bodyFormat: req.request.bodyFormat,
+        mailBody: req.request.mailBody,
+        mailSubject: req.request.mailSubject,
+        receiverEmailAddresses: req.request.receiverEmailAddresses,
+      });
       close({ success: true });
     } catch (error) {
       close({ error, success: false });

--- a/src/query/mail/mutation/postMailSend.ts
+++ b/src/query/mail/mutation/postMailSend.ts
@@ -1,0 +1,19 @@
+import { api } from '@/apis/api';
+
+export interface PostMailSendParams {
+  attachmentReferences: {
+    fileId: number;
+  }[];
+  bodyFormat: 'HTML' | 'PLAIN_TEXT';
+  mailBody: string;
+  mailSubject: string;
+  receiverEmailAddresses: string[];
+}
+
+export const postMailSend = (data: PostMailSendParams) => {
+  return api
+    .post('api/mails/send', {
+      json: data,
+    })
+    .json<void>();
+};


### PR DESCRIPTION
테스트 메일 api를 api/mails/send로 변경했어요.

백엔드 메일 스케쥴러에 쌓지 않고 즉시 전송할 수 있도록 해요.

- 최대 1분 기다리지 않아도 바로 전송을 테스트할 수 있게 됐어요.
- 메일 예약함에도 쌓이지 않아요.