### PR TITLE
feat: 메일 에디터 내에서 심볼 보이도록 설정 추가

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -12,4 +12,42 @@
     font-size: 3.2em;
     line-height: 1.1;
   }
+  ul {
+    margin: 0;
+    margin-top: 4px;
+    list-style: none;
+  }
+  ul li {
+    margin-top: 4px;
+    position: relative;
+    padding-left: 24px;
+  }
+  ul li:before {
+    content: '•';
+    display: inline-block;
+    min-width: 22px;
+    position: absolute;
+    left: 0;
+    text-align: center;
+  }
+  ol {
+    margin: 0;
+    margin-top: 4px;
+    list-style: none;
+    counter-reset: list-counter;
+  }
+  ol li {
+    margin-top: 4px;
+    position: relative;
+    padding-left: 24px;
+    counter-increment: list-counter;
+  }
+  ol li:before {
+    content: counter(list-counter) '.';
+    display: inline-block;
+    min-width: 22px;
+    position: absolute;
+    left: 0;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
## as-is

- 메일 에디터 내에서 심볼 안 보이는 문제가 있었어요(실제 메일 전송 시에는 보임)

> numbered list, unordered list의 심볼이 보이지 않습니다!!!
> 사진상 하단 툴바에서 리스트가 활성화된 것처럼, 시스템상 list 형태임은 지정되어있으나, 그 심볼만 보이지 않는 것 같습니다.
> from Roro
<img width="954" height="706" alt="image" src="https://github.com/user-attachments/assets/a7b717c9-fb63-4212-8413-3ae96e24e18c" />

## to-be

- bass.css 에 ul/ol 스타일 설정 추가해서 해결

<img width="640" height="318" alt="스크린샷 2026-03-16 오전 12 21 27" src="https://github.com/user-attachments/assets/58aa5ef4-af73-4b19-a23d-c5a23f34cec2" />



