### PR TITLE
feat: 멤버 api 스펙 변경사항을 반영하여 필드 수정

### DIFF
--- a/src/components/Cell/InputCell.tsx
+++ b/src/components/Cell/InputCell.tsx
@@ -1,10 +1,25 @@
 import { IcEditLine } from '@yourssu/design-system-react';
+import { HoverCard } from 'radix-ui';
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import styled from 'styled-components';
 
 import { StyledEditIcon, StyledInput } from '@/components/Cell/Cell.style.ts';
 import Cell from '@/components/Cell/Cell.tsx';
 import { Tooltip } from '@/components/Tooltip/Tooltip.tsx';
+
+const StyledFullTextContent = styled.div`
+  max-width: 360px;
+  padding: 10px 14px;
+  background: #373a43;
+  border-radius: ${({ theme }) => theme.semantic.radius.xs}px;
+  color: ${({ theme }) => theme.semantic.color.textBasicWhite};
+  ${({ theme }) => theme.typo.B2_Rg_15};
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.6;
+  z-index: 100;
+`;
 
 interface InputCellProps extends PropsWithChildren {
   bold?: boolean;
@@ -12,6 +27,7 @@ interface InputCellProps extends PropsWithChildren {
   disabled?: boolean;
   handleSubmit: (value: string) => void;
   tooltipContent: string;
+  truncate?: boolean;
 }
 
 const InputCell = ({
@@ -21,6 +37,7 @@ const InputCell = ({
   handleSubmit,
   bold = false,
   disabled = false,
+  truncate = false,
 }: InputCellProps) => {
   const [editing, setEditing] = useState(false);
   const { register, setFocus, watch } = useForm({
@@ -59,7 +76,30 @@ const InputCell = ({
         />
       ) : (
         <>
-          <span>{children}</span>
+          {truncate ? (
+            <HoverCard.Root closeDelay={100} openDelay={300}>
+              <HoverCard.Trigger asChild>
+                <span
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                    flex: 1,
+                  }}
+                >
+                  {children}
+                </span>
+              </HoverCard.Trigger>
+              <HoverCard.Portal>
+                <HoverCard.Content align="start" side="bottom" sideOffset={6}>
+                  <StyledFullTextContent>{children}</StyledFullTextContent>
+                </HoverCard.Content>
+              </HoverCard.Portal>
+            </HoverCard.Root>
+          ) : (
+            <span>{children}</span>
+          )}
           {!disabled && (
             <StyledEditIcon onClick={() => setEditing(true)}>
               <Tooltip content={tooltipContent}>

--- a/src/components/StateButton/GradeStateButton.tsx
+++ b/src/components/StateButton/GradeStateButton.tsx
@@ -1,0 +1,28 @@
+import { Popover } from 'radix-ui';
+
+import { StateButton } from './StateButton';
+
+const GRADE_OPTIONS = ['1학년', '2학년', '3학년', '4학년', '5학년'].map((label) => ({ label }));
+
+export const GradeStateButton = ({
+  selectedValue,
+  onStateChange,
+  contentProps,
+  disabled = false,
+}: {
+  contentProps?: Popover.PopoverContentProps;
+  disabled?: boolean;
+  onStateChange: (value: number) => void;
+  selectedValue: null | number;
+}) => {
+  return (
+    <StateButton
+      contentProps={contentProps}
+      disabled={disabled}
+      onSelect={(value) => onStateChange(parseInt(value))}
+      options={GRADE_OPTIONS}
+      selectedValue={selectedValue != null ? `${selectedValue}학년` : '-'}
+      variant="outlined"
+    />
+  );
+};

--- a/src/components/StateButton/index.ts
+++ b/src/components/StateButton/index.ts
@@ -1,3 +1,4 @@
 export * from './ApplicantStateButton';
+export * from './GradeStateButton';
 export * from './MemberStateButton';
 export * from './RoleStateButton';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -37,7 +37,16 @@ const Body = ({ rows }: { rows: Row<unknown>[] }) => (
     {rows.map((row) => (
       <StyledList key={row.id}>
         {row.getVisibleCells().map((cell) => (
-          <StyledBodyCell key={cell.id} style={{ minWidth: `${cell.column.getSize()}px` }}>
+          <StyledBodyCell
+            key={cell.id}
+            style={{
+              minWidth: `${cell.column.getSize()}px`,
+              maxWidth: (cell.column.columnDef.meta as { fixedWidth?: boolean } | undefined)
+                ?.fixedWidth
+                ? `${cell.column.getSize()}px`
+                : undefined,
+            }}
+          >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </StyledBodyCell>
         ))}

--- a/src/pages/SendMail/components/MailEditDialog/MailEditDialog.tsx
+++ b/src/pages/SendMail/components/MailEditDialog/MailEditDialog.tsx
@@ -85,7 +85,9 @@ const MailDialogContent = ({
   const bcc = useMemo(
     () =>
       (mailDetails[0]?.bccEmailAddresses ?? []).map(
-        (email) => allMembers.members.find((m) => m.email === email)?.nickname ?? email,
+        (email) =>
+          allMembers.members.find((m) => m.state !== '탈퇴' && m.email === email)?.nickname ??
+          email,
       ),
     [allMembers, mailDetails],
   );
@@ -117,7 +119,9 @@ const MailDialogContent = ({
 
   const senderEmail = mailDetails[0]?.senderEmailAddress;
   const sender = useMemo(
-    () => allMembers.members.find((m) => m.email === senderEmail)?.nickname ?? senderEmail,
+    () =>
+      allMembers.members.find((m) => m.state !== '탈퇴' && m.email === senderEmail)?.nickname ??
+      senderEmail,
     [allMembers, senderEmail],
   );
 

--- a/src/pages/SendMail/hooks/useMailReservation.ts
+++ b/src/pages/SendMail/hooks/useMailReservation.ts
@@ -44,7 +44,7 @@ export const useMailActions = () => {
 
     // 멤버에서 찾기
     const member = allMembers?.members.find((m) => m.nickname === name);
-    if (member) {
+    if (member && member.state !== '탈퇴' && 'email' in member) {
       return member.email;
     }
 

--- a/src/query/member/hooks/useMemberColumns.tsx
+++ b/src/query/member/hooks/useMemberColumns.tsx
@@ -6,7 +6,7 @@ import Cell from '@/components/Cell/Cell.tsx';
 import DepartmentCell from '@/components/Cell/DepartmentCell.tsx';
 import InputCell from '@/components/Cell/InputCell.tsx';
 import PartsCell from '@/components/Cell/PartsCell.tsx';
-import { MemberStateButton, RoleStateButton } from '@/components/StateButton';
+import { GradeStateButton, MemberStateButton, RoleStateButton } from '@/components/StateButton';
 import { SemesterStateButton } from '@/components/StateButton/SemesterStateButton.tsx';
 import {
   ActivePeriod,
@@ -320,6 +320,82 @@ export const useMemberColumns = (
               </Cell>
             ),
             size: 139,
+          }),
+        ]
+      : []),
+    ...(state === '액티브'
+      ? [
+          columnHelper.accessor('grade', {
+            header: '학년',
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '액티브') {
+                return (
+                  <Cell>
+                    <GradeStateButton
+                      contentProps={{ align: 'start' }}
+                      disabled={isSensitiveMasked}
+                      onStateChange={(value) => {
+                        if (handlePatchMember) {
+                          handlePatchMember(member.memberId, 'grade', value);
+                        }
+                      }}
+                      selectedValue={member.grade}
+                    />
+                  </Cell>
+                );
+              }
+            },
+            size: 120,
+          }),
+          columnHelper.accessor('isOnLeave', {
+            header: () => (
+              <div
+                style={{
+                  width: '100%',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  paddingRight: 16,
+                }}
+              >
+                휴학여부
+              </div>
+            ),
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '액티브') {
+                return (
+                  <Cell>
+                    <div
+                      style={{
+                        paddingLeft: 8,
+                        width: '100%',
+                        display: 'flex',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <Checkbox
+                        disabled={isSensitiveMasked}
+                        onChange={(e) => {
+                          if (handlePatchMember) {
+                            handlePatchMember(
+                              member.memberId,
+                              'isOnLeave',
+                              e.currentTarget.checked,
+                            );
+                          }
+                        }}
+                        selected={Boolean(info.getValue())}
+                        size="large"
+                      >
+                        {''}
+                      </Checkbox>
+                    </div>
+                  </Cell>
+                );
+              }
+            },
+            size: 120,
           }),
         ]
       : []),

--- a/src/query/member/hooks/useMemberColumns.tsx
+++ b/src/query/member/hooks/useMemberColumns.tsx
@@ -86,28 +86,32 @@ export const useMemberColumns = (
       header: '파트',
       size: 214,
     }),
-    columnHelper.accessor('role', {
-      header: '역할',
-      cell: (info) => {
-        return (
-          <Cell>
-            <RoleStateButton
-              contentProps={{
-                align: 'start',
-              }}
-              disabled={isSensitiveMasked}
-              onStateChange={(state) => {
-                if (handlePatchMember) {
-                  handlePatchMember(info.row.original.memberId, 'role', state);
-                }
-              }}
-              selectedValue={info.getValue()}
-            />
-          </Cell>
-        );
-      },
-      size: 146,
-    }),
+    ...(state !== '탈퇴'
+      ? [
+          columnHelper.accessor('role', {
+            header: '역할',
+            cell: (info) => {
+              return (
+                <Cell>
+                  <RoleStateButton
+                    contentProps={{
+                      align: 'start',
+                    }}
+                    disabled={isSensitiveMasked}
+                    onStateChange={(state) => {
+                      if (handlePatchMember) {
+                        handlePatchMember(info.row.original.memberId, 'role', state);
+                      }
+                    }}
+                    selectedValue={info.getValue()}
+                  />
+                </Cell>
+              );
+            },
+            size: 146,
+          }),
+        ]
+      : []),
     columnHelper.accessor('name', {
       header: '이름',
       cell: (info) => (
@@ -145,133 +149,143 @@ export const useMemberColumns = (
       ),
       size: 192,
     }),
-    columnHelper.accessor('state', {
-      header: '상태',
-      cell: (info) => (
-        <Cell>
-          <MemberStateButton
-            contentProps={{
-              align: 'start',
-            }}
-            disabled={isSensitiveMasked}
-            onStateChange={(value) => {
-              if (handlePatchMember) {
-                handlePatchMember(info.row.original.memberId, 'state', value);
-              }
-            }}
-            selectedValue={info.getValue()}
-          />
-        </Cell>
-      ),
-      size: 144,
-    }),
-    columnHelper.accessor('email', {
-      header: '유어슈 이메일',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue()}
-          disabled={isSensitiveMasked}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'email', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </InputCell>
-      ),
-      size: 235,
-    }),
-    columnHelper.accessor('phoneNumber', {
-      header: '연락처',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue() ?? '010-****-****'}
-          disabled={isSensitiveMasked}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'phoneNumber', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue() ?? '010-****-****'}
-        </InputCell>
-      ),
-      size: 175,
-    }),
-    columnHelper.accessor('department', {
-      header: '전공',
-      cell: (info) => (
-        <DepartmentCell
-          disabled={isSensitiveMasked}
-          onSelect={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'departmentId', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </DepartmentCell>
-      ),
-      size: 260,
-    }),
-    columnHelper.accessor('studentId', {
-      header: '학번',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue() ?? '********'}
-          disabled={isSensitiveMasked}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'studentId', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue() ?? '********'}
-        </InputCell>
-      ),
-      size: 136,
-    }),
-    columnHelper.accessor('birthDate', {
-      header: '생년월일',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue() ?? '********'}
-          disabled={isSensitiveMasked}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'birthDate', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue() ?? '********'}
-        </InputCell>
-      ),
-      size: 142,
-    }),
-    columnHelper.accessor('joinDate', {
-      header: '가입일',
-      cell: (info) => (
-        <InputCell
-          defaultValue={info.getValue()}
-          disabled={isSensitiveMasked}
-          handleSubmit={(value) => {
-            if (handlePatchMember) {
-              handlePatchMember(info.row.original.memberId, 'joinDate', value);
-            }
-          }}
-          tooltipContent={`${info.row.original.name} 정보 수정`}
-        >
-          {info.getValue()}
-        </InputCell>
-      ),
-      size: 142,
-    }),
+    ...(state !== '탈퇴'
+      ? [
+          columnHelper.accessor('state', {
+            header: '상태',
+            cell: (info) => (
+              <Cell>
+                <MemberStateButton
+                  contentProps={{
+                    align: 'start',
+                  }}
+                  disabled={isSensitiveMasked}
+                  onStateChange={(value) => {
+                    if (handlePatchMember) {
+                      handlePatchMember(info.row.original.memberId, 'state', value);
+                    }
+                  }}
+                  selectedValue={info.getValue()}
+                />
+              </Cell>
+            ),
+            size: 144,
+          }),
+          columnHelper.accessor((row) => (row as Exclude<Member, { state: '탈퇴' }>).email, {
+            id: 'email',
+            header: '유어슈 이메일',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue()}
+                disabled={isSensitiveMasked}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'email', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue()}
+              </InputCell>
+            ),
+            size: 235,
+          }),
+          columnHelper.accessor((row) => (row as Exclude<Member, { state: '탈퇴' }>).phoneNumber, {
+            id: 'phoneNumber',
+            header: '연락처',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? '010-****-****'}
+                disabled={isSensitiveMasked}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'phoneNumber', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? '010-****-****'}
+              </InputCell>
+            ),
+            size: 175,
+          }),
+          columnHelper.accessor((row) => (row as Exclude<Member, { state: '탈퇴' }>).department, {
+            id: 'department',
+            header: '전공',
+            cell: (info) => (
+              <DepartmentCell
+                disabled={isSensitiveMasked}
+                onSelect={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'departmentId', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue()}
+              </DepartmentCell>
+            ),
+            size: 260,
+          }),
+          columnHelper.accessor((row) => (row as Exclude<Member, { state: '탈퇴' }>).studentId, {
+            id: 'studentId',
+            header: '학번',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? '********'}
+                disabled={isSensitiveMasked}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'studentId', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? '********'}
+              </InputCell>
+            ),
+            size: 136,
+          }),
+          columnHelper.accessor((row) => (row as Exclude<Member, { state: '탈퇴' }>).birthDate, {
+            id: 'birthDate',
+            header: '생년월일',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue() ?? '********'}
+                disabled={isSensitiveMasked}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'birthDate', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue() ?? '********'}
+              </InputCell>
+            ),
+            size: 142,
+          }),
+          columnHelper.accessor((row) => (row as Exclude<Member, { state: '탈퇴' }>).joinDate, {
+            id: 'joinDate',
+            header: '가입일',
+            cell: (info) => (
+              <InputCell
+                defaultValue={info.getValue()}
+                disabled={isSensitiveMasked}
+                handleSubmit={(value) => {
+                  if (handlePatchMember) {
+                    handlePatchMember(info.row.original.memberId, 'joinDate', value);
+                  }
+                }}
+                tooltipContent={`${info.row.original.name} 정보 수정`}
+              >
+                {info.getValue()}
+              </InputCell>
+            ),
+            size: 142,
+          }),
+        ]
+      : []),
     ...(state === '액티브' && !isSensitiveMasked
       ? [
           columnHelper.accessor('membershipFee', {
@@ -396,13 +410,13 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...(state === '졸업' || state === '수료'
+    ...(state === '졸업'
       ? [
           columnHelper.accessor('activePeriod', {
             header: '활동 기간',
             cell: (info) => {
               const member = info.row.original;
-              if (member.state === '졸업' || member.state === '수료') {
+              if (member.state === '졸업') {
                 const activePeriod = member.activePeriod || {
                   startSemester: '****-*',
                   endSemester: '****-*',
@@ -571,7 +585,34 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...((state === '졸업' || state === '수료') && !isSensitiveMasked
+    ...(state === '수료'
+      ? [
+          columnHelper.accessor('completionSemester', {
+            header: '수료 일자',
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '수료') {
+                return (
+                  <InputCell
+                    defaultValue={member.completionSemester ?? ''}
+                    disabled={isSensitiveMasked}
+                    handleSubmit={(value) => {
+                      if (handlePatchMember) {
+                        handlePatchMember(member.memberId, 'completionSemester', value);
+                      }
+                    }}
+                    tooltipContent={`${member.name} 정보 수정`}
+                  >
+                    {member.completionSemester ?? ''}
+                  </InputCell>
+                );
+              }
+            },
+            size: 142,
+          }),
+        ]
+      : []),
+    ...(state === '졸업' && !isSensitiveMasked
       ? [
           columnHelper.accessor('isAdvisorDesired', {
             header: '어드바이저 희망',
@@ -605,6 +646,33 @@ export const useMemberColumns = (
               </Cell>
             ),
             size: 131,
+          }),
+        ]
+      : []),
+    ...(state === '탈퇴'
+      ? [
+          columnHelper.accessor('withdrawnDate', {
+            header: '탈퇴 일자',
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '탈퇴') {
+                return (
+                  <InputCell
+                    defaultValue={member.withdrawnDate ?? ''}
+                    disabled={isSensitiveMasked}
+                    handleSubmit={(value) => {
+                      if (handlePatchMember) {
+                        handlePatchMember(member.memberId, 'withdrawnDate', value);
+                      }
+                    }}
+                    tooltipContent={`${member.name} 정보 수정`}
+                  >
+                    {member.withdrawnDate ?? ''}
+                  </InputCell>
+                );
+              }
+            },
+            size: 142,
           }),
         ]
       : []),

--- a/src/query/member/hooks/useMemberColumns.tsx
+++ b/src/query/member/hooks/useMemberColumns.tsx
@@ -8,10 +8,7 @@ import InputCell from '@/components/Cell/InputCell.tsx';
 import PartsCell from '@/components/Cell/PartsCell.tsx';
 import { GradeStateButton, MemberStateButton, RoleStateButton } from '@/components/StateButton';
 import { SemesterStateButton } from '@/components/StateButton/SemesterStateButton.tsx';
-import {
-  ActivePeriod,
-  InactivePeriod,
-} from '@/pages/Members/components/MemberTable/MemberTable.style.ts';
+import { ActivePeriod } from '@/pages/Members/components/MemberTable/MemberTable.style.ts';
 import { Member, MemberState, PatchMember } from '@/query/member/schema.ts';
 import { partOptions } from '@/query/part/options.ts';
 import { semesterOptions } from '@/query/semester/options.ts';
@@ -399,17 +396,13 @@ export const useMemberColumns = (
           }),
         ]
       : []),
-    ...(state === '비액티브' || state === '졸업' || state === '수료'
+    ...(state === '졸업' || state === '수료'
       ? [
           columnHelper.accessor('activePeriod', {
             header: '활동 기간',
             cell: (info) => {
               const member = info.row.original;
-              if (
-                member.state === '비액티브' ||
-                member.state === '졸업' ||
-                member.state === '수료'
-              ) {
+              if (member.state === '졸업' || member.state === '수료') {
                 const activePeriod = member.activePeriod || {
                   startSemester: '****-*',
                   endSemester: '****-*',
@@ -440,6 +433,20 @@ export const useMemberColumns = (
               }
             },
             size: 185,
+          }),
+        ]
+      : []),
+    ...(state === '비액티브'
+      ? [
+          columnHelper.accessor('activeSemesterCountLabel', {
+            header: '액티브 학기 수',
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '비액티브') {
+                return <Cell>{member.activeSemesterCountLabel ?? '-'}</Cell>;
+              }
+            },
+            size: 137,
           }),
         ]
       : []),
@@ -479,42 +486,88 @@ export const useMemberColumns = (
       : []),
     ...(state === '비액티브'
       ? [
-          columnHelper.accessor('inactivePeriod', {
-            header: '비액티브 기간',
+          columnHelper.accessor('inactiveSemesterCountLabel', {
+            header: '비액티브 학기 수',
             cell: (info) => {
               const member = info.row.original;
               if (member.state === '비액티브') {
-                const inactivePeriod = member.inactivePeriod || {
-                  startSemester: '****-*',
-                  endSemester: '****-*',
-                };
+                return <Cell>{member.inactiveSemesterCountLabel ?? '-'}</Cell>;
+              }
+            },
+            size: 152,
+          }),
+          columnHelper.accessor('reason', {
+            header: '비액티브 사유',
+            meta: { fixedWidth: true },
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '비액티브') {
+                return (
+                  <InputCell
+                    defaultValue={member.reason ?? ''}
+                    disabled={isSensitiveMasked}
+                    handleSubmit={(value) => {
+                      if (handlePatchMember) {
+                        handlePatchMember(member.memberId, 'reason', value);
+                      }
+                    }}
+                    tooltipContent={`${member.name} 정보 수정`}
+                    truncate
+                  >
+                    {member.reason ?? ''}
+                  </InputCell>
+                );
+              }
+            },
+            size: 400,
+          }),
+          columnHelper.accessor('smsReplied', {
+            header: '문자회신여부',
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '비액티브') {
                 return (
                   <Cell>
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 4,
+                    <Checkbox
+                      disabled={isSensitiveMasked}
+                      onChange={(e) => {
+                        if (handlePatchMember) {
+                          handlePatchMember(member.memberId, 'smsReplied', e.currentTarget.checked);
+                        }
                       }}
+                      selected={Boolean(member.smsReplied)}
+                      size="large"
                     >
-                      <InactivePeriod disabled size="small" variant="filledSecondary">
-                        {inactivePeriod.startSemester}
-                      </InactivePeriod>
-                      ~
-                      <InactivePeriod
-                        disabled
-                        size="small"
-                        style={{ pointerEvents: 'none' }}
-                        variant="filledSecondary"
-                      >
-                        {inactivePeriod.endSemester}
-                      </InactivePeriod>
-                    </div>
+                      {''}
+                    </Checkbox>
                   </Cell>
                 );
               }
             },
-            size: 185,
+            size: 120,
+          }),
+          columnHelper.accessor('smsReplyDesiredPeriod', {
+            header: '문자회신 희망시기',
+            cell: (info) => {
+              const member = info.row.original;
+              if (member.state === '비액티브') {
+                return (
+                  <InputCell
+                    defaultValue={member.smsReplyDesiredPeriod ?? ''}
+                    disabled={isSensitiveMasked}
+                    handleSubmit={(value) => {
+                      if (handlePatchMember) {
+                        handlePatchMember(member.memberId, 'smsReplyDesiredPeriod', value);
+                      }
+                    }}
+                    tooltipContent={`${member.name} 정보 수정`}
+                  >
+                    {member.smsReplyDesiredPeriod ?? ''}
+                  </InputCell>
+                );
+              }
+            },
+            size: 152,
           }),
         ]
       : []),

--- a/src/query/member/schema.ts
+++ b/src/query/member/schema.ts
@@ -42,7 +42,7 @@ const ActiveMemberSchema = BaseMemberSchema.extend({
   membershipFee: z.boolean().nullable(),
   state: z.literal('액티브'),
   grade: z.number().nullable(),
-  isOnLeave: z.boolean().nullable(),
+  isOnLeave: z.boolean().nullable(), // 휴학 여부
 });
 
 const InactiveMemberSchema = BaseMemberSchema.extend({
@@ -50,6 +50,11 @@ const InactiveMemberSchema = BaseMemberSchema.extend({
   expectedReturnSemester: z.string().nullable(),
   inactivePeriod: PeriodSchema.nullable(),
   state: z.literal('비액티브'),
+  reason: z.string().nullable(), // 비액티브 사유
+  smsReplied: z.boolean().nullable(), // 문자 회신 여부
+  smsReplyDesiredPeriod: z.string().nullable(), // 문자 회신 희망 시기
+  activeSemesterCountLabel: z.string().nullable(), // 총 액티브 학기 수
+  inactiveSemesterCountLabel: z.string().nullable(), // 총 비액티브 학기 수
 });
 
 const GraduatedMemberSchema = BaseMemberSchema.extend({

--- a/src/query/member/schema.ts
+++ b/src/query/member/schema.ts
@@ -64,13 +64,19 @@ const GraduatedMemberSchema = BaseMemberSchema.extend({
 });
 
 const CompletedMemberSchema = BaseMemberSchema.extend({
-  activePeriod: PeriodSchema.nullable(),
-  isAdvisorDesired: z.boolean().nullable(),
+  completionSemester: z.string().nullable(),
   state: z.literal('수료'),
 });
 
-const WithdrawnMemberSchema = BaseMemberSchema.extend({
+const WithdrawnMemberSchema = z.object({
+  memberId: z.number(),
+  parts: z.array(PartSchema),
+  role: MemberRoleSchema,
+  name: z.string(),
+  nickname: z.string(),
   state: z.literal('탈퇴'),
+  withdrawnDate: DateSchema.nullable(),
+  note: z.string().nullable(),
 });
 
 const MemberSchema = z.discriminatedUnion('state', [

--- a/src/query/member/schema.ts
+++ b/src/query/member/schema.ts
@@ -41,6 +41,8 @@ export const MeSchema = BaseMemberSchema.omit({
 const ActiveMemberSchema = BaseMemberSchema.extend({
   membershipFee: z.boolean().nullable(),
   state: z.literal('액티브'),
+  grade: z.number().nullable(),
+  isOnLeave: z.boolean().nullable(),
 });
 
 const InactiveMemberSchema = BaseMemberSchema.extend({

--- a/src/utils/getEmailAddress.ts
+++ b/src/utils/getEmailAddress.ts
@@ -9,5 +9,8 @@ export const getEmailAddress = ({ input }: GetEmailAddressParams) => {
   if (typeof input === 'string') {
     return input;
   }
-  return input.email;
+  if ('email' in input) {
+    return input.email;
+  }
+  return undefined;
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

멤버 api 응답이 변경됨에 따라 관련 작업을 했어요.
- 액티브: 학년, 휴학여부 추가
- 비액티브: 액티브/비액 기간 -> 학기 수 카운트로 변경 + 비액티브 사유, 문자회신 여부, 문자회신 희망 시기 추가
- 수료: 수료일자 추가, 활동학기 & advisor여부 삭제
- 탈퇴: 구분, 파트, 이름, 닉네임(발음), 탈퇴 일자, 비고 6개 필드만 사용

자세한 내용: https://yourssu.slack.com/archives/C082XCSQK0F/p1774340731107079?thread_ts=1774339191.237669&cid=C082XCSQK0F


