### PR TITLE
refactor: 예약 메일 삭제 로직 개선

### DIFF
--- a/src/pages/SendMail/components/MailTab/MailTab.tsx
+++ b/src/pages/SendMail/components/MailTab/MailTab.tsx
@@ -40,15 +40,16 @@ export const MailTab = ({
   }>(null);
   const queryClient = useQueryClient();
 
-  const { mutate: deleteReservation } = useMutation({
+  const { mutateAsync: deleteReservation } = useMutation({
     mutationFn: deleteMailReservation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: MailReservationKeys.all });
-    },
   });
 
-  const handleConfirmDelete = () => {
-    pendingDeleteGroup?.ids.forEach((id) => deleteReservation({ reservationId: id }));
+  const handleConfirmDelete = async () => {
+    if (!pendingDeleteGroup) { return; }
+    await Promise.all(
+      pendingDeleteGroup.ids.map((id) => deleteReservation({ reservationId: id })),
+    );
+    queryClient.invalidateQueries({ queryKey: MailReservationKeys.all });
     setPendingDeleteGroup(null);
   };
 


### PR DESCRIPTION
### as is
- 그룹 내 메일 삭제 시 forEach로 순차 요청
- 한명당 1초씩 걸려서 지원자 6명 걸린 메일 지울때 5초가 넘게 걸림

### to be
- 병렬 요청으로 처리
