### PR TITLE
fix: 리렌더링 방지로 인한 ConflictCard 갱신 문제 해결

### DIFF
--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewScheduleSidebar.tsx
@@ -59,12 +59,24 @@ export const InterviewScheduleSidebar = ({ schedules }: InterviewScheduleSidebar
       )}
       <InterviewSidebarLayout.CardList>
         {confilctGroups.length > 0
-          ? confilctGroups.map((group, i) => (
-              <InterviewSidebarConflictCard key={i} schedules={group} />
-            ))
-          : classroomGroups.map((group, i) => (
-              <InterviewSidebarClassroomCard key={i} schedules={group} />
-            ))}
+          ? confilctGroups.map(
+              (group) =>
+                group.length > 0 && (
+                  <InterviewSidebarConflictCard
+                    key={`conflict-${group[0].id}-${group.length}`}
+                    schedules={group}
+                  />
+                ),
+            )
+          : classroomGroups.map(
+              (group) =>
+                group.length > 0 && (
+                  <InterviewSidebarClassroomCard
+                    key={`classroom-${group[0].id}-${group.length}`}
+                    schedules={group}
+                  />
+                ),
+            )}
         <InterviewSidebarDownloadCard />
       </InterviewSidebarLayout.CardList>
     </InterviewSidebarLayout>

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarClassroomCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarClassroomCard.tsx
@@ -113,11 +113,15 @@ export const InterviewSidebarClassroomCard = ({
     } as const;
 
     const loc = locations[scheduleId];
-    await mutateAsync({
-      scheduleId,
-      locationType: locMap[loc.type as LocationType],
-      locationDetail: loc.detail,
-    });
+    try {
+      await mutateAsync({
+        scheduleId,
+        locationType: locMap[loc.type as LocationType],
+        locationDetail: loc.detail,
+      });
+    } catch (error) {
+      console.error('Failed to save schedule location:', error);
+    }
 
     setEditedSchedules((prev) => ({ ...prev, [scheduleId]: false }));
   };

--- a/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarConflictCard.tsx
+++ b/src/pages/Interview/components/InterviewScheduleMode/InterviewSidebarConflictCard.tsx
@@ -129,11 +129,15 @@ export const InterviewSidebarConflictCard = ({ schedules }: InterviewSidebarConf
 
     const paramsList = schedules.map((s) => ({
       scheduleId: s.id,
-      locationType: locMap[locations[s.id].type as LocationType],
+      locationType: locMap[locations[s.id].type],
       locationDetail: locations[s.id].detail,
     }));
 
-    await mutateAsync(paramsList);
+    try {
+      await mutateAsync(paramsList);
+    } catch (error) {
+      console.error('Failed to save schedule locations:', error);
+    }
   };
 
   if (!schedules.length) {
@@ -145,12 +149,18 @@ export const InterviewSidebarConflictCard = ({ schedules }: InterviewSidebarConf
   const locValues = Object.values(locations);
   const hasChanges = schedules.some((s) => {
     const loc = locations[s.id];
+    if (!loc) {
+      return false;
+    }
     const initialType = s.locationType === '동방' ? '동아리방' : (s.locationType as LocationType);
     const initialDetail = s.locationDetail ?? '';
     return loc.type !== initialType || loc.detail !== initialDetail;
   });
 
   const isSaveEnabled = locValues.every((loc) => {
+    if (!loc) {
+      return false;
+    }
     if (loc.type === '강의실' || loc.type === '기타') {
       return loc.detail.trim().length > 0;
     }


### PR DESCRIPTION
## 상황

장소 카드 리스트에서 마지막을 제외한 어떤 카드의 장소를 변경했을 경우 문제가 터짐

## 원인

이 카드 리스트의 각 카드 컴포넌트 key를 인덱스로 관리하고 있었는데,
장소 겹침이 해결되면 해당 카드가 리스트에서 사라지고, 나머지 카드들의 인덱스가 바뀜.

근데 실제로 리스트 key들은 변경되는게 아니기 때문에 이전 컴포넌트 내용을 그대로 사용함.
내부 로직에서 fresh하지 못한 내용을 참조하고 있기 때문에 에러가 발생 (undefined에 index 접근)

## 해결

key를 유니크하게 보완해줌