### PR TITLE
feat: 기존 면접 일정이 있다면 수정시에도 장소는 유지

### DIFF
--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock.tsx
@@ -1,13 +1,16 @@
 import clsx from 'clsx';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { Applicant } from '@/query/applicant/schema';
+import { LocationType } from '@/types/location';
 import { formatTemplates } from '@/utils/date';
 
 interface ManualScheduleBlockProps {
   applicant: Applicant | undefined;
   date: Date;
   isFirstBlock: boolean;
+  locationDetail?: null | string;
+  locationType?: LocationType;
   onClick: () => void;
   shouldScrollIntoView?: boolean;
 }
@@ -16,10 +19,23 @@ export const ManualScheduleBlock = ({
   applicant,
   date,
   isFirstBlock,
+  locationDetail,
+  locationType,
   onClick,
   shouldScrollIntoView,
 }: ManualScheduleBlockProps) => {
   const ref = useRef<HTMLButtonElement>(null);
+
+  const locationLabel = useMemo(() => {
+    if (!locationType || locationType === '동방') {
+      return '유어슈 동아리방';
+    }
+    if (locationType === '비대면') {
+      return '비대면';
+    }
+    const suffix = locationDetail ? `(${locationDetail})` : '';
+    return `${locationType}${suffix}`;
+  }, [locationType, locationDetail]);
 
   useEffect(() => {
     if (shouldScrollIntoView && ref.current) {
@@ -44,7 +60,7 @@ export const ManualScheduleBlock = ({
           </div>
           <div className="typo-c3_rg_11 flex size-full items-start gap-1.5 px-2">
             <div>{formatTemplates['23:59'](date)}</div>
-            <div>유어슈 동아리방</div>
+            <div>{locationLabel}</div>
           </div>
         </>
       )}

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleCalendar.tsx
@@ -2,14 +2,15 @@ import { setHours, setMinutes, subMinutes } from 'date-fns';
 
 import { useDateMap, UseDateMapAction } from '@/hooks/useDateMap';
 import { InterviewCalendar } from '@/pages/Interview/components/InterviewCalendar/InterviewCalendar';
+import { ScheduledApplicant } from '@/pages/Interview/components/ManualScheduleMode/index';
 import { ManualScheduleBlock } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleBlock';
 import { useInterviewAutoScheduleContext } from '@/pages/Interview/context';
 import { Applicant } from '@/query/applicant/schema';
 import { DateMap } from '@/utils/DateMap';
 
 interface ManualScheduleCalendarProps {
-  completedScheduleMap: DateMap<Applicant>;
-  completedScheduleMapAction: UseDateMapAction<Applicant>;
+  completedScheduleMap: DateMap<ScheduledApplicant>;
+  completedScheduleMapAction: UseDateMapAction<ScheduledApplicant>;
   month: number;
   selectedApplicant: Applicant;
   week: number;
@@ -68,6 +69,8 @@ export const ManualScheduleCalendar = ({
               applicant={settedApplicantHere}
               date={actualScheduleDate}
               isFirstBlock={actualScheduleDate.getTime() === targetDate.getTime()}
+              locationDetail={settedApplicantHere?.locationDetail}
+              locationType={settedApplicantHere?.locationType}
               onClick={() => {
                 // 1. 클릭한 블럭에 채워져있는 게 내 일정이라면 지운다
                 if (settedApplicantHereIsMe) {
@@ -76,8 +79,9 @@ export const ManualScheduleCalendar = ({
                 }
                 // 2. 내 일정이 다른곳에서 이미 지정되어있다면 클릭한 블럭으로 변경한다
                 if (meAlreadySettedAt) {
+                  const myScheduledData = completedScheduleMap.get(meAlreadySettedAt);
                   completedScheduleMapAction.remove(meAlreadySettedAt);
-                  completedScheduleMapAction.set(targetDate, selectedApplicant);
+                  completedScheduleMapAction.set(targetDate, myScheduledData ?? selectedApplicant);
                   return;
                 }
                 // 3. 클릭한 블럭에 아무도 채워져있지 않다면 채운다

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeader.tsx
@@ -1,4 +1,5 @@
 import { InterviewHeaderLayout } from '@/pages/Interview/components/InterviewHeaderLayout';
+import { ScheduledApplicant } from '@/pages/Interview/components/ManualScheduleMode/index';
 import { ManualScheduleHeaderChipGroup } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleHeaderChipGroup';
 import { ScheduleModeToggleButton } from '@/pages/Interview/components/ScheduleModeToggleButton';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
@@ -6,7 +7,7 @@ import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleHeaderProps {
   applicants: Applicant[];
-  completedApplicants: Applicant[];
+  completedApplicants: ScheduledApplicant[];
   indicator: {
     month: number;
     onNextWeek: () => void;
@@ -14,7 +15,7 @@ interface ManualScheduleHeaderProps {
     week: number;
   };
   onSelectedApplicantChange: (v: Applicant) => void;
-  selectedApplicant: Applicant;
+  selectedApplicant: ScheduledApplicant;
 }
 
 export const ManualScheduleHeader = ({

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeaderChipGroup.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleHeaderChipGroup.tsx
@@ -1,13 +1,14 @@
 import { IcCheckLine } from '@yourssu/design-system-react';
 import { tv } from 'tailwind-variants';
 
+import { ScheduledApplicant } from '@/pages/Interview/components/ManualScheduleMode/index';
 import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleHeaderChipGroupProps {
   applicants: Applicant[];
-  completedApplicants: Applicant[];
+  completedApplicants: ScheduledApplicant[];
   onSelectedApplicantChange: (v: Applicant) => void;
-  selectedApplicant: Applicant;
+  selectedApplicant: ScheduledApplicant;
 }
 
 const chip = tv({

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton.tsx
@@ -4,19 +4,19 @@ import { addHours, addMinutes, isBefore } from 'date-fns';
 import { assert } from 'es-toolkit';
 
 import { useAlertDialog } from '@/hooks/useAlertDialog';
+import { ScheduledApplicant } from '@/pages/Interview/components/ManualScheduleMode/index';
 import {
   useInterviewAutoScheduleContext,
   useInterviewCalendarModeContext,
   useInterviewPartSelectionContext,
 } from '@/pages/Interview/context';
 import { useScheduleConfirmDialog } from '@/pages/Interview/hooks/useScheduleConfirmDialog';
-import { Applicant } from '@/query/applicant/schema';
 import { useInvalidateSchedule } from '@/query/schedule/hooks/useInvalidateSchedule';
 import { deletePartSchedule } from '@/query/schedule/mutations/deletePartSchedule';
 import { postSchedule } from '@/query/schedule/mutations/postSchedule';
 
 interface ManualScheduleSaveButtonProps {
-  completedApplicants: [Date, Applicant][];
+  completedApplicants: [Date, ScheduledApplicant][];
   method: '대면' | '비대면';
   totalApplicantCount: number;
 }
@@ -55,7 +55,8 @@ export const ManualScheduleSaveButton = ({
       applicantName: applicant.name,
       part: applicant.part,
       endTime: (duration === '1시간' ? addHours(date, 1) : addMinutes(date, 30)).toISOString(),
-      locationType: method === '대면' ? '동방' : ('비대면' as '동방' | '비대면'),
+      locationType: applicant.locationType ?? (method === '대면' ? '동방' : '비대면'),
+      locationDetail: applicant.locationDetail ?? null,
       partId,
       startTime: date.toISOString(),
     }));
@@ -89,6 +90,7 @@ export const ManualScheduleSaveButton = ({
       schedules: schedulesToSave.map((schedule) => ({
         applicantId: schedule.applicantId,
         endTime: schedule.endTime,
+        locationDetail: schedule.locationDetail,
         locationType: schedule.locationType,
         partId,
         startTime: schedule.startTime,

--- a/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebar.tsx
@@ -1,14 +1,14 @@
 import { InterviewSidebarLayout } from '@/pages/Interview/components/InterviewSidebarLayout';
+import { ScheduledApplicant } from '@/pages/Interview/components/ManualScheduleMode/index';
 import { ManualScheduleSaveButton } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSaveButton';
 import { ManualScheduleSidebarDurationCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarDurationCard';
 import { ManualScheduleSidebarMethodCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarMethodCard';
 import { ManualScheduleSidebarPartCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarPartCard';
 import { ManualScheduleSidebarProgressCard } from '@/pages/Interview/components/ManualScheduleMode/ManualScheduleSidebarProgressCard';
 import { useInterviewPartSelectionContext } from '@/pages/Interview/context';
-import { Applicant } from '@/query/applicant/schema';
 
 interface ManualScheduleSidebarProps {
-  completedApplicants: [Date, Applicant][];
+  completedApplicants: [Date, ScheduledApplicant][];
   method: '대면' | '비대면';
   onChangeMethod: (method: '대면' | '비대면') => void;
   totalApplicantCount: number;

--- a/src/pages/Interview/components/ManualScheduleMode/index.tsx
+++ b/src/pages/Interview/components/ManualScheduleMode/index.tsx
@@ -13,6 +13,12 @@ import { applicantOptions } from '@/query/applicant/options';
 import { Applicant } from '@/query/applicant/schema';
 import { scheduleOptions } from '@/query/schedule/options';
 import { semesterNowOptions } from '@/query/semester/now/options';
+import { LocationType } from '@/types/location';
+
+export type ScheduledApplicant = Applicant & {
+  locationDetail?: null | string;
+  locationType?: LocationType;
+};
 
 export const ManualScheduleMode = () => {
   const { partId } = useInterviewPartSelectionContext();
@@ -26,7 +32,7 @@ export const ManualScheduleMode = () => {
 
   // 기존 스케줄을 Applicant와 매칭하여 초기 엔트리로 변환
   const initialScheduleEntries = useMemo(() => {
-    const entries: [Date, Applicant][] = [];
+    const entries: [Date, ScheduledApplicant][] = [];
 
     existingSchedules.forEach((schedule) => {
       // 이름으로 지원자 매칭
@@ -35,21 +41,28 @@ export const ManualScheduleMode = () => {
       );
 
       if (matchedApplicant) {
-        entries.push([new Date(schedule.startTime), matchedApplicant]);
+        entries.push([
+          new Date(schedule.startTime),
+          {
+            ...matchedApplicant,
+            locationType: schedule.locationType,
+            locationDetail: schedule.locationDetail,
+          },
+        ]);
       }
     });
 
     return entries;
   }, [existingSchedules, applicants]);
 
-  const [selectedApplicant, setSelectedApplicant] = useState(applicants[0]);
+  const [selectedApplicant, setSelectedApplicant] = useState<ScheduledApplicant>(applicants[0]);
   const { year, month, week, handlePrevWeek, handleNextWeek, jump } = useWeekIndicator({
     initialDate:
       existingSchedules.length > 0
         ? existingSchedules[0].startTime
         : selectedApplicant?.availableTimes[0],
   });
-  const [completedScheduleMap, completedScheduleMapAction] = useDateMap<Applicant>({
+  const [completedScheduleMap, completedScheduleMapAction] = useDateMap<ScheduledApplicant>({
     initialEntries: initialScheduleEntries,
     precision: '분',
   });
@@ -57,13 +70,20 @@ export const ManualScheduleMode = () => {
 
   useEffect(() => {
     completedScheduleMapAction.reset();
-    setSelectedApplicant(applicants[0]);
+    const firstApplicant = applicants[0];
+    const initialMatchedApplicant = initialScheduleEntries.find(
+      ([, a]) => a.applicantId === firstApplicant?.applicantId,
+    )?.[1];
+    setSelectedApplicant(initialMatchedApplicant || firstApplicant);
     // eslint-disable-next-line
   }, [initialScheduleEntries]);
 
   useEffect(() => {
-    setSelectedApplicant(applicants[0]);
-  }, [applicants]);
+    const initialMatchedApplicant = initialScheduleEntries.find(
+      ([, a]) => a.applicantId === applicants[0]?.applicantId,
+    )?.[1];
+    setSelectedApplicant(initialMatchedApplicant || applicants[0]);
+  }, [applicants, initialScheduleEntries]);
 
   return (
     <InterviewPageLayout
@@ -83,15 +103,21 @@ export const ManualScheduleMode = () => {
                 .entries()
                 .find(([, applicant]) => applicant.applicantId === v.applicantId);
 
+              const initialMatchedApplicant = initialScheduleEntries.find(
+                ([, a]) => a.applicantId === v.applicantId,
+              )?.[1];
+
+              const targetApplicant = settedApplicantEntry?.[1] || initialMatchedApplicant || v;
+
               if (settedApplicantEntry) {
                 jump(settedApplicantEntry[0]);
-              } else if (v.availableTimes.length > 0) {
+              } else if (targetApplicant.availableTimes.length > 0) {
                 const earliest = Math.min(
-                  ...v.availableTimes.map((time) => new Date(time).getTime()),
+                  ...targetApplicant.availableTimes.map((time) => new Date(time).getTime()),
                 );
                 jump(new Date(earliest));
               }
-              setSelectedApplicant(v);
+              setSelectedApplicant(targetApplicant);
             }}
             selectedApplicant={selectedApplicant}
           />

--- a/src/query/schedule/mutations/postSchedule.ts
+++ b/src/query/schedule/mutations/postSchedule.ts
@@ -5,7 +5,7 @@ interface PostScheduleParams {
   schedules: Array<{
     applicantId: number;
     endTime: string;
-    locationDetail?: string;
+    locationDetail?: null | string;
     locationType: LocationType;
     partId: number;
     startTime: string;


### PR DESCRIPTION
## as-is
면접 일정 > 수동으로 일정을 지정할 때 장소가 동방으로 초기화되던 문제가 있었어요.

## to-be
이 PR에서는 기존 장소 타입과 장소 상세를 유지하는 방향으로 수정했어요.

## 기타

- 자동으로 일정을 만드는 경우는 동방으로 무조건 고정돼요. (수정/신규 생성 상관없이)
