### PR TITLE
feat: Calendar Dialog에 Divider 추가

### DIFF
--- a/src/components/CalendarDialog/CalendarDialog.tsx
+++ b/src/components/CalendarDialog/CalendarDialog.tsx
@@ -1,10 +1,19 @@
 import {
   BoxButton,
+  Divider,
   IcArrowsChevronLeftLine,
   IcArrowsChevronRightLine,
   Switch,
 } from '@yourssu/design-system-react';
-import { addHours, addMonths, isSameDay, setHours, setMinutes, startOfDay, startOfHour } from 'date-fns';
+import {
+  addHours,
+  addMonths,
+  isSameDay,
+  setHours,
+  setMinutes,
+  startOfDay,
+  startOfHour,
+} from 'date-fns';
 import { Popover } from 'radix-ui';
 import { useState } from 'react';
 
@@ -89,6 +98,7 @@ export const CalendarDialog = ({ onSelect, trigger, selectedDate }: CalendarDial
           <Popover.Content style={{ zIndex: 50 }}>
             <CalendarDialogContainer>
               <CalendarContent onSelect={handleDateChange} selectedDate={tempDate} />
+              <Divider thickness={1} />
               <SwitchRow>
                 <span>시간 포함</span>
                 <Switch isSelected={withTime} onSelectedChange={setWithTime} size="large" />


### PR DESCRIPTION
### as is

<img width="349" height="493" alt="image" src="https://github.com/user-attachments/assets/b8f5f897-7aff-48bd-b1ff-9a0231c40547" />

### to be

<img width="349" height="532" alt="image" src="https://github.com/user-attachments/assets/faf0ea77-0c84-4260-8db7-27f027367a8a" />
