### PR TITLE
feat: 템플릿 및 메일 예약 스펙 개편

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -19,9 +19,7 @@
   "paths": {
     "/recruiter/schedule/part/{partId}": {
       "put": {
-        "tags": [
-          "면접 일정"
-        ],
+        "tags": ["면접 일정"],
         "summary": "파트 스케줄 수정 API",
         "description": "특정 파트의 스케줄을 전체 수정합니다.",
         "operationId": "updateByPart",
@@ -61,9 +59,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "면접 일정"
-        ],
+        "tags": ["면접 일정"],
         "summary": "파트별 스케줄 삭제 API",
         "description": "특정 파트의 모든 면접 스케줄을 삭제합니다.",
         "operationId": "deleteByPart",
@@ -104,9 +100,7 @@
     },
     "/api/mails/templates/{templateId}": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 템플릿 상세 조회",
         "description": "특정 메일 템플릿의 상세 내용을 조회합니다. (편집용)",
         "operationId": "readDetail",
@@ -136,9 +130,7 @@
         }
       },
       "put": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 템플릿 수정",
         "description": "특정 메일 템플릿을 수정합니다. 전체 메일 템플릿의 내용을 보내야 합니다.\n\n**변수 규칙:**\n- 모든 변수 키는 `var-{UUID}` 형식이어야 합니다 (예: `var-550e8400-e29b-41d4-a716-446655440000`)",
         "operationId": "update",
@@ -177,9 +169,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 템플릿 삭제",
         "description": "특정 메일 템플릿을 삭제합니다. 해당 메일 템플릿이 없을 시 404를 반환합니다.",
         "operationId": "delete",
@@ -208,9 +198,7 @@
     },
     "/api/mails/reservation/{reservationId}": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "예약 메일 단건 조회",
         "description": "예약 ID에 해당하는 메일 예약 상세를 조회합니다. status: SCHEDULED, PENDING_SEND, SENT. 다른 사용자의 예약에는 접근할 수 없습니다.",
         "operationId": "getReservationDetail",
@@ -259,9 +247,7 @@
         }
       },
       "put": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "예약 메일 수정",
         "description": "기존 예약 메일의 발송 시각과 내용을 수정합니다. 요청 바디는 생성과 동일한 MailReserveRequest 형식을 사용하며, 전체를 교체합니다.",
         "operationId": "updateReservation",
@@ -314,9 +300,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "예약 메일 취소",
         "description": "아직 발송되지 않은 예약 메일을 취소합니다.",
         "operationId": "cancelReservation",
@@ -361,9 +345,7 @@
     },
     "/withdrawal": {
       "post": {
-        "tags": [
-          "인증/인가"
-        ],
+        "tags": ["인증/인가"],
         "summary": "회원 탈퇴",
         "operationId": "withdraw",
         "requestBody": {
@@ -386,9 +368,7 @@
     },
     "/semesters": {
       "get": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "학기 전체 조회",
         "description": "생성된 전체 학기 정보를 조회합니다.",
         "operationId": "readAll",
@@ -409,9 +389,7 @@
         }
       },
       "post": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "학기 생성",
         "description": "연도, 학기 조합으로 학기를 생성합니다.",
         "operationId": "create",
@@ -435,9 +413,7 @@
     },
     "/refresh-token": {
       "post": {
-        "tags": [
-          "인증/인가"
-        ],
+        "tags": ["인증/인가"],
         "summary": "토큰 재발급",
         "description": "Authorization 헤더는 무시되며, 바디의 refreshToken(순수 JWT)만 사용합니다.",
         "operationId": "refreshToken",
@@ -478,9 +454,7 @@
     },
     "/recruiter/schedule": {
       "get": {
-        "tags": [
-          "면접 일정"
-        ],
+        "tags": ["면접 일정"],
         "summary": "면접 스케줄 조회 API",
         "description": "면접 스케줄 조회 API 입니다. 추후 partID를 입력하지 않으면 전체 조회가 되도록 변경 예정",
         "operationId": "getSchedules",
@@ -512,9 +486,7 @@
         }
       },
       "post": {
-        "tags": [
-          "면접 일정"
-        ],
+        "tags": ["면접 일정"],
         "summary": "면접 스케줄 추가 API",
         "description": "면접 스케줄을 추가하는 API 입니다.",
         "operationId": "createSchedules",
@@ -541,10 +513,7 @@
     },
     "/oauth2/login/{oauth2Type}": {
       "post": {
-        "tags": [
-          "OAUTH2",
-          "인증/인가"
-        ],
+        "tags": ["OAUTH2", "인증/인가"],
         "summary": "로그인",
         "description": "/oauth2/{oauth2Type}에서 얻은 code를 이용해 로그인을 진행합니다. 등록된 멤버만 로그인할 수 있습니다.",
         "operationId": "login",
@@ -555,9 +524,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [
-                "GOOGLE"
-              ]
+              "enum": ["GOOGLE"]
             }
           }
         ],
@@ -598,10 +565,7 @@
     },
     "/members/include-from-applicants": {
       "post": {
-        "tags": [
-          "합격자 동기화 API",
-          "유어슈 멤버"
-        ],
+        "tags": ["합격자 동기화 API", "유어슈 멤버"],
         "summary": "지원자 중 합격자 멤버 동기화",
         "description": "리크루팅 지원자 중 합격자를 멤버에 동기화 합니다.",
         "operationId": "includeFromApplicants",
@@ -637,10 +601,7 @@
     },
     "/members/include-from-applicants/{semesterString}": {
       "post": {
-        "tags": [
-          "합격자 동기화 API",
-          "유어슈 멤버"
-        ],
+        "tags": ["합격자 동기화 API", "유어슈 멤버"],
         "summary": "지정 학기 합격자 멤버 동기화",
         "description": "지정한 학기(semesterString, yy-term 예: 25-1)의 합격자만 멤버에 동기화합니다. 없으면 전체 동기화와 동일.",
         "operationId": "includeFromApplicants_1",
@@ -690,9 +651,7 @@
     },
     "/logout": {
       "post": {
-        "tags": [
-          "인증/인가"
-        ],
+        "tags": ["인증/인가"],
         "summary": "로그아웃",
         "operationId": "logout",
         "requestBody": {
@@ -715,9 +674,7 @@
     },
     "/internal/dev/member-privacy/privileged/self/enable": {
       "post": {
-        "tags": [
-          "[DEV] 멤버 민감정보 권한 테스트"
-        ],
+        "tags": ["[DEV] 멤버 민감정보 권한 테스트"],
         "summary": "나를 권한자로 복원 (테스트용)",
         "description": "비권한자로 전환한 상태를 해제하고, 다시 민감정보 열람 권한이 있는 상태로 돌립니다.",
         "operationId": "enablePrivilegeForSelf",
@@ -735,9 +692,7 @@
     },
     "/internal/dev/member-privacy/privileged/self/disable": {
       "post": {
-        "tags": [
-          "[DEV] 멤버 민감정보 권한 테스트"
-        ],
+        "tags": ["[DEV] 멤버 민감정보 권한 테스트"],
         "summary": "나를 비권한자로 전환 (테스트용)",
         "description": "이후 멤버 API 호출 시 내 계정은 민감정보가 마스킹된 응답을 받습니다. 스카우터 팀원만 호출 가능.",
         "operationId": "disablePrivilegeForSelf",
@@ -755,9 +710,7 @@
     },
     "/applicants": {
       "get": {
-        "tags": [
-          "리크루팅 지원자"
-        ],
+        "tags": ["리크루팅 지원자"],
         "summary": "지원자 목록 조회",
         "description": "지원자 목록을 검색, 필터링을 통해 얻습니다. 필터링에 필요한 정보는 각 api에서 얻어야 합니다.",
         "operationId": "readAll_1",
@@ -814,9 +767,7 @@
         }
       },
       "post": {
-        "tags": [
-          "리크루팅 지원자"
-        ],
+        "tags": ["리크루팅 지원자"],
         "summary": "지원자 추가 API",
         "operationId": "create_1",
         "requestBody": {
@@ -845,10 +796,7 @@
     },
     "/applicants/include-from-forms": {
       "post": {
-        "tags": [
-          "지원자 동기화 API",
-          "리크루팅 지원자"
-        ],
+        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
         "summary": "구글폼 응답을 지원자 목록에 업데이트",
         "description": "현재 로그인 되어있는 사용자의 계정을 이용해 지원자의 구글폼 응답을 동기화 합니다.",
         "operationId": "includeFromForms",
@@ -874,10 +822,7 @@
     },
     "/applicants/include-from-forms/semesters/{semesterId}": {
       "post": {
-        "tags": [
-          "지원자 동기화 API",
-          "리크루팅 지원자"
-        ],
+        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
         "operationId": "includeFromFormsBySemesterAndPart",
         "parameters": [
           {
@@ -912,9 +857,7 @@
     },
     "/api/mails/templates": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 템플릿 목록 조회",
         "description": "현재 등록된 전체 메일 템플릿을 조회합니다.",
         "operationId": "readAll_2",
@@ -963,9 +906,7 @@
         }
       },
       "post": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 템플릿 생성",
         "description": "제목과 양식을 지정해 새로운 메일 템플릿을 생성합니다.\n\n**변수 규칙:**\n- 모든 변수 키는 `var-{UUID}` 형식이어야 합니다 (예: `var-550e8400-e29b-41d4-a716-446655440000`)\n- 메일 본문에서 변수는 `{{var-{UUID}}}` 형식으로 사용합니다\n\n**변수 타입:**\n- **사용자 입력 변수**: PERSON, DATE, LINK, TEXT\n- **자동 채움 변수**: APPLICANT, PARTNAME",
         "operationId": "create_2",
@@ -995,9 +936,7 @@
     },
     "/api/mails/send": {
       "post": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 즉시 발송",
         "description": "메일을 즉시 발송합니다. DB에 저장하지 않고 바로 발송됩니다. 파일은 사전에 /api/mails/files/* API로 업로드/확정한 뒤, fileId 참조만 전달합니다.",
         "operationId": "sendMail",
@@ -1041,9 +980,7 @@
     },
     "/api/mails/reservation": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "예약 메일 목록 조회",
         "description": "현재 사용자가 예약한 메일 목록을 조회합니다. status: SCHEDULED(예약됨), PENDING_SEND(발송 실패/재시도 대기), SENT(발송 완료)",
         "operationId": "getReservations",
@@ -1061,9 +998,7 @@
         }
       },
       "post": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 전송 예약",
         "description": "application/json으로 요청합니다. 파일은 사전에 /api/mails/files/* API로 업로드/확정한 뒤, 예약 시 fileId 참조만 전달합니다.",
         "operationId": "reserveMail",
@@ -1097,9 +1032,7 @@
     },
     "/api/mails/reservation/{reservationId}/retry": {
       "post": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "예약 메일 재전송",
         "description": "예약 시간이 지났는데 발송 실패(PENDING_SEND)인 메일을 즉시 재전송 시도합니다. 이미 발송된 메일(SENT)이나 예약 시간 전에는 호출할 수 없습니다.",
         "operationId": "retryReservation",
@@ -1164,9 +1097,7 @@
     },
     "/api/mails/files/presign": {
       "post": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 파일 업로드용 presigned URL 발급",
         "operationId": "createPresignedUploadUrls",
         "requestBody": {
@@ -1195,9 +1126,7 @@
     },
     "/api/mails/files/confirm": {
       "post": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "업로드 완료 파일 등록",
         "operationId": "confirmUploads",
         "requestBody": {
@@ -1226,9 +1155,7 @@
     },
     "/recruiter/schedule/{scheduleId}/location": {
       "patch": {
-        "tags": [
-          "면접 일정"
-        ],
+        "tags": ["면접 일정"],
         "summary": "면접 장소 변경 API",
         "description": "스케줄 ID를 기준으로 면접 장소 대분류와 세부장소를 수정합니다.",
         "operationId": "updateLocation",
@@ -1267,9 +1194,7 @@
     },
     "/members/withdrawn/{memberId}": {
       "patch": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "탈퇴 멤버 정보 수정",
         "description": "변경되지 않은 정보는 보내면 안됩니다.",
         "operationId": "updateWithdrawnById",
@@ -1316,9 +1241,7 @@
     },
     "/members/inactive/{memberId}": {
       "patch": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "비액티브 멤버 정보 수정",
         "description": "한 요청에는 (1) 회원 공통 프로필 필드만 또는 (2) 비액티브 전용 필드만 보낸다. 비액티브 전용은 조회 응답과 동일한 키(복귀 예정 학기 문자열, 사유, 문자 회신, 활동학기 라벨, 학기 수 등)를 사용한다. 활동 기간(activePeriod)·비액티브 기간(inactivePeriod) 객체와 activeSemesterCountLabel·inactiveSemesterCountLabel은 조회 전용이며 본문에 넣으면 Member-007이다. 복귀 예정 학기 변경 시 서버가 비액티브 기간 종료 학기를 도메인 규칙에 맞게 조정할 수 있다.",
         "operationId": "updateInactiveById",
@@ -1365,9 +1288,7 @@
     },
     "/members/graduated/{memberId}": {
       "patch": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "졸업 멤버 정보 수정",
         "description": "한 요청에는 (1) 회원 공통 프로필만 또는 (2) isAdvisorDesired만 보낸다. 활동 기간(activePeriod)은 조회 전용이며 본문에 넣으면 Member-007이다.",
         "operationId": "updateGraduatedById",
@@ -1414,9 +1335,7 @@
     },
     "/members/completed/{memberId}": {
       "patch": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "수료 멤버 정보 수정",
         "description": "변경되지 않은 정보는 보내면 안됩니다.",
         "operationId": "updateCompletedById",
@@ -1463,9 +1382,7 @@
     },
     "/members/active/{memberId}": {
       "patch": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "액티브 멤버 정보 수정",
         "description": "변경되지 않은 정보는 보내면 안됩니다.",
         "operationId": "updateActiveById",
@@ -1512,9 +1429,7 @@
     },
     "/applicants/{applicantId}": {
       "get": {
-        "tags": [
-          "리크루팅 지원자"
-        ],
+        "tags": ["리크루팅 지원자"],
         "summary": "지원자 단일 조회",
         "description": "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자의 세부정보를 확인합니다.",
         "operationId": "readById",
@@ -1543,9 +1458,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "리크루팅 지원자"
-        ],
+        "tags": ["리크루팅 지원자"],
         "summary": "지원자 삭제",
         "description": "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자를 삭제합니다.",
         "operationId": "deleteById",
@@ -1568,9 +1481,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "리크루팅 지원자"
-        ],
+        "tags": ["리크루팅 지원자"],
         "summary": "지원자 정보 수정",
         "description": "변경할 지원자 정보의 값을 보냅니다. 변경되지 않은 값은 보내면 안 됩니다.",
         "operationId": "updateById",
@@ -1605,9 +1516,7 @@
     },
     "/validate-token": {
       "get": {
-        "tags": [
-          "인증/인가"
-        ],
+        "tags": ["인증/인가"],
         "summary": "AccessToken 유효성 검사",
         "operationId": "validateToken",
         "responses": {
@@ -1627,9 +1536,7 @@
     },
     "/semesters/now": {
       "get": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "현재 학기 조회",
         "description": "현재 학기에 해당하는 정보를 조회합니다.",
         "operationId": "readByDate",
@@ -1649,9 +1556,7 @@
     },
     "/recruiter/schedule/auto/{partId}": {
       "get": {
-        "tags": [
-          "면접 일정"
-        ],
+        "tags": ["면접 일정"],
         "summary": "면접 스케줄 자동 생성 API",
         "description": "\n            백트래킹 알고리즘을 사용하여 면접 스케줄을 자동 생성합니다.\n            - 같은 파트의 같은 시간에는 중복 배정하지 않습니다.\n            - 모든 지원자를 배정할 수 없는 경우 400 에러를 반환합니다.\n            - 지원자가 많을 경우 응답 시간이 길어질 수 있습니다.\n            - **주의**: 저장은 되지 않으며, 미리보기 용도입니다.\n        ",
         "operationId": "getAutoSchedules",
@@ -1696,9 +1601,7 @@
     },
     "/parts": {
       "get": {
-        "tags": [
-          "구분/파트"
-        ],
+        "tags": ["구분/파트"],
         "summary": "파트(팀) 목록 조회",
         "description": "Head lead, Finance 등 파트 목록을 조회합니다.",
         "operationId": "readAll_3",
@@ -1721,10 +1624,7 @@
     },
     "/oauth2/{oauth2Type}": {
       "get": {
-        "tags": [
-          "OAUTH2",
-          "인증/인가"
-        ],
+        "tags": ["OAUTH2", "인증/인가"],
         "summary": "OAuth2 로그인 페이지 리다이렉트",
         "description": "여기에서는 리다이렉트가 되지 않습니다. Authorize 이용.",
         "operationId": "redirectAuthCodeRequestUrl",
@@ -1735,9 +1635,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [
-                "GOOGLE"
-              ]
+              "enum": ["GOOGLE"]
             }
           }
         ],
@@ -1752,10 +1650,7 @@
     },
     "/oauth2/google-refresh-token-status": {
       "get": {
-        "tags": [
-          "OAUTH2",
-          "인증/인가"
-        ],
+        "tags": ["OAUTH2", "인증/인가"],
         "summary": "Google refresh token 유효 여부 조회",
         "description": "현재 사용자의 Google OAuth2 refresh token이 유효한지 검사합니다. 무효일 때는 401을 반환하며, 다른 인증 실패(401)와 동일하게 재로그인 유도 처리하면 됩니다. 메일 예약, 구글 폼/드라이브 동기화 등 Google API 연동 기능에서 공통으로 사용할 수 있습니다.",
         "operationId": "getGoogleRefreshTokenStatus",
@@ -1785,9 +1680,7 @@
     },
     "/members/withdrawn": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "탈퇴 멤버 목록 조회/검색",
         "description": "응답 필드: memberId, parts(구분·파트), role, name, nickname(영어(한글발음)), state, withdrawnDate, note. 이메일·연락처·전공·학번·생년월일·가입일은 포함하지 않음. HR·스카우터가 아니면 isSensitiveMasked true이며 탈퇴일자·비고는 null.",
         "operationId": "readAllWithdrawn",
@@ -1828,9 +1721,7 @@
     },
     "/members/states": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "멤버 상태 목록 조회",
         "description": "액티브, 비액티브, 수료, 졸업, 탈퇴 등 상태를 조회합니다.",
         "operationId": "readAllMemberStates",
@@ -1853,9 +1744,7 @@
     },
     "/members/roles": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "멤버 역할 목록 조회",
         "description": "Lead, Vice Lead, Member 등 역할을 조회합니다.",
         "operationId": "readAllMemberRoles",
@@ -1878,9 +1767,7 @@
     },
     "/members/me": {
       "get": {
-        "tags": [
-          "내 정보"
-        ],
+        "tags": ["내 정보"],
         "summary": "내 정보 조회",
         "description": "액세스 토큰으로 현재 로그인한 사용자의 멤버 정보와 프로필 이미지를 조회합니다.",
         "operationId": "getMe",
@@ -1910,10 +1797,7 @@
     },
     "/members/lastUpdatedTime": {
       "get": {
-        "tags": [
-          "합격자 동기화 API",
-          "유어슈 멤버"
-        ],
+        "tags": ["합격자 동기화 API", "유어슈 멤버"],
         "summary": "마지막 동기화 시간 조회",
         "description": "유어슈 멤버의 마지막 동기화 시간을 조회합니다.",
         "operationId": "lastSyncTime",
@@ -1933,9 +1817,7 @@
     },
     "/members/inactive": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "비액티브 멤버 목록 조회/검색",
         "description": "응답은 기간 히스토리(activePeriod/inactivePeriod)와 UI 표기용 학기 수 라벨(activeSemesterCountLabel/inactiveSemesterCountLabel)을 함께 제공한다. 학기 수를 확정할 수 없으면 라벨은 null이다. HR·스카우터가 아니면 isSensitiveMasked true, 연락처·생년월일·학번·복귀예정·사유·문자회신·비고·학기 수 라벨 등 null.",
         "operationId": "readAllInActive",
@@ -1976,9 +1858,7 @@
     },
     "/members/graduated": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "졸업 멤버 목록 조회/검색",
         "description": "HR·스카우터가 아니면 isSensitiveMasked true, 민감 필드 및 졸업 기간(activePeriod) null.",
         "operationId": "readAllGraduated",
@@ -2019,9 +1899,7 @@
     },
     "/members/completed": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "수료 멤버 목록 조회/검색",
         "description": "응답 필드: memberId, parts(구분·파트), role, name, nickname(영어(한글발음)), state, email, phoneNumber, department, studentId, birthDate, joinDate, completionSemester(수료 학기), note. HR·스카우터가 아니면 isSensitiveMasked true이며 연락처·생년월일·학번·비고·completionSemester는 null.",
         "operationId": "readAllCompleted",
@@ -2062,9 +1940,7 @@
     },
     "/members/active": {
       "get": {
-        "tags": [
-          "유어슈 멤버"
-        ],
+        "tags": ["유어슈 멤버"],
         "summary": "액티브 멤버 목록 조회/검색",
         "description": "HR·스카우터 개발자가 아니면 isSensitiveMasked가 true이고, 연락처·생년월일·학번·회비·비고 등 민감 필드는 null로 내려갑니다.",
         "operationId": "readAllActive",
@@ -2105,9 +1981,7 @@
     },
     "/divisions": {
       "get": {
-        "tags": [
-          "구분/파트"
-        ],
+        "tags": ["구분/파트"],
         "summary": "멤버 구분 목록 조회",
         "description": "운영, 개발, 디자인 등 각 구분의 목록을 조회합니다.",
         "operationId": "readAll_4",
@@ -2130,9 +2004,7 @@
     },
     "/departments": {
       "get": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "전체 학과 조회",
         "description": "전체 학과 정보를 조회합니다.",
         "operationId": "readAll_5",
@@ -2155,9 +2027,7 @@
     },
     "/colleges": {
       "get": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "전체 단과대 조회",
         "description": "전체 단과대의 정보를 조회합니다.",
         "operationId": "readAll_6",
@@ -2180,9 +2050,7 @@
     },
     "/colleges/{collegeId}/departments": {
       "get": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "단과대 소속 학과 조회",
         "description": "특정 단과대에 소속된 전체 학과 정보를 조회합니다.",
         "operationId": "readAllByCollegeId",
@@ -2216,9 +2084,7 @@
     },
     "/applicants/states": {
       "get": {
-        "tags": [
-          "리크루팅 지원자"
-        ],
+        "tags": ["리크루팅 지원자"],
         "summary": "지원자 상태 목록 조회",
         "description": "전체 지원자의 가능한 상태 목록을 확인합니다. 현재 지원자와는 관련이 없습니다.",
         "operationId": "readAllMemberStates_1",
@@ -2248,10 +2114,7 @@
     },
     "/applicants/lastUpdatedTime": {
       "get": {
-        "tags": [
-          "지원자 동기화 API",
-          "리크루팅 지원자"
-        ],
+        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
         "summary": "마지막 동기화 시간 조회",
         "operationId": "lastSyncTime_1",
         "responses": {
@@ -2270,9 +2133,7 @@
     },
     "/api/mails/reservation/status": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "예약 메일 발송 상태 조회",
         "description": "현재 사용자의 미발송 예약 목록과 발송 실패 사유를 조회합니다. failureErrorCode가 OAuth-Token-Refresh-Fail이면 재로그인 후 다음 스케줄 실행 시 자동 발송됩니다.",
         "operationId": "getReservationStatus",
@@ -2292,9 +2153,7 @@
     },
     "/api/mails/reservation/groups": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 그룹 목록 조회",
         "description": "메일 예약 그룹 메타데이터와 각 그룹에 속한 메일 ID 목록을 조회합니다. 1 예약 요청 = 1 그룹, 수신자 수만큼 메일 ID가 존재합니다.",
         "operationId": "getMailGroups",
@@ -2314,9 +2173,7 @@
     },
     "/api/mails/images": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 이미지 조회 (302 Redirect)",
         "description": "S3에 업로드된 이미지의 공개 URL로 302 리다이렉트합니다.\n\n**공개 엔드포인트:**\n- 인증 없이 접근 가능합니다.\n\n**사용 방법:**\n- `<img src=\"/api/mails/images?cid=xxx\">` 형태로 HTML에서 직접 사용 가능합니다.",
         "operationId": "redirectToImage",
@@ -2340,9 +2197,7 @@
     },
     "/api/mails/files": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "내 메일 파일 목록 조회",
         "operationId": "readFiles",
         "parameters": [
@@ -2352,10 +2207,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "INLINE",
-                "ATTACHMENT"
-              ]
+              "enum": ["INLINE", "ATTACHMENT"]
             }
           }
         ],
@@ -2375,9 +2227,7 @@
     },
     "/api/mails/files/download-url": {
       "get": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "메일 파일 다운로드용 presigned URL 발급",
         "operationId": "createPresignedDownloadUrl",
         "parameters": [
@@ -2406,9 +2256,7 @@
     },
     "/semesters/{semesterId}": {
       "delete": {
-        "tags": [
-          "학과/학기/단과대"
-        ],
+        "tags": ["학과/학기/단과대"],
         "summary": "학기 삭제",
         "description": "특정 학기 정보를 삭제합니다.",
         "operationId": "deleteById_1",
@@ -2433,9 +2281,7 @@
     },
     "/api/mails/files/{fileId}": {
       "delete": {
-        "tags": [
-          "메일"
-        ],
+        "tags": ["메일"],
         "summary": "내 메일 파일 삭제",
         "operationId": "deleteFile",
         "parameters": [
@@ -2481,24 +2327,13 @@
           },
           "locationType": {
             "type": "string",
-            "enum": [
-              "CLUB_ROOM",
-              "CLASS_ROOM",
-              "ONLINE",
-              "ETC"
-            ]
+            "enum": ["CLUB_ROOM", "CLASS_ROOM", "ONLINE", "ETC"]
           },
           "locationDetail": {
             "type": "string"
           }
         },
-        "required": [
-          "applicantId",
-          "endTime",
-          "locationType",
-          "partId",
-          "startTime"
-        ]
+        "required": ["applicantId", "endTime", "locationType", "partId", "startTime"]
       },
       "AttachmentReferenceRequest": {
         "type": "object",
@@ -2511,9 +2346,7 @@
             "example": 11
           }
         },
-        "required": [
-          "fileId"
-        ]
+        "required": ["fileId"]
       },
       "CreateMailTemplateRequest": {
         "type": "object",
@@ -2552,13 +2385,7 @@
             }
           }
         },
-        "required": [
-          "attachmentReferences",
-          "bodyHtml",
-          "subject",
-          "title",
-          "variables"
-        ]
+        "required": ["attachmentReferences", "bodyHtml", "subject", "title", "variables"]
       },
       "TemplateVariableRequest": {
         "type": "object",
@@ -2573,14 +2400,7 @@
           "type": {
             "type": "string",
             "description": "변수 타입. PERSON, DATE, LINK, TEXT는 사용자 입력 변수. APPLICANT, PARTNAME은 자동 채움 변수",
-            "enum": [
-              "PERSON",
-              "DATE",
-              "LINK",
-              "TEXT",
-              "APPLICANT",
-              "PARTNAME"
-            ],
+            "enum": ["PERSON", "DATE", "LINK", "TEXT", "APPLICANT", "PARTNAME"],
             "example": "TEXT"
           },
           "displayName": {
@@ -2599,12 +2419,7 @@
             "example": "applicant.name"
           }
         },
-        "required": [
-          "displayName",
-          "key",
-          "perRecipient",
-          "type"
-        ]
+        "required": ["displayName", "key", "perRecipient", "type"]
       },
       "CreateMailTemplateResponse": {
         "type": "object",
@@ -2621,11 +2436,7 @@
             "format": "date-time"
           }
         },
-        "required": [
-          "id",
-          "title",
-          "updatedAt"
-        ]
+        "required": ["id", "title", "updatedAt"]
       },
       "MailReserveRequest": {
         "type": "object",
@@ -2672,12 +2483,7 @@
             }
           }
         },
-        "required": [
-          "recipients",
-          "reservationTime",
-          "sharedBindings",
-          "templateId"
-        ]
+        "required": ["recipients", "reservationTime", "sharedBindings", "templateId"]
       },
       "RecipientRequest": {
         "type": "object",
@@ -2701,10 +2507,7 @@
             "description": "수신자별 바인딩 (perRecipient=true 변수)"
           }
         },
-        "required": [
-          "bindings",
-          "email"
-        ]
+        "required": ["bindings", "email"]
       },
       "ExceptionResponse": {
         "type": "object",
@@ -2724,12 +2527,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "errorCode",
-          "message",
-          "status",
-          "timestamp"
-        ]
+        "required": ["errorCode", "message", "status", "timestamp"]
       },
       "WithdrawalRequest": {
         "type": "object",
@@ -2739,9 +2537,7 @@
             "minLength": 1
           }
         },
-        "required": [
-          "refreshToken"
-        ]
+        "required": ["refreshToken"]
       },
       "CreateSemesterRequest": {
         "type": "object",
@@ -2755,10 +2551,7 @@
             "format": "int32"
           }
         },
-        "required": [
-          "term",
-          "year"
-        ]
+        "required": ["term", "year"]
       },
       "TokenRefreshRequest": {
         "type": "object",
@@ -2768,9 +2561,7 @@
             "minLength": 1
           }
         },
-        "required": [
-          "refreshToken"
-        ]
+        "required": ["refreshToken"]
       },
       "TokenRefreshResponse": {
         "type": "object",
@@ -2785,11 +2576,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "accessToken",
-          "refreshToken",
-          "tokenType"
-        ]
+        "required": ["accessToken", "refreshToken", "tokenType"]
       },
       "CreateScheduleRequest": {
         "type": "object",
@@ -2824,13 +2611,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "applicantId",
-          "endTime",
-          "locationType",
-          "partId",
-          "startTime"
-        ]
+        "required": ["applicantId", "endTime", "locationType", "partId", "startTime"]
       },
       "OAuth2LoginRequest": {
         "type": "object",
@@ -2843,9 +2624,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "authorizationCode"
-        ]
+        "required": ["authorizationCode"]
       },
       "LoginResponse": {
         "type": "object",
@@ -2865,11 +2644,7 @@
             "description": "리프레시 토큰"
           }
         },
-        "required": [
-          "accessToken",
-          "refreshToken",
-          "tokenType"
-        ]
+        "required": ["accessToken", "refreshToken", "tokenType"]
       },
       "MemberSyncResponse": {
         "type": "object",
@@ -2877,9 +2652,7 @@
           "failureMessages": {
             "type": "array",
             "description": "동기화 실패 메시지 목록",
-            "example": [
-              "email 중복: test@example.com"
-            ],
+            "example": ["email 중복: test@example.com"],
             "items": {
               "type": "string"
             }
@@ -2891,10 +2664,7 @@
             "example": 12
           }
         },
-        "required": [
-          "createdCount",
-          "failureMessages"
-        ]
+        "required": ["createdCount", "failureMessages"]
       },
       "LogoutRequest": {
         "type": "object",
@@ -2904,9 +2674,7 @@
             "minLength": 1
           }
         },
-        "required": [
-          "refreshToken"
-        ]
+        "required": ["refreshToken"]
       },
       "CreateApplicantRequest": {
         "type": "object",
@@ -3000,10 +2768,7 @@
             }
           }
         },
-        "required": [
-          "failures",
-          "successes"
-        ]
+        "required": ["failures", "successes"]
       },
       "MailSendRequest": {
         "type": "object",
@@ -3012,9 +2777,7 @@
           "receiverEmailAddresses": {
             "type": "array",
             "description": "수신자 이메일 주소 목록",
-            "example": [
-              "user@example.com"
-            ],
+            "example": ["user@example.com"],
             "items": {
               "type": "string"
             }
@@ -3032,10 +2795,7 @@
           "bodyFormat": {
             "type": "string",
             "description": "본문 형식",
-            "enum": [
-              "HTML",
-              "PLAIN_TEXT"
-            ],
+            "enum": ["HTML", "PLAIN_TEXT"],
             "example": "HTML"
           },
           "attachmentReferences": {
@@ -3070,17 +2830,10 @@
           "usage": {
             "type": "string",
             "description": "파일 용도",
-            "enum": [
-              "INLINE",
-              "ATTACHMENT"
-            ]
+            "enum": ["INLINE", "ATTACHMENT"]
           }
         },
-        "required": [
-          "contentType",
-          "fileName",
-          "usage"
-        ]
+        "required": ["contentType", "fileName", "usage"]
       },
       "MailFilePresignRequest": {
         "type": "object",
@@ -3093,9 +2846,7 @@
             }
           }
         },
-        "required": [
-          "files"
-        ]
+        "required": ["files"]
       },
       "MailFilePresignResponse": {
         "type": "object",
@@ -3107,9 +2858,7 @@
             }
           }
         },
-        "required": [
-          "uploads"
-        ]
+        "required": ["uploads"]
       },
       "PresignedUpload": {
         "type": "object",
@@ -3128,12 +2877,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "cid",
-          "contentType",
-          "expiresAt",
-          "putUrl"
-        ]
+        "required": ["cid", "contentType", "expiresAt", "putUrl"]
       },
       "File": {
         "type": "object",
@@ -3156,18 +2900,10 @@
           "usage": {
             "type": "string",
             "description": "파일 용도",
-            "enum": [
-              "INLINE",
-              "ATTACHMENT"
-            ]
+            "enum": ["INLINE", "ATTACHMENT"]
           }
         },
-        "required": [
-          "cid",
-          "contentType",
-          "fileName",
-          "usage"
-        ]
+        "required": ["cid", "contentType", "fileName", "usage"]
       },
       "MailFileConfirmRequest": {
         "type": "object",
@@ -3179,9 +2915,7 @@
             }
           }
         },
-        "required": [
-          "files"
-        ]
+        "required": ["files"]
       },
       "MailFileConfirmResponse": {
         "type": "object",
@@ -3193,9 +2927,7 @@
             }
           }
         },
-        "required": [
-          "files"
-        ]
+        "required": ["files"]
       },
       "MailFileSummary": {
         "type": "object",
@@ -3206,10 +2938,7 @@
           },
           "usage": {
             "type": "string",
-            "enum": [
-              "INLINE",
-              "ATTACHMENT"
-            ]
+            "enum": ["INLINE", "ATTACHMENT"]
           },
           "fileName": {
             "type": "string"
@@ -3228,14 +2957,7 @@
             "format": "date-time"
           }
         },
-        "required": [
-          "cid",
-          "contentType",
-          "fileId",
-          "fileName",
-          "usage",
-          "used"
-        ]
+        "required": ["cid", "contentType", "fileId", "fileName", "usage", "used"]
       },
       "UpdateScheduleLocationRequest": {
         "type": "object",
@@ -3250,9 +2972,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "locationType"
-        ]
+        "required": ["locationType"]
       },
       "UpdateWithdrawnMemberRequest": {
         "type": "object",
@@ -3260,10 +2980,7 @@
           "partIds": {
             "type": "array",
             "description": "파트 ID 목록",
-            "example": [
-              1,
-              2
-            ],
+            "example": [1, 2],
             "items": {
               "type": "integer",
               "format": "int64"
@@ -3356,10 +3073,7 @@
           "partIds": {
             "type": "array",
             "description": "파트 ID 목록",
-            "example": [
-              1,
-              2
-            ],
+            "example": [1, 2],
             "items": {
               "type": "integer",
               "format": "int64"
@@ -3467,10 +3181,7 @@
           "partIds": {
             "type": "array",
             "description": "파트 ID 목록",
-            "example": [
-              1,
-              2
-            ],
+            "example": [1, 2],
             "items": {
               "type": "integer",
               "format": "int64"
@@ -3545,10 +3256,7 @@
           "partIds": {
             "type": "array",
             "description": "파트 ID 목록",
-            "example": [
-              1,
-              2
-            ],
+            "example": [1, 2],
             "items": {
               "type": "integer",
               "format": "int64"
@@ -3623,10 +3331,7 @@
           "partIds": {
             "type": "array",
             "description": "파트 ID 목록",
-            "example": [
-              1,
-              2
-            ],
+            "example": [1, 2],
             "items": {
               "type": "integer",
               "format": "int64"
@@ -3766,9 +3471,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "validated"
-        ]
+        "required": ["validated"]
       },
       "ReadSemesterResponse": {
         "type": "object",
@@ -3781,10 +3484,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "semester",
-          "semesterId"
-        ]
+        "required": ["semester", "semesterId"]
       },
       "ReadScheduleResponse": {
         "type": "object",
@@ -3818,15 +3518,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "applicantId",
-          "endTime",
-          "id",
-          "locationType",
-          "name",
-          "part",
-          "startTime"
-        ]
+        "required": ["applicantId", "endTime", "id", "locationType", "name", "part", "startTime"]
       },
       "AutoScheduleRequest": {
         "type": "object",
@@ -3845,11 +3537,7 @@
             "example": 60
           }
         },
-        "required": [
-          "duration",
-          "size",
-          "strategy"
-        ]
+        "required": ["duration", "size", "strategy"]
       },
       "AutoScheduleResponse": {
         "type": "object",
@@ -3873,13 +3561,7 @@
             "format": "date-time"
           }
         },
-        "required": [
-          "applicantId",
-          "applicantName",
-          "endTime",
-          "part",
-          "startTime"
-        ]
+        "required": ["applicantId", "applicantName", "endTime", "part", "startTime"]
       },
       "ReadPartsResponse": {
         "type": "object",
@@ -3892,10 +3574,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "partId",
-          "partName"
-        ]
+        "required": ["partId", "partName"]
       },
       "MemberListResponseReadWithdrawnMemberListItemResponse": {
         "type": "object",
@@ -3918,10 +3597,7 @@
             "example": false
           }
         },
-        "required": [
-          "isSensitiveMasked",
-          "members"
-        ]
+        "required": ["isSensitiveMasked", "members"]
       },
       "ReadDivisionAndPartInMemberResponse": {
         "type": "object",
@@ -3937,10 +3613,7 @@
             "example": "백엔드"
           }
         },
-        "required": [
-          "division",
-          "part"
-        ]
+        "required": ["division", "part"]
       },
       "ReadWithdrawnMemberListItemResponse": {
         "type": "object",
@@ -3990,14 +3663,7 @@
             "example": "개인 사정"
           }
         },
-        "required": [
-          "memberId",
-          "name",
-          "nickname",
-          "parts",
-          "role",
-          "state"
-        ]
+        "required": ["memberId", "name", "nickname", "parts", "role", "state"]
       },
       "MeResponse": {
         "type": "object",
@@ -4139,10 +3805,7 @@
             "example": false
           }
         },
-        "required": [
-          "isSensitiveMasked",
-          "members"
-        ]
+        "required": ["isSensitiveMasked", "members"]
       },
       "ReadInactiveMemberListItemResponse": {
         "type": "object",
@@ -4294,10 +3957,7 @@
             "example": "24-2"
           }
         },
-        "required": [
-          "endSemester",
-          "startSemester"
-        ]
+        "required": ["endSemester", "startSemester"]
       },
       "MemberListResponseReadGraduatedMemberListItemResponse": {
         "type": "object",
@@ -4320,10 +3980,7 @@
             "example": false
           }
         },
-        "required": [
-          "isSensitiveMasked",
-          "members"
-        ]
+        "required": ["isSensitiveMasked", "members"]
       },
       "ReadGraduatedMemberListItemResponse": {
         "type": "object",
@@ -4442,10 +4099,7 @@
             "example": false
           }
         },
-        "required": [
-          "isSensitiveMasked",
-          "members"
-        ]
+        "required": ["isSensitiveMasked", "members"]
       },
       "ReadCompletedMemberListItemResponse": {
         "type": "object",
@@ -4559,10 +4213,7 @@
             "example": false
           }
         },
-        "required": [
-          "isSensitiveMasked",
-          "members"
-        ]
+        "required": ["isSensitiveMasked", "members"]
       },
       "ReadActiveMemberListItemResponse": {
         "type": "object",
@@ -4677,10 +4328,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "divisionId",
-          "divisionName"
-        ]
+        "required": ["divisionId", "divisionName"]
       },
       "ReadDepartmentsResponse": {
         "type": "object",
@@ -4693,10 +4341,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "departmentId",
-          "departmentName"
-        ]
+        "required": ["departmentId", "departmentName"]
       },
       "ReadCollegeResponse": {
         "type": "object",
@@ -4709,10 +4354,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "collegeId",
-          "collegeName"
-        ]
+        "required": ["collegeId", "collegeName"]
       },
       "ReadApplicantResponse": {
         "type": "object",
@@ -4814,13 +4456,7 @@
             "format": "int32"
           }
         },
-        "required": [
-          "content",
-          "page",
-          "size",
-          "totalElements",
-          "totalPages"
-        ]
+        "required": ["content", "page", "size", "totalElements", "totalPages"]
       },
       "ReadMailTemplateSummaryResponse": {
         "type": "object",
@@ -4837,11 +4473,7 @@
             "format": "date-time"
           }
         },
-        "required": [
-          "id",
-          "title",
-          "updatedAt"
-        ]
+        "required": ["id", "title", "updatedAt"]
       },
       "AttachmentReference": {
         "type": "object",
@@ -4868,11 +4500,7 @@
             "example": "mail-files/attachment/uuid-guide.pdf"
           }
         },
-        "required": [
-          "contentType",
-          "fileName",
-          "storageKey"
-        ]
+        "required": ["contentType", "fileName", "storageKey"]
       },
       "DetailVariable": {
         "type": "object",
@@ -4886,14 +4514,7 @@
           "type": {
             "type": "string",
             "description": "변수 타입. PERSON, DATE, LINK, TEXT는 사용자 입력 변수. APPLICANT, PARTNAME은 자동 채움 변수",
-            "enum": [
-              "PERSON",
-              "DATE",
-              "LINK",
-              "TEXT",
-              "APPLICANT",
-              "PARTNAME"
-            ],
+            "enum": ["PERSON", "DATE", "LINK", "TEXT", "APPLICANT", "PARTNAME"],
             "example": "TEXT"
           },
           "displayName": {
@@ -4912,12 +4533,7 @@
             "example": "applicant.name"
           }
         },
-        "required": [
-          "displayName",
-          "key",
-          "perRecipient",
-          "type"
-        ]
+        "required": ["displayName", "key", "perRecipient", "type"]
       },
       "ReadMailTemplateDetailResponse": {
         "type": "object",
@@ -4992,11 +4608,7 @@
           "status": {
             "type": "string",
             "description": "예약 상태",
-            "enum": [
-              "SCHEDULED",
-              "PENDING_SEND",
-              "SENT"
-            ],
+            "enum": ["SCHEDULED", "PENDING_SEND", "SENT"],
             "example": "SCHEDULED"
           },
           "senderEmailAddress": {
@@ -5040,9 +4652,7 @@
             }
           }
         },
-        "required": [
-          "items"
-        ]
+        "required": ["items"]
       },
       "MailReservationDetailResponse": {
         "type": "object",
@@ -5062,11 +4672,7 @@
           "status": {
             "type": "string",
             "description": "예약 상태",
-            "enum": [
-              "SCHEDULED",
-              "PENDING_SEND",
-              "SENT"
-            ],
+            "enum": ["SCHEDULED", "PENDING_SEND", "SENT"],
             "example": "SCHEDULED"
           },
           "senderEmailAddress": {
@@ -5147,11 +4753,7 @@
             "format": "date-time"
           }
         },
-        "required": [
-          "mailId",
-          "reservationId",
-          "reservationTime"
-        ]
+        "required": ["mailId", "reservationId", "reservationTime"]
       },
       "MailReservationStatusResponse": {
         "type": "object",
@@ -5163,9 +4765,7 @@
             }
           }
         },
-        "required": [
-          "items"
-        ]
+        "required": ["items"]
       },
       "MailGroupItem": {
         "type": "object",
@@ -5187,12 +4787,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "SCHEDULED",
-              "PENDING_SEND",
-              "SENDING",
-              "SENT"
-            ]
+            "enum": ["SCHEDULED", "PENDING_SEND", "SENDING", "SENT"]
           },
           "createdAt": {
             "type": "string",
@@ -5206,14 +4801,7 @@
             }
           }
         },
-        "required": [
-          "createdAt",
-          "groupId",
-          "mailIds",
-          "reservationTime",
-          "senderEmail",
-          "status"
-        ]
+        "required": ["createdAt", "groupId", "mailIds", "reservationTime", "senderEmail", "status"]
       },
       "MailGroupListResponse": {
         "type": "object",
@@ -5225,9 +4813,7 @@
             }
           }
         },
-        "required": [
-          "groups"
-        ]
+        "required": ["groups"]
       },
       "MailFileListResponse": {
         "type": "object",
@@ -5239,9 +4825,7 @@
             }
           }
         },
-        "required": [
-          "files"
-        ]
+        "required": ["files"]
       },
       "MailFileDownloadResponse": {
         "type": "object",
@@ -5256,10 +4840,7 @@
             "description": "URL 만료 시각"
           }
         },
-        "required": [
-          "expiresAt",
-          "getUrl"
-        ]
+        "required": ["expiresAt", "getUrl"]
       },
       "DeleteByPartResponse": {
         "type": "object",
@@ -5269,9 +4850,7 @@
             "format": "int32"
           }
         },
-        "required": [
-          "deletedCount"
-        ]
+        "required": ["deletedCount"]
       }
     },
     "securitySchemes": {

--- a/schema.json
+++ b/schema.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://api.dev.scouter.yourssu.com",
+      "url": "https://scouter-dev-api.yourssu.com",
       "description": "production server"
     }
   ],
@@ -19,7 +19,9 @@
   "paths": {
     "/recruiter/schedule/part/{partId}": {
       "put": {
-        "tags": ["면접 일정"],
+        "tags": [
+          "면접 일정"
+        ],
         "summary": "파트 스케줄 수정 API",
         "description": "특정 파트의 스케줄을 전체 수정합니다.",
         "operationId": "updateByPart",
@@ -59,7 +61,9 @@
         }
       },
       "delete": {
-        "tags": ["면접 일정"],
+        "tags": [
+          "면접 일정"
+        ],
         "summary": "파트별 스케줄 삭제 API",
         "description": "특정 파트의 모든 면접 스케줄을 삭제합니다.",
         "operationId": "deleteByPart",
@@ -100,7 +104,9 @@
     },
     "/api/mails/templates/{templateId}": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 템플릿 상세 조회",
         "description": "특정 메일 템플릿의 상세 내용을 조회합니다. (편집용)",
         "operationId": "readDetail",
@@ -130,7 +136,9 @@
         }
       },
       "put": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 템플릿 수정",
         "description": "특정 메일 템플릿을 수정합니다. 전체 메일 템플릿의 내용을 보내야 합니다.\n\n**변수 규칙:**\n- 모든 변수 키는 `var-{UUID}` 형식이어야 합니다 (예: `var-550e8400-e29b-41d4-a716-446655440000`)",
         "operationId": "update",
@@ -169,7 +177,9 @@
         }
       },
       "delete": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 템플릿 삭제",
         "description": "특정 메일 템플릿을 삭제합니다. 해당 메일 템플릿이 없을 시 404를 반환합니다.",
         "operationId": "delete",
@@ -198,7 +208,9 @@
     },
     "/api/mails/reservation/{reservationId}": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "예약 메일 단건 조회",
         "description": "예약 ID에 해당하는 메일 예약 상세를 조회합니다. status: SCHEDULED, PENDING_SEND, SENT. 다른 사용자의 예약에는 접근할 수 없습니다.",
         "operationId": "getReservationDetail",
@@ -224,8 +236,8 @@
               }
             }
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -234,8 +246,8 @@
               }
             }
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -247,7 +259,9 @@
         }
       },
       "put": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "예약 메일 수정",
         "description": "기존 예약 메일의 발송 시각과 내용을 수정합니다. 요청 바디는 생성과 동일한 MailReserveRequest 형식을 사용하며, 전체를 교체합니다.",
         "operationId": "updateReservation",
@@ -277,8 +291,8 @@
             "description": "수정 성공",
             "content": {}
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -287,8 +301,8 @@
               }
             }
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -300,7 +314,9 @@
         }
       },
       "delete": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "예약 메일 취소",
         "description": "아직 발송되지 않은 예약 메일을 취소합니다.",
         "operationId": "cancelReservation",
@@ -320,8 +336,8 @@
             "description": "취소 성공",
             "content": {}
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -330,8 +346,8 @@
               }
             }
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -345,7 +361,9 @@
     },
     "/withdrawal": {
       "post": {
-        "tags": ["인증/인가"],
+        "tags": [
+          "인증/인가"
+        ],
         "summary": "회원 탈퇴",
         "operationId": "withdraw",
         "requestBody": {
@@ -368,7 +386,9 @@
     },
     "/semesters": {
       "get": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "학기 전체 조회",
         "description": "생성된 전체 학기 정보를 조회합니다.",
         "operationId": "readAll",
@@ -389,7 +409,9 @@
         }
       },
       "post": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "학기 생성",
         "description": "연도, 학기 조합으로 학기를 생성합니다.",
         "operationId": "create",
@@ -413,7 +435,9 @@
     },
     "/refresh-token": {
       "post": {
-        "tags": ["인증/인가"],
+        "tags": [
+          "인증/인가"
+        ],
         "summary": "토큰 재발급",
         "description": "Authorization 헤더는 무시되며, 바디의 refreshToken(순수 JWT)만 사용합니다.",
         "operationId": "refreshToken",
@@ -454,7 +478,9 @@
     },
     "/recruiter/schedule": {
       "get": {
-        "tags": ["면접 일정"],
+        "tags": [
+          "면접 일정"
+        ],
         "summary": "면접 스케줄 조회 API",
         "description": "면접 스케줄 조회 API 입니다. 추후 partID를 입력하지 않으면 전체 조회가 되도록 변경 예정",
         "operationId": "getSchedules",
@@ -486,7 +512,9 @@
         }
       },
       "post": {
-        "tags": ["면접 일정"],
+        "tags": [
+          "면접 일정"
+        ],
         "summary": "면접 스케줄 추가 API",
         "description": "면접 스케줄을 추가하는 API 입니다.",
         "operationId": "createSchedules",
@@ -513,7 +541,10 @@
     },
     "/oauth2/login/{oauth2Type}": {
       "post": {
-        "tags": ["OAUTH2", "인증/인가"],
+        "tags": [
+          "OAUTH2",
+          "인증/인가"
+        ],
         "summary": "로그인",
         "description": "/oauth2/{oauth2Type}에서 얻은 code를 이용해 로그인을 진행합니다. 등록된 멤버만 로그인할 수 있습니다.",
         "operationId": "login",
@@ -524,7 +555,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["GOOGLE"]
+              "enum": [
+                "GOOGLE"
+              ]
             }
           }
         ],
@@ -565,7 +598,10 @@
     },
     "/members/include-from-applicants": {
       "post": {
-        "tags": ["합격자 동기화 API", "유어슈 멤버"],
+        "tags": [
+          "합격자 동기화 API",
+          "유어슈 멤버"
+        ],
         "summary": "지원자 중 합격자 멤버 동기화",
         "description": "리크루팅 지원자 중 합격자를 멤버에 동기화 합니다.",
         "operationId": "includeFromApplicants",
@@ -601,15 +637,18 @@
     },
     "/members/include-from-applicants/{semesterString}": {
       "post": {
-        "tags": ["합격자 동기화 API", "유어슈 멤버"],
+        "tags": [
+          "합격자 동기화 API",
+          "유어슈 멤버"
+        ],
         "summary": "지정 학기 합격자 멤버 동기화",
-        "description": "지정한 학기(semesterString, 예: 2025-1)의 합격자만 멤버에 동기화합니다. 없으면 전체 동기화와 동일.",
+        "description": "지정한 학기(semesterString, yy-term 예: 25-1)의 합격자만 멤버에 동기화합니다. 없으면 전체 동기화와 동일.",
         "operationId": "includeFromApplicants_1",
         "parameters": [
           {
             "name": "semesterString",
             "in": "path",
-            "description": "학기 문자열 (예: 2025-1)",
+            "description": "학기 문자열 (yy-term, 예: 25-1)",
             "required": true,
             "schema": {
               "type": "string"
@@ -651,7 +690,9 @@
     },
     "/logout": {
       "post": {
-        "tags": ["인증/인가"],
+        "tags": [
+          "인증/인가"
+        ],
         "summary": "로그아웃",
         "operationId": "logout",
         "requestBody": {
@@ -674,7 +715,9 @@
     },
     "/internal/dev/member-privacy/privileged/self/enable": {
       "post": {
-        "tags": ["[DEV] 멤버 민감정보 권한 테스트"],
+        "tags": [
+          "[DEV] 멤버 민감정보 권한 테스트"
+        ],
         "summary": "나를 권한자로 복원 (테스트용)",
         "description": "비권한자로 전환한 상태를 해제하고, 다시 민감정보 열람 권한이 있는 상태로 돌립니다.",
         "operationId": "enablePrivilegeForSelf",
@@ -692,7 +735,9 @@
     },
     "/internal/dev/member-privacy/privileged/self/disable": {
       "post": {
-        "tags": ["[DEV] 멤버 민감정보 권한 테스트"],
+        "tags": [
+          "[DEV] 멤버 민감정보 권한 테스트"
+        ],
         "summary": "나를 비권한자로 전환 (테스트용)",
         "description": "이후 멤버 API 호출 시 내 계정은 민감정보가 마스킹된 응답을 받습니다. 스카우터 팀원만 호출 가능.",
         "operationId": "disablePrivilegeForSelf",
@@ -710,7 +755,9 @@
     },
     "/applicants": {
       "get": {
-        "tags": ["리크루팅 지원자"],
+        "tags": [
+          "리크루팅 지원자"
+        ],
         "summary": "지원자 목록 조회",
         "description": "지원자 목록을 검색, 필터링을 통해 얻습니다. 필터링에 필요한 정보는 각 api에서 얻어야 합니다.",
         "operationId": "readAll_1",
@@ -767,7 +814,9 @@
         }
       },
       "post": {
-        "tags": ["리크루팅 지원자"],
+        "tags": [
+          "리크루팅 지원자"
+        ],
         "summary": "지원자 추가 API",
         "operationId": "create_1",
         "requestBody": {
@@ -796,7 +845,10 @@
     },
     "/applicants/include-from-forms": {
       "post": {
-        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
+        "tags": [
+          "지원자 동기화 API",
+          "리크루팅 지원자"
+        ],
         "summary": "구글폼 응답을 지원자 목록에 업데이트",
         "description": "현재 로그인 되어있는 사용자의 계정을 이용해 지원자의 구글폼 응답을 동기화 합니다.",
         "operationId": "includeFromForms",
@@ -822,7 +874,10 @@
     },
     "/applicants/include-from-forms/semesters/{semesterId}": {
       "post": {
-        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
+        "tags": [
+          "지원자 동기화 API",
+          "리크루팅 지원자"
+        ],
         "operationId": "includeFromFormsBySemesterAndPart",
         "parameters": [
           {
@@ -857,7 +912,9 @@
     },
     "/api/mails/templates": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 템플릿 목록 조회",
         "description": "현재 등록된 전체 메일 템플릿을 조회합니다.",
         "operationId": "readAll_2",
@@ -906,7 +963,9 @@
         }
       },
       "post": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 템플릿 생성",
         "description": "제목과 양식을 지정해 새로운 메일 템플릿을 생성합니다.\n\n**변수 규칙:**\n- 모든 변수 키는 `var-{UUID}` 형식이어야 합니다 (예: `var-550e8400-e29b-41d4-a716-446655440000`)\n- 메일 본문에서 변수는 `{{var-{UUID}}}` 형식으로 사용합니다\n\n**변수 타입:**\n- **사용자 입력 변수**: PERSON, DATE, LINK, TEXT\n- **자동 채움 변수**: APPLICANT, PARTNAME",
         "operationId": "create_2",
@@ -936,7 +995,9 @@
     },
     "/api/mails/send": {
       "post": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 즉시 발송",
         "description": "메일을 즉시 발송합니다. DB에 저장하지 않고 바로 발송됩니다. 파일은 사전에 /api/mails/files/* API로 업로드/확정한 뒤, fileId 참조만 전달합니다.",
         "operationId": "sendMail",
@@ -980,7 +1041,9 @@
     },
     "/api/mails/reservation": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "예약 메일 목록 조회",
         "description": "현재 사용자가 예약한 메일 목록을 조회합니다. status: SCHEDULED(예약됨), PENDING_SEND(발송 실패/재시도 대기), SENT(발송 완료)",
         "operationId": "getReservations",
@@ -998,7 +1061,9 @@
         }
       },
       "post": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 전송 예약",
         "description": "application/json으로 요청합니다. 파일은 사전에 /api/mails/files/* API로 업로드/확정한 뒤, 예약 시 fileId 참조만 전달합니다.",
         "operationId": "reserveMail",
@@ -1032,7 +1097,9 @@
     },
     "/api/mails/reservation/{reservationId}/retry": {
       "post": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "예약 메일 재전송",
         "description": "예약 시간이 지났는데 발송 실패(PENDING_SEND)인 메일을 즉시 재전송 시도합니다. 이미 발송된 메일(SENT)이나 예약 시간 전에는 호출할 수 없습니다.",
         "operationId": "retryReservation",
@@ -1062,8 +1129,8 @@
               }
             }
           },
-          "404": {
-            "description": "예약을 찾을 수 없음",
+          "403": {
+            "description": "다른 사용자의 예약에 대한 접근 거부",
             "content": {
               "*/*": {
                 "schema": {
@@ -1072,8 +1139,8 @@
               }
             }
           },
-          "403": {
-            "description": "다른 사용자의 예약에 대한 접근 거부",
+          "404": {
+            "description": "예약을 찾을 수 없음",
             "content": {
               "*/*": {
                 "schema": {
@@ -1097,7 +1164,9 @@
     },
     "/api/mails/files/presign": {
       "post": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 파일 업로드용 presigned URL 발급",
         "operationId": "createPresignedUploadUrls",
         "requestBody": {
@@ -1126,7 +1195,9 @@
     },
     "/api/mails/files/confirm": {
       "post": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "업로드 완료 파일 등록",
         "operationId": "confirmUploads",
         "requestBody": {
@@ -1155,7 +1226,9 @@
     },
     "/recruiter/schedule/{scheduleId}/location": {
       "patch": {
-        "tags": ["면접 일정"],
+        "tags": [
+          "면접 일정"
+        ],
         "summary": "면접 장소 변경 API",
         "description": "스케줄 ID를 기준으로 면접 장소 대분류와 세부장소를 수정합니다.",
         "operationId": "updateLocation",
@@ -1194,7 +1267,9 @@
     },
     "/members/withdrawn/{memberId}": {
       "patch": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "탈퇴 멤버 정보 수정",
         "description": "변경되지 않은 정보는 보내면 안됩니다.",
         "operationId": "updateWithdrawnById",
@@ -1241,9 +1316,11 @@
     },
     "/members/inactive/{memberId}": {
       "patch": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "비액티브 멤버 정보 수정",
-        "description": "변경되지 않은 정보는 보내면 안됩니다.",
+        "description": "한 요청에는 (1) 회원 공통 프로필 필드만 또는 (2) 비액티브 전용 필드만 보낸다. 비액티브 전용은 조회 응답과 동일한 키(복귀 예정 학기 문자열, 사유, 문자 회신, 활동학기 라벨, 학기 수 등)를 사용한다. 활동 기간(activePeriod)·비액티브 기간(inactivePeriod) 객체와 activeSemesterCountLabel·inactiveSemesterCountLabel은 조회 전용이며 본문에 넣으면 Member-007이다. 복귀 예정 학기 변경 시 서버가 비액티브 기간 종료 학기를 도메인 규칙에 맞게 조정할 수 있다.",
         "operationId": "updateInactiveById",
         "parameters": [
           {
@@ -1272,7 +1349,7 @@
             "content": {}
           },
           "400": {
-            "description": "Member-002 (잘못된 수정 요청: 한 번에 하나의 필드만 수정 가능 등)",
+            "description": "Member-002 (잘못된 수정 요청: 한 번에 하나의 필드만 수정 가능 등), Member-007 (조회 전용·기간 필드를 본문에 넣은 경우)",
             "content": {}
           },
           "403": {
@@ -1288,9 +1365,11 @@
     },
     "/members/graduated/{memberId}": {
       "patch": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "졸업 멤버 정보 수정",
-        "description": "변경되지 않은 정보는 보내면 안됩니다.",
+        "description": "한 요청에는 (1) 회원 공통 프로필만 또는 (2) isAdvisorDesired만 보낸다. 활동 기간(activePeriod)은 조회 전용이며 본문에 넣으면 Member-007이다.",
         "operationId": "updateGraduatedById",
         "parameters": [
           {
@@ -1319,7 +1398,7 @@
             "content": {}
           },
           "400": {
-            "description": "Member-002 (잘못된 수정 요청: 한 번에 하나의 필드만 수정 가능 등)",
+            "description": "Member-002 (잘못된 수정 요청: 한 번에 하나의 필드만 수정 가능 등), Member-007 (activePeriod 등 수정 불가 필드 포함)",
             "content": {}
           },
           "403": {
@@ -1335,7 +1414,9 @@
     },
     "/members/completed/{memberId}": {
       "patch": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "수료 멤버 정보 수정",
         "description": "변경되지 않은 정보는 보내면 안됩니다.",
         "operationId": "updateCompletedById",
@@ -1382,7 +1463,9 @@
     },
     "/members/active/{memberId}": {
       "patch": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "액티브 멤버 정보 수정",
         "description": "변경되지 않은 정보는 보내면 안됩니다.",
         "operationId": "updateActiveById",
@@ -1429,7 +1512,9 @@
     },
     "/applicants/{applicantId}": {
       "get": {
-        "tags": ["리크루팅 지원자"],
+        "tags": [
+          "리크루팅 지원자"
+        ],
         "summary": "지원자 단일 조회",
         "description": "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자의 세부정보를 확인합니다.",
         "operationId": "readById",
@@ -1458,7 +1543,9 @@
         }
       },
       "delete": {
-        "tags": ["리크루팅 지원자"],
+        "tags": [
+          "리크루팅 지원자"
+        ],
         "summary": "지원자 삭제",
         "description": "지원자 목록 조회에서 얻은 applicantId를 이용해 지원자를 삭제합니다.",
         "operationId": "deleteById",
@@ -1481,7 +1568,9 @@
         }
       },
       "patch": {
-        "tags": ["리크루팅 지원자"],
+        "tags": [
+          "리크루팅 지원자"
+        ],
         "summary": "지원자 정보 수정",
         "description": "변경할 지원자 정보의 값을 보냅니다. 변경되지 않은 값은 보내면 안 됩니다.",
         "operationId": "updateById",
@@ -1516,7 +1605,9 @@
     },
     "/validate-token": {
       "get": {
-        "tags": ["인증/인가"],
+        "tags": [
+          "인증/인가"
+        ],
         "summary": "AccessToken 유효성 검사",
         "operationId": "validateToken",
         "responses": {
@@ -1536,7 +1627,9 @@
     },
     "/semesters/now": {
       "get": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "현재 학기 조회",
         "description": "현재 학기에 해당하는 정보를 조회합니다.",
         "operationId": "readByDate",
@@ -1556,7 +1649,9 @@
     },
     "/recruiter/schedule/auto/{partId}": {
       "get": {
-        "tags": ["면접 일정"],
+        "tags": [
+          "면접 일정"
+        ],
         "summary": "면접 스케줄 자동 생성 API",
         "description": "\n            백트래킹 알고리즘을 사용하여 면접 스케줄을 자동 생성합니다.\n            - 같은 파트의 같은 시간에는 중복 배정하지 않습니다.\n            - 모든 지원자를 배정할 수 없는 경우 400 에러를 반환합니다.\n            - 지원자가 많을 경우 응답 시간이 길어질 수 있습니다.\n            - **주의**: 저장은 되지 않으며, 미리보기 용도입니다.\n        ",
         "operationId": "getAutoSchedules",
@@ -1601,7 +1696,9 @@
     },
     "/parts": {
       "get": {
-        "tags": ["구분/파트"],
+        "tags": [
+          "구분/파트"
+        ],
         "summary": "파트(팀) 목록 조회",
         "description": "Head lead, Finance 등 파트 목록을 조회합니다.",
         "operationId": "readAll_3",
@@ -1624,7 +1721,10 @@
     },
     "/oauth2/{oauth2Type}": {
       "get": {
-        "tags": ["OAUTH2", "인증/인가"],
+        "tags": [
+          "OAUTH2",
+          "인증/인가"
+        ],
         "summary": "OAuth2 로그인 페이지 리다이렉트",
         "description": "여기에서는 리다이렉트가 되지 않습니다. Authorize 이용.",
         "operationId": "redirectAuthCodeRequestUrl",
@@ -1635,7 +1735,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["GOOGLE"]
+              "enum": [
+                "GOOGLE"
+              ]
             }
           }
         ],
@@ -1650,7 +1752,10 @@
     },
     "/oauth2/google-refresh-token-status": {
       "get": {
-        "tags": ["OAUTH2", "인증/인가"],
+        "tags": [
+          "OAUTH2",
+          "인증/인가"
+        ],
         "summary": "Google refresh token 유효 여부 조회",
         "description": "현재 사용자의 Google OAuth2 refresh token이 유효한지 검사합니다. 무효일 때는 401을 반환하며, 다른 인증 실패(401)와 동일하게 재로그인 유도 처리하면 됩니다. 메일 예약, 구글 폼/드라이브 동기화 등 Google API 연동 기능에서 공통으로 사용할 수 있습니다.",
         "operationId": "getGoogleRefreshTokenStatus",
@@ -1680,9 +1785,11 @@
     },
     "/members/withdrawn": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "탈퇴 멤버 목록 조회/검색",
-        "description": "HR·스카우터가 아니면 isSensitiveMasked true, 연락처·생년월일·학번·탈퇴일자·비고 등 null.",
+        "description": "응답 필드: memberId, parts(구분·파트), role, name, nickname(영어(한글발음)), state, withdrawnDate, note. 이메일·연락처·전공·학번·생년월일·가입일은 포함하지 않음. HR·스카우터가 아니면 isSensitiveMasked true이며 탈퇴일자·비고는 null.",
         "operationId": "readAllWithdrawn",
         "parameters": [
           {
@@ -1721,7 +1828,9 @@
     },
     "/members/states": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "멤버 상태 목록 조회",
         "description": "액티브, 비액티브, 수료, 졸업, 탈퇴 등 상태를 조회합니다.",
         "operationId": "readAllMemberStates",
@@ -1744,7 +1853,9 @@
     },
     "/members/roles": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "멤버 역할 목록 조회",
         "description": "Lead, Vice Lead, Member 등 역할을 조회합니다.",
         "operationId": "readAllMemberRoles",
@@ -1767,7 +1878,9 @@
     },
     "/members/me": {
       "get": {
-        "tags": ["내 정보"],
+        "tags": [
+          "내 정보"
+        ],
         "summary": "내 정보 조회",
         "description": "액세스 토큰으로 현재 로그인한 사용자의 멤버 정보와 프로필 이미지를 조회합니다.",
         "operationId": "getMe",
@@ -1797,7 +1910,10 @@
     },
     "/members/lastUpdatedTime": {
       "get": {
-        "tags": ["합격자 동기화 API", "유어슈 멤버"],
+        "tags": [
+          "합격자 동기화 API",
+          "유어슈 멤버"
+        ],
         "summary": "마지막 동기화 시간 조회",
         "description": "유어슈 멤버의 마지막 동기화 시간을 조회합니다.",
         "operationId": "lastSyncTime",
@@ -1817,9 +1933,11 @@
     },
     "/members/inactive": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "비액티브 멤버 목록 조회/검색",
-        "description": "HR·스카우터가 아니면 isSensitiveMasked true, 연락처·생년월일·학번·복귀예정·사유·문자회신·비고 등 null.",
+        "description": "응답은 기간 히스토리(activePeriod/inactivePeriod)와 UI 표기용 학기 수 라벨(activeSemesterCountLabel/inactiveSemesterCountLabel)을 함께 제공한다. 학기 수를 확정할 수 없으면 라벨은 null이다. HR·스카우터가 아니면 isSensitiveMasked true, 연락처·생년월일·학번·복귀예정·사유·문자회신·비고·학기 수 라벨 등 null.",
         "operationId": "readAllInActive",
         "parameters": [
           {
@@ -1858,7 +1976,9 @@
     },
     "/members/graduated": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "졸업 멤버 목록 조회/검색",
         "description": "HR·스카우터가 아니면 isSensitiveMasked true, 민감 필드 및 졸업 기간(activePeriod) null.",
         "operationId": "readAllGraduated",
@@ -1899,9 +2019,11 @@
     },
     "/members/completed": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "수료 멤버 목록 조회/검색",
-        "description": "HR·스카우터가 아니면 isSensitiveMasked true, 민감 필드 및 수료 기간(activePeriod) null.",
+        "description": "응답 필드: memberId, parts(구분·파트), role, name, nickname(영어(한글발음)), state, email, phoneNumber, department, studentId, birthDate, joinDate, completionSemester(수료 학기), note. HR·스카우터가 아니면 isSensitiveMasked true이며 연락처·생년월일·학번·비고·completionSemester는 null.",
         "operationId": "readAllCompleted",
         "parameters": [
           {
@@ -1940,7 +2062,9 @@
     },
     "/members/active": {
       "get": {
-        "tags": ["유어슈 멤버"],
+        "tags": [
+          "유어슈 멤버"
+        ],
         "summary": "액티브 멤버 목록 조회/검색",
         "description": "HR·스카우터 개발자가 아니면 isSensitiveMasked가 true이고, 연락처·생년월일·학번·회비·비고 등 민감 필드는 null로 내려갑니다.",
         "operationId": "readAllActive",
@@ -1981,7 +2105,9 @@
     },
     "/divisions": {
       "get": {
-        "tags": ["구분/파트"],
+        "tags": [
+          "구분/파트"
+        ],
         "summary": "멤버 구분 목록 조회",
         "description": "운영, 개발, 디자인 등 각 구분의 목록을 조회합니다.",
         "operationId": "readAll_4",
@@ -2004,7 +2130,9 @@
     },
     "/departments": {
       "get": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "전체 학과 조회",
         "description": "전체 학과 정보를 조회합니다.",
         "operationId": "readAll_5",
@@ -2027,7 +2155,9 @@
     },
     "/colleges": {
       "get": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "전체 단과대 조회",
         "description": "전체 단과대의 정보를 조회합니다.",
         "operationId": "readAll_6",
@@ -2050,7 +2180,9 @@
     },
     "/colleges/{collegeId}/departments": {
       "get": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "단과대 소속 학과 조회",
         "description": "특정 단과대에 소속된 전체 학과 정보를 조회합니다.",
         "operationId": "readAllByCollegeId",
@@ -2084,7 +2216,9 @@
     },
     "/applicants/states": {
       "get": {
-        "tags": ["리크루팅 지원자"],
+        "tags": [
+          "리크루팅 지원자"
+        ],
         "summary": "지원자 상태 목록 조회",
         "description": "전체 지원자의 가능한 상태 목록을 확인합니다. 현재 지원자와는 관련이 없습니다.",
         "operationId": "readAllMemberStates_1",
@@ -2114,7 +2248,10 @@
     },
     "/applicants/lastUpdatedTime": {
       "get": {
-        "tags": ["지원자 동기화 API", "리크루팅 지원자"],
+        "tags": [
+          "지원자 동기화 API",
+          "리크루팅 지원자"
+        ],
         "summary": "마지막 동기화 시간 조회",
         "operationId": "lastSyncTime_1",
         "responses": {
@@ -2133,7 +2270,9 @@
     },
     "/api/mails/reservation/status": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "예약 메일 발송 상태 조회",
         "description": "현재 사용자의 미발송 예약 목록과 발송 실패 사유를 조회합니다. failureErrorCode가 OAuth-Token-Refresh-Fail이면 재로그인 후 다음 스케줄 실행 시 자동 발송됩니다.",
         "operationId": "getReservationStatus",
@@ -2151,9 +2290,33 @@
         }
       }
     },
+    "/api/mails/reservation/groups": {
+      "get": {
+        "tags": [
+          "메일"
+        ],
+        "summary": "메일 그룹 목록 조회",
+        "description": "메일 예약 그룹 메타데이터와 각 그룹에 속한 메일 ID 목록을 조회합니다. 1 예약 요청 = 1 그룹, 수신자 수만큼 메일 ID가 존재합니다.",
+        "operationId": "getMailGroups",
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MailGroupListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mails/images": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 이미지 조회 (302 Redirect)",
         "description": "S3에 업로드된 이미지의 공개 URL로 302 리다이렉트합니다.\n\n**공개 엔드포인트:**\n- 인증 없이 접근 가능합니다.\n\n**사용 방법:**\n- `<img src=\"/api/mails/images?cid=xxx\">` 형태로 HTML에서 직접 사용 가능합니다.",
         "operationId": "redirectToImage",
@@ -2177,7 +2340,9 @@
     },
     "/api/mails/files": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "내 메일 파일 목록 조회",
         "operationId": "readFiles",
         "parameters": [
@@ -2187,7 +2352,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["INLINE", "ATTACHMENT"]
+              "enum": [
+                "INLINE",
+                "ATTACHMENT"
+              ]
             }
           }
         ],
@@ -2207,7 +2375,9 @@
     },
     "/api/mails/files/download-url": {
       "get": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "메일 파일 다운로드용 presigned URL 발급",
         "operationId": "createPresignedDownloadUrl",
         "parameters": [
@@ -2236,7 +2406,9 @@
     },
     "/semesters/{semesterId}": {
       "delete": {
-        "tags": ["학과/학기/단과대"],
+        "tags": [
+          "학과/학기/단과대"
+        ],
         "summary": "학기 삭제",
         "description": "특정 학기 정보를 삭제합니다.",
         "operationId": "deleteById_1",
@@ -2261,7 +2433,9 @@
     },
     "/api/mails/files/{fileId}": {
       "delete": {
-        "tags": ["메일"],
+        "tags": [
+          "메일"
+        ],
         "summary": "내 메일 파일 삭제",
         "operationId": "deleteFile",
         "parameters": [
@@ -2307,13 +2481,24 @@
           },
           "locationType": {
             "type": "string",
-            "enum": ["CLUB_ROOM", "CLASS_ROOM", "ONLINE", "ETC"]
+            "enum": [
+              "CLUB_ROOM",
+              "CLASS_ROOM",
+              "ONLINE",
+              "ETC"
+            ]
           },
           "locationDetail": {
             "type": "string"
           }
         },
-        "required": ["applicantId", "endTime", "locationType", "partId", "startTime"]
+        "required": [
+          "applicantId",
+          "endTime",
+          "locationType",
+          "partId",
+          "startTime"
+        ]
       },
       "AttachmentReferenceRequest": {
         "type": "object",
@@ -2326,7 +2511,9 @@
             "example": 11
           }
         },
-        "required": ["fileId"]
+        "required": [
+          "fileId"
+        ]
       },
       "CreateMailTemplateRequest": {
         "type": "object",
@@ -2335,6 +2522,12 @@
             "type": "string",
             "description": "메일 템플릿 제목",
             "example": "합격 안내 메일",
+            "minLength": 1
+          },
+          "subject": {
+            "type": "string",
+            "description": "메일 제목. 변수는 {{var-{UUID}}} 형식으로 사용",
+            "example": "[유어슈] {{var-550e8400-e29b-41d4-a716-446655440000}}님 면접 안내",
             "minLength": 1
           },
           "bodyHtml": {
@@ -2359,7 +2552,13 @@
             }
           }
         },
-        "required": ["attachmentReferences", "bodyHtml", "title", "variables"]
+        "required": [
+          "attachmentReferences",
+          "bodyHtml",
+          "subject",
+          "title",
+          "variables"
+        ]
       },
       "TemplateVariableRequest": {
         "type": "object",
@@ -2374,7 +2573,14 @@
           "type": {
             "type": "string",
             "description": "변수 타입. PERSON, DATE, LINK, TEXT는 사용자 입력 변수. APPLICANT, PARTNAME은 자동 채움 변수",
-            "enum": ["PERSON", "DATE", "LINK", "TEXT", "APPLICANT", "PARTNAME"],
+            "enum": [
+              "PERSON",
+              "DATE",
+              "LINK",
+              "TEXT",
+              "APPLICANT",
+              "PARTNAME"
+            ],
             "example": "TEXT"
           },
           "displayName": {
@@ -2384,11 +2590,21 @@
           },
           "perRecipient": {
             "type": "boolean",
-            "description": "수신자별로 다른 값 입력 여부",
+            "description": "수신자별로 다른 값 입력 여부. USER_INPUT 타입에만 적용",
             "example": true
+          },
+          "attributeKey": {
+            "type": "string",
+            "description": "APPLICANT 타입 변수의 속성 키. RecipientAttributeResolver.availableKeys() 에서 제공하는 값이어야 함",
+            "example": "applicant.name"
           }
         },
-        "required": ["displayName", "key", "perRecipient", "type"]
+        "required": [
+          "displayName",
+          "key",
+          "perRecipient",
+          "type"
+        ]
       },
       "CreateMailTemplateResponse": {
         "type": "object",
@@ -2405,51 +2621,21 @@
             "format": "date-time"
           }
         },
-        "required": ["id", "title", "updatedAt"]
+        "required": [
+          "id",
+          "title",
+          "updatedAt"
+        ]
       },
       "MailReserveRequest": {
         "type": "object",
         "description": "메일 예약 요청",
         "properties": {
-          "receiverEmailAddresses": {
-            "type": "array",
-            "description": "수신자 이메일 주소 목록",
-            "example": ["user@example.com"],
-            "items": {
-              "type": "string"
-            }
-          },
-          "ccEmailAddresses": {
-            "type": "array",
-            "description": "참조(CC) 이메일 주소 목록",
-            "example": [],
-            "items": {
-              "type": "string"
-            }
-          },
-          "bccEmailAddresses": {
-            "type": "array",
-            "description": "숨은참조(BCC) 이메일 주소 목록",
-            "example": [],
-            "items": {
-              "type": "string"
-            }
-          },
-          "mailSubject": {
-            "type": "string",
-            "description": "메일 제목",
-            "example": "면접 안내"
-          },
-          "mailBody": {
-            "type": "string",
-            "description": "메일 본문",
-            "example": "<p>안녕하세요</p>"
-          },
-          "bodyFormat": {
-            "type": "string",
-            "description": "본문 형식",
-            "enum": ["HTML", "PLAIN_TEXT"],
-            "example": "HTML"
+          "templateId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "사용할 템플릿 ID",
+            "example": 42
           },
           "reservationTime": {
             "type": "string",
@@ -2457,21 +2643,67 @@
             "description": "예약 발송 시간 (ISO 8601, UTC)",
             "example": "2026-02-06T02:00:00Z"
           },
-          "attachmentReferences": {
+          "recipients": {
             "type": "array",
-            "description": "첨부파일 참조 목록",
+            "description": "수신자 목록",
             "items": {
-              "$ref": "#/components/schemas/AttachmentReferenceRequest"
+              "$ref": "#/components/schemas/RecipientRequest"
+            }
+          },
+          "sharedBindings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "수신자 공통 바인딩 (perRecipient=false 변수)"
+          },
+          "ccEmailAddresses": {
+            "type": "array",
+            "description": "참조(CC) 이메일 주소 목록",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bccEmailAddresses": {
+            "type": "array",
+            "description": "숨은참조(BCC) 이메일 주소 목록",
+            "items": {
+              "type": "string"
             }
           }
         },
         "required": [
-          "attachmentReferences",
-          "bodyFormat",
-          "mailBody",
-          "mailSubject",
-          "receiverEmailAddresses",
-          "reservationTime"
+          "recipients",
+          "reservationTime",
+          "sharedBindings",
+          "templateId"
+        ]
+      },
+      "RecipientRequest": {
+        "type": "object",
+        "description": "수신자 정보",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "수신자 이메일",
+            "example": "alice@example.com"
+          },
+          "applicantId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "지원자 ID (있으면 이메일보다 우선 사용)"
+          },
+          "bindings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "수신자별 바인딩 (perRecipient=true 변수)"
+          }
+        },
+        "required": [
+          "bindings",
+          "email"
         ]
       },
       "ExceptionResponse": {
@@ -2492,7 +2724,12 @@
             "type": "string"
           }
         },
-        "required": ["errorCode", "message", "status", "timestamp"]
+        "required": [
+          "errorCode",
+          "message",
+          "status",
+          "timestamp"
+        ]
       },
       "WithdrawalRequest": {
         "type": "object",
@@ -2502,7 +2739,9 @@
             "minLength": 1
           }
         },
-        "required": ["refreshToken"]
+        "required": [
+          "refreshToken"
+        ]
       },
       "CreateSemesterRequest": {
         "type": "object",
@@ -2516,7 +2755,10 @@
             "format": "int32"
           }
         },
-        "required": ["term", "year"]
+        "required": [
+          "term",
+          "year"
+        ]
       },
       "TokenRefreshRequest": {
         "type": "object",
@@ -2526,7 +2768,9 @@
             "minLength": 1
           }
         },
-        "required": ["refreshToken"]
+        "required": [
+          "refreshToken"
+        ]
       },
       "TokenRefreshResponse": {
         "type": "object",
@@ -2541,7 +2785,11 @@
             "type": "string"
           }
         },
-        "required": ["accessToken", "refreshToken", "tokenType"]
+        "required": [
+          "accessToken",
+          "refreshToken",
+          "tokenType"
+        ]
       },
       "CreateScheduleRequest": {
         "type": "object",
@@ -2576,7 +2824,13 @@
             "type": "string"
           }
         },
-        "required": ["applicantId", "endTime", "locationType", "partId", "startTime"]
+        "required": [
+          "applicantId",
+          "endTime",
+          "locationType",
+          "partId",
+          "startTime"
+        ]
       },
       "OAuth2LoginRequest": {
         "type": "object",
@@ -2589,7 +2843,9 @@
             "type": "string"
           }
         },
-        "required": ["authorizationCode"]
+        "required": [
+          "authorizationCode"
+        ]
       },
       "LoginResponse": {
         "type": "object",
@@ -2609,23 +2865,36 @@
             "description": "리프레시 토큰"
           }
         },
-        "required": ["accessToken", "refreshToken", "tokenType"]
+        "required": [
+          "accessToken",
+          "refreshToken",
+          "tokenType"
+        ]
       },
       "MemberSyncResponse": {
         "type": "object",
         "properties": {
           "failureMessages": {
             "type": "array",
+            "description": "동기화 실패 메시지 목록",
+            "example": [
+              "email 중복: test@example.com"
+            ],
             "items": {
               "type": "string"
             }
           },
           "createdCount": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "생성된 멤버 수",
+            "example": 12
           }
         },
-        "required": ["createdCount", "failureMessages"]
+        "required": [
+          "createdCount",
+          "failureMessages"
+        ]
       },
       "LogoutRequest": {
         "type": "object",
@@ -2635,7 +2904,9 @@
             "minLength": 1
           }
         },
-        "required": ["refreshToken"]
+        "required": [
+          "refreshToken"
+        ]
       },
       "CreateApplicantRequest": {
         "type": "object",
@@ -2729,7 +3000,10 @@
             }
           }
         },
-        "required": ["failures", "successes"]
+        "required": [
+          "failures",
+          "successes"
+        ]
       },
       "MailSendRequest": {
         "type": "object",
@@ -2738,7 +3012,9 @@
           "receiverEmailAddresses": {
             "type": "array",
             "description": "수신자 이메일 주소 목록",
-            "example": ["user@example.com"],
+            "example": [
+              "user@example.com"
+            ],
             "items": {
               "type": "string"
             }
@@ -2756,7 +3032,10 @@
           "bodyFormat": {
             "type": "string",
             "description": "본문 형식",
-            "enum": ["HTML", "PLAIN_TEXT"],
+            "enum": [
+              "HTML",
+              "PLAIN_TEXT"
+            ],
             "example": "HTML"
           },
           "attachmentReferences": {
@@ -2791,10 +3070,17 @@
           "usage": {
             "type": "string",
             "description": "파일 용도",
-            "enum": ["INLINE", "ATTACHMENT"]
+            "enum": [
+              "INLINE",
+              "ATTACHMENT"
+            ]
           }
         },
-        "required": ["contentType", "fileName", "usage"]
+        "required": [
+          "contentType",
+          "fileName",
+          "usage"
+        ]
       },
       "MailFilePresignRequest": {
         "type": "object",
@@ -2807,7 +3093,9 @@
             }
           }
         },
-        "required": ["files"]
+        "required": [
+          "files"
+        ]
       },
       "MailFilePresignResponse": {
         "type": "object",
@@ -2819,7 +3107,9 @@
             }
           }
         },
-        "required": ["uploads"]
+        "required": [
+          "uploads"
+        ]
       },
       "PresignedUpload": {
         "type": "object",
@@ -2838,7 +3128,12 @@
             "type": "string"
           }
         },
-        "required": ["cid", "contentType", "expiresAt", "putUrl"]
+        "required": [
+          "cid",
+          "contentType",
+          "expiresAt",
+          "putUrl"
+        ]
       },
       "File": {
         "type": "object",
@@ -2861,10 +3156,18 @@
           "usage": {
             "type": "string",
             "description": "파일 용도",
-            "enum": ["INLINE", "ATTACHMENT"]
+            "enum": [
+              "INLINE",
+              "ATTACHMENT"
+            ]
           }
         },
-        "required": ["cid", "contentType", "fileName", "usage"]
+        "required": [
+          "cid",
+          "contentType",
+          "fileName",
+          "usage"
+        ]
       },
       "MailFileConfirmRequest": {
         "type": "object",
@@ -2876,7 +3179,9 @@
             }
           }
         },
-        "required": ["files"]
+        "required": [
+          "files"
+        ]
       },
       "MailFileConfirmResponse": {
         "type": "object",
@@ -2888,7 +3193,9 @@
             }
           }
         },
-        "required": ["files"]
+        "required": [
+          "files"
+        ]
       },
       "MailFileSummary": {
         "type": "object",
@@ -2899,7 +3206,10 @@
           },
           "usage": {
             "type": "string",
-            "enum": ["INLINE", "ATTACHMENT"]
+            "enum": [
+              "INLINE",
+              "ATTACHMENT"
+            ]
           },
           "fileName": {
             "type": "string"
@@ -2918,7 +3228,14 @@
             "format": "date-time"
           }
         },
-        "required": ["cid", "contentType", "fileId", "fileName", "usage", "used"]
+        "required": [
+          "cid",
+          "contentType",
+          "fileId",
+          "fileName",
+          "usage",
+          "used"
+        ]
       },
       "UpdateScheduleLocationRequest": {
         "type": "object",
@@ -2933,42 +3250,65 @@
             "type": "string"
           }
         },
-        "required": ["locationType"]
+        "required": [
+          "locationType"
+        ]
       },
       "UpdateWithdrawnMemberRequest": {
         "type": "object",
         "properties": {
           "partIds": {
             "type": "array",
+            "description": "파트 ID 목록",
+            "example": [
+              1,
+              2
+            ],
             "items": {
               "type": "integer",
               "format": "int64"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "WITHDRAWN"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호",
+            "example": "01012345678"
           },
           "departmentId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "학과/소속 ID",
+            "example": 7
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
@@ -2980,8 +3320,33 @@
             "format": "date",
             "example": "2024-01-01"
           },
+          "withdrawnDate": {
+            "type": "string",
+            "format": "date",
+            "description": "탈퇴 일자 (탈퇴 멤버 전용, 다른 회원 정보 필드와 동시에 보낼 수 없음)",
+            "example": "2025-09-01"
+          },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고",
+            "example": "메모"
+          }
+        }
+      },
+      "InactiveActivitySemestersPatch": {
+        "type": "object",
+        "description": "비액티브 활동학기 표시용 원문·총 학기 수 일괄 갱신",
+        "properties": {
+          "activitySemestersLabel": {
+            "type": "string",
+            "description": "시트 표기용 자유 텍스트",
+            "example": "23년도 1학기, 24년도 2학기~25년도 1학기"
+          },
+          "totalActiveSemesters": {
+            "type": "integer",
+            "format": "int32",
+            "description": "총 활동 학기 수",
+            "example": 3
           }
         }
       },
@@ -2990,35 +3355,56 @@
         "properties": {
           "partIds": {
             "type": "array",
+            "description": "파트 ID 목록",
+            "example": [
+              1,
+              2
+            ],
             "items": {
               "type": "integer",
               "format": "int64"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "INACTIVE"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호",
+            "example": "01012345678"
           },
           "departmentId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "학과/소속 ID",
+            "example": 7
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
@@ -3030,12 +3416,48 @@
             "format": "date",
             "example": "2024-01-01"
           },
-          "expectedReturnSemesterId": {
-            "type": "integer",
-            "format": "int64"
-          },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고",
+            "example": "메모"
+          },
+          "expectedReturnSemester": {
+            "type": "string",
+            "description": "복귀 예정 학기(조회와 동일 yy-term, 예: 25-1)",
+            "example": "25-1"
+          },
+          "reason": {
+            "type": "string",
+            "description": "비액티브 사유",
+            "example": "개인 사정"
+          },
+          "smsReplied": {
+            "type": "boolean",
+            "description": "문자 회신 여부",
+            "example": true
+          },
+          "smsReplyDesiredPeriod": {
+            "type": "string",
+            "description": "문자 회신 희망 시기(자유 텍스트)",
+            "example": "다음 학기 시작 전"
+          },
+          "activitySemestersLabel": {
+            "type": "string",
+            "description": "비액티브 시트 활동학기 표시용 원문"
+          },
+          "totalActiveSemesters": {
+            "type": "integer",
+            "format": "int32",
+            "description": "총 활동 학기 수"
+          },
+          "totalInactiveSemesters": {
+            "type": "integer",
+            "format": "int32",
+            "description": "총 비액티브 학기 수"
+          },
+          "activitySemestersPatch": {
+            "$ref": "#/components/schemas/InactiveActivitySemestersPatch",
+            "description": "하위 호환용. [activitySemestersLabel]·[totalActiveSemesters]를 객체로 보낼 때 사용. 같은 필드를 본문 최상위와 동시에내면 이 객체의 값이 우선한다."
           }
         }
       },
@@ -3044,35 +3466,56 @@
         "properties": {
           "partIds": {
             "type": "array",
+            "description": "파트 ID 목록",
+            "example": [
+              1,
+              2
+            ],
             "items": {
               "type": "integer",
               "format": "int64"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "GRADUATED"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호",
+            "example": "01012345678"
           },
           "departmentId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "학과/소속 ID",
+            "example": 7
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
@@ -3085,10 +3528,14 @@
             "example": "2024-01-01"
           },
           "isAdvisorDesired": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "지도교수 의향 여부",
+            "example": false
           },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고",
+            "example": "메모"
           }
         }
       },
@@ -3097,35 +3544,56 @@
         "properties": {
           "partIds": {
             "type": "array",
+            "description": "파트 ID 목록",
+            "example": [
+              1,
+              2
+            ],
             "items": {
               "type": "integer",
               "format": "int64"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "COMPLETED"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호",
+            "example": "01012345678"
           },
           "departmentId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "학과/소속 ID",
+            "example": 7
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
@@ -3137,8 +3605,15 @@
             "format": "date",
             "example": "2024-01-01"
           },
+          "completionSemester": {
+            "type": "string",
+            "description": "수료 학기(조회 completionSemester와 동일 yy-term)",
+            "example": "25-1"
+          },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고",
+            "example": "메모"
           }
         }
       },
@@ -3147,35 +3622,56 @@
         "properties": {
           "partIds": {
             "type": "array",
+            "description": "파트 ID 목록",
+            "example": [
+              1,
+              2
+            ],
             "items": {
               "type": "integer",
               "format": "int64"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "ACTIVE"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호",
+            "example": "01012345678"
           },
           "departmentId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "학과/소속 ID",
+            "example": 7
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
@@ -3188,7 +3684,9 @@
             "example": "2024-01-01"
           },
           "membershipFee": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "회비 납부 여부",
+            "example": true
           },
           "grade": {
             "type": "integer",
@@ -3202,7 +3700,9 @@
             "example": false
           },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고",
+            "example": "메모"
           }
         }
       },
@@ -3266,7 +3766,9 @@
             "type": "boolean"
           }
         },
-        "required": ["validated"]
+        "required": [
+          "validated"
+        ]
       },
       "ReadSemesterResponse": {
         "type": "object",
@@ -3279,7 +3781,10 @@
             "type": "string"
           }
         },
-        "required": ["semester", "semesterId"]
+        "required": [
+          "semester",
+          "semesterId"
+        ]
       },
       "ReadScheduleResponse": {
         "type": "object",
@@ -3313,7 +3818,15 @@
             "type": "string"
           }
         },
-        "required": ["applicantId", "endTime", "id", "locationType", "name", "part", "startTime"]
+        "required": [
+          "applicantId",
+          "endTime",
+          "id",
+          "locationType",
+          "name",
+          "part",
+          "startTime"
+        ]
       },
       "AutoScheduleRequest": {
         "type": "object",
@@ -3332,7 +3845,11 @@
             "example": 60
           }
         },
-        "required": ["duration", "size", "strategy"]
+        "required": [
+          "duration",
+          "size",
+          "strategy"
+        ]
       },
       "AutoScheduleResponse": {
         "type": "object",
@@ -3356,7 +3873,13 @@
             "format": "date-time"
           }
         },
-        "required": ["applicantId", "applicantName", "endTime", "part", "startTime"]
+        "required": [
+          "applicantId",
+          "applicantName",
+          "endTime",
+          "part",
+          "startTime"
+        ]
       },
       "ReadPartsResponse": {
         "type": "object",
@@ -3369,7 +3892,10 @@
             "type": "string"
           }
         },
-        "required": ["partId", "partName"]
+        "required": [
+          "partId",
+          "partName"
+        ]
       },
       "MemberListResponseReadWithdrawnMemberListItemResponse": {
         "type": "object",
@@ -3381,85 +3907,90 @@
         "properties": {
           "members": {
             "type": "array",
+            "description": "멤버 목록",
             "items": {
               "$ref": "#/components/schemas/ReadWithdrawnMemberListItemResponse"
             }
           },
           "isSensitiveMasked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "민감정보 마스킹 적용 여부",
+            "example": false
           }
         },
-        "required": ["isSensitiveMasked", "members"]
+        "required": [
+          "isSensitiveMasked",
+          "members"
+        ]
       },
       "ReadDivisionAndPartInMemberResponse": {
         "type": "object",
         "properties": {
           "division": {
-            "type": "string"
+            "type": "string",
+            "description": "소속 구분(예: 개발, 디자인)",
+            "example": "개발"
           },
           "part": {
-            "type": "string"
+            "type": "string",
+            "description": "파트명",
+            "example": "백엔드"
           }
         },
-        "required": ["division", "part"]
+        "required": [
+          "division",
+          "part"
+        ]
       },
       "ReadWithdrawnMemberListItemResponse": {
         "type": "object",
         "properties": {
           "memberId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "멤버 ID",
+            "example": 123
           },
           "parts": {
             "type": "array",
+            "description": "소속 파트 목록",
             "items": {
               "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "phoneNumber": {
-            "type": "string"
-          },
-          "department": {
-            "type": "string"
-          },
-          "studentId": {
-            "type": "string"
-          },
-          "birthDate": {
             "type": "string",
-            "format": "date"
-          },
-          "joinDate": {
-            "type": "string",
-            "format": "date"
+            "description": "멤버 상태",
+            "example": "WITHDRAWN"
           },
           "withdrawnDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "탈퇴 일자(민감정보 마스킹 시 null)",
+            "example": "2025-09-01"
           },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고(민감정보 마스킹 시 null)",
+            "example": "개인 사정"
           }
         },
         "required": [
-          "department",
-          "email",
-          "joinDate",
           "memberId",
           "name",
           "nickname",
@@ -3581,7 +4112,9 @@
         "properties": {
           "lastUpdatedTime": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "마지막 동기화 시각(UTC, 없으면 null)",
+            "example": "2026-03-24T09:30:00Z"
           }
         }
       },
@@ -3595,78 +4128,139 @@
         "properties": {
           "members": {
             "type": "array",
+            "description": "멤버 목록",
             "items": {
               "$ref": "#/components/schemas/ReadInactiveMemberListItemResponse"
             }
           },
           "isSensitiveMasked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "민감정보 마스킹 적용 여부",
+            "example": false
           }
         },
-        "required": ["isSensitiveMasked", "members"]
+        "required": [
+          "isSensitiveMasked",
+          "members"
+        ]
       },
       "ReadInactiveMemberListItemResponse": {
         "type": "object",
         "properties": {
           "memberId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "멤버 ID",
+            "example": 123
           },
           "parts": {
             "type": "array",
+            "description": "소속 파트 목록",
             "items": {
               "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "INACTIVE"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호(민감정보 마스킹 시 null)",
+            "example": "01012345678"
           },
           "department": {
-            "type": "string"
+            "type": "string",
+            "description": "학과(또는 소속)",
+            "example": "컴퓨터학부"
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번(민감정보 마스킹 시 null)",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "생년월일(민감정보 마스킹 시 null)",
+            "example": "2003-09-23"
           },
           "joinDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "가입일",
+            "example": "2024-01-01"
           },
           "activePeriod": {
-            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse"
+            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse",
+            "description": "활동 기간(학기 범위)"
           },
           "expectedReturnSemester": {
-            "type": "string"
+            "type": "string",
+            "description": "복귀 예정 학기(없으면 null, yy-term)",
+            "example": "25-1"
           },
           "inactivePeriod": {
-            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse"
+            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse",
+            "description": "비액티브 기간(학기 범위)"
           },
           "reason": {
-            "type": "string"
+            "type": "string",
+            "description": "비액티브 사유(민감정보 마스킹 시 null)",
+            "example": "개인 사정"
           },
           "smsReplied": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "문자 회신 여부(민감정보 마스킹 시 null)",
+            "example": true
           },
           "smsReplyDesiredPeriod": {
-            "type": "string"
+            "type": "string",
+            "description": "문자 회신 희망 시기(자유 텍스트, 없으면 null)",
+            "example": "다음 학기 시작 전"
+          },
+          "activitySemestersLabel": {
+            "type": "string",
+            "description": "비액티브 시트 활동학기 표시용 원문(없으면 null)"
+          },
+          "totalActiveSemesters": {
+            "type": "integer",
+            "format": "int32",
+            "description": "총 활동 학기 수(없으면 null)"
+          },
+          "totalInactiveSemesters": {
+            "type": "integer",
+            "format": "int32",
+            "description": "총 비액티브 학기 수(없으면 null)"
+          },
+          "activeSemesterCountLabel": {
+            "type": "string",
+            "description": "활동 기간 표기용 학기 수 라벨(예: 3학기, 모르면 null)"
+          },
+          "inactiveSemesterCountLabel": {
+            "type": "string",
+            "description": "비액티브 기간 표기용 학기 수 라벨(예: 2학기, 모르면 null)"
           },
           "note": {
             "type": "string"
@@ -3690,13 +4284,20 @@
         "type": "object",
         "properties": {
           "startSemester": {
-            "type": "string"
+            "type": "string",
+            "description": "시작 학기(yy-term, 조회·저장 동일 형식)",
+            "example": "23-2"
           },
           "endSemester": {
-            "type": "string"
+            "type": "string",
+            "description": "종료 학기(yy-term, 조회·저장 동일 형식)",
+            "example": "24-2"
           }
         },
-        "required": ["endSemester", "startSemester"]
+        "required": [
+          "endSemester",
+          "startSemester"
+        ]
       },
       "MemberListResponseReadGraduatedMemberListItemResponse": {
         "type": "object",
@@ -3708,69 +4309,103 @@
         "properties": {
           "members": {
             "type": "array",
+            "description": "멤버 목록",
             "items": {
               "$ref": "#/components/schemas/ReadGraduatedMemberListItemResponse"
             }
           },
           "isSensitiveMasked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "민감정보 마스킹 적용 여부",
+            "example": false
           }
         },
-        "required": ["isSensitiveMasked", "members"]
+        "required": [
+          "isSensitiveMasked",
+          "members"
+        ]
       },
       "ReadGraduatedMemberListItemResponse": {
         "type": "object",
         "properties": {
           "memberId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "멤버 ID",
+            "example": 123
           },
           "parts": {
             "type": "array",
+            "description": "소속 파트 목록",
             "items": {
               "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "GRADUATED"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호(민감정보 마스킹 시 null)",
+            "example": "01012345678"
           },
           "department": {
-            "type": "string"
+            "type": "string",
+            "description": "학과(또는 소속)",
+            "example": "컴퓨터학부"
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번(민감정보 마스킹 시 null)",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "생년월일(민감정보 마스킹 시 null)",
+            "example": "2003-09-23"
           },
           "joinDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "가입일",
+            "example": "2024-01-01"
           },
           "activePeriod": {
-            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse"
+            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse",
+            "description": "활동 기간(학기 범위, 없으면 null)"
           },
           "isAdvisorDesired": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "지도교수 의향 여부",
+            "example": false
           },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고(민감정보 마스킹 시 null)",
+            "example": "메모"
           }
         },
         "required": [
@@ -3796,75 +4431,104 @@
         "properties": {
           "members": {
             "type": "array",
+            "description": "멤버 목록",
             "items": {
               "$ref": "#/components/schemas/ReadCompletedMemberListItemResponse"
             }
           },
           "isSensitiveMasked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "민감정보 마스킹 적용 여부",
+            "example": false
           }
         },
-        "required": ["isSensitiveMasked", "members"]
+        "required": [
+          "isSensitiveMasked",
+          "members"
+        ]
       },
       "ReadCompletedMemberListItemResponse": {
         "type": "object",
         "properties": {
           "memberId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "멤버 ID",
+            "example": 123
           },
           "parts": {
             "type": "array",
+            "description": "소속 파트 목록",
             "items": {
               "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "COMPLETED"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호(민감정보 마스킹 시 null)",
+            "example": "01012345678"
           },
           "department": {
-            "type": "string"
+            "type": "string",
+            "description": "학과(또는 소속)",
+            "example": "컴퓨터학부"
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번(민감정보 마스킹 시 null)",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "생년월일(민감정보 마스킹 시 null)",
+            "example": "2003-09-23"
           },
           "joinDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "가입일",
+            "example": "2024-01-01"
           },
-          "activePeriod": {
-            "$ref": "#/components/schemas/ReadSemesterPeriodInMemberResponse"
-          },
-          "isAdvisorDesired": {
-            "type": "boolean"
+          "completionSemester": {
+            "type": "string",
+            "description": "수료 학기(없으면 null, yy-term)",
+            "example": "25-1"
           },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고(민감정보 마스킹 시 null)",
+            "example": "메모"
           }
         },
         "required": [
           "department",
           "email",
-          "isAdvisorDesired",
           "joinDate",
           "memberId",
           "name",
@@ -3884,73 +4548,110 @@
         "properties": {
           "members": {
             "type": "array",
+            "description": "멤버 목록",
             "items": {
               "$ref": "#/components/schemas/ReadActiveMemberListItemResponse"
             }
           },
           "isSensitiveMasked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "민감정보 마스킹 적용 여부",
+            "example": false
           }
         },
-        "required": ["isSensitiveMasked", "members"]
+        "required": [
+          "isSensitiveMasked",
+          "members"
+        ]
       },
       "ReadActiveMemberListItemResponse": {
         "type": "object",
         "properties": {
           "memberId": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "멤버 ID",
+            "example": 123
           },
           "parts": {
             "type": "array",
+            "description": "소속 파트 목록",
             "items": {
               "$ref": "#/components/schemas/ReadDivisionAndPartInMemberResponse"
             }
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 역할",
+            "example": "MEMBER"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "이름",
+            "example": "홍길동"
           },
           "nickname": {
-            "type": "string"
+            "type": "string",
+            "description": "닉네임(영문/한글 조합)",
+            "example": "gil동"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "멤버 상태",
+            "example": "ACTIVE"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "이메일",
+            "example": "gildong@example.com"
           },
           "phoneNumber": {
-            "type": "string"
+            "type": "string",
+            "description": "전화번호(민감정보 마스킹 시 null)",
+            "example": "01012345678"
           },
           "department": {
-            "type": "string"
+            "type": "string",
+            "description": "학과(또는 소속)",
+            "example": "컴퓨터학부"
           },
           "studentId": {
-            "type": "string"
+            "type": "string",
+            "description": "학번(민감정보 마스킹 시 null)",
+            "example": 20201234
           },
           "birthDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "생년월일(민감정보 마스킹 시 null)",
+            "example": "2003-09-23"
           },
           "joinDate": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "description": "가입일",
+            "example": "2024-01-01"
           },
           "membershipFee": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "회비 납부 여부(민감정보 마스킹 시 null)",
+            "example": true
           },
           "grade": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "학년(민감정보 마스킹 시 null)",
+            "example": 3
           },
           "isOnLeave": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "재휴학 여부",
+            "example": false
           },
           "note": {
-            "type": "string"
+            "type": "string",
+            "description": "비고(민감정보 마스킹 시 null)",
+            "example": "메모"
           }
         },
         "required": [
@@ -3976,7 +4677,10 @@
             "type": "string"
           }
         },
-        "required": ["divisionId", "divisionName"]
+        "required": [
+          "divisionId",
+          "divisionName"
+        ]
       },
       "ReadDepartmentsResponse": {
         "type": "object",
@@ -3989,7 +4693,10 @@
             "type": "string"
           }
         },
-        "required": ["departmentId", "departmentName"]
+        "required": [
+          "departmentId",
+          "departmentName"
+        ]
       },
       "ReadCollegeResponse": {
         "type": "object",
@@ -4002,7 +4709,10 @@
             "type": "string"
           }
         },
-        "required": ["collegeId", "collegeName"]
+        "required": [
+          "collegeId",
+          "collegeName"
+        ]
       },
       "ReadApplicantResponse": {
         "type": "object",
@@ -4104,7 +4814,13 @@
             "format": "int32"
           }
         },
-        "required": ["content", "page", "size", "totalElements", "totalPages"]
+        "required": [
+          "content",
+          "page",
+          "size",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "ReadMailTemplateSummaryResponse": {
         "type": "object",
@@ -4121,7 +4837,11 @@
             "format": "date-time"
           }
         },
-        "required": ["id", "title", "updatedAt"]
+        "required": [
+          "id",
+          "title",
+          "updatedAt"
+        ]
       },
       "AttachmentReference": {
         "type": "object",
@@ -4148,7 +4868,11 @@
             "example": "mail-files/attachment/uuid-guide.pdf"
           }
         },
-        "required": ["contentType", "fileName", "storageKey"]
+        "required": [
+          "contentType",
+          "fileName",
+          "storageKey"
+        ]
       },
       "DetailVariable": {
         "type": "object",
@@ -4162,7 +4886,14 @@
           "type": {
             "type": "string",
             "description": "변수 타입. PERSON, DATE, LINK, TEXT는 사용자 입력 변수. APPLICANT, PARTNAME은 자동 채움 변수",
-            "enum": ["PERSON", "DATE", "LINK", "TEXT", "APPLICANT", "PARTNAME"],
+            "enum": [
+              "PERSON",
+              "DATE",
+              "LINK",
+              "TEXT",
+              "APPLICANT",
+              "PARTNAME"
+            ],
             "example": "TEXT"
           },
           "displayName": {
@@ -4172,11 +4903,21 @@
           },
           "perRecipient": {
             "type": "boolean",
-            "description": "수신자별로 다른 값 입력 여부",
+            "description": "수신자별로 다른 값 입력 여부. UserInput 타입에만 유효",
             "example": true
+          },
+          "attributeKey": {
+            "type": "string",
+            "description": "APPLICANT 타입 변수의 속성 키",
+            "example": "applicant.name"
           }
         },
-        "required": ["displayName", "key", "perRecipient", "type"]
+        "required": [
+          "displayName",
+          "key",
+          "perRecipient",
+          "type"
+        ]
       },
       "ReadMailTemplateDetailResponse": {
         "type": "object",
@@ -4192,6 +4933,11 @@
             "type": "string",
             "description": "템플릿 제목",
             "example": "합격 안내 메일"
+          },
+          "subject": {
+            "type": "string",
+            "description": "메일 제목. 변수는 {{var-{UUID}}} 형식으로 사용",
+            "example": "[유어슈] {{var-550e8400-e29b-41d4-a716-446655440000}}님 면접 안내"
           },
           "bodyHtml": {
             "type": "string",
@@ -4218,7 +4964,15 @@
             "description": "최종 수정 시간"
           }
         },
-        "required": ["attachmentReferences", "bodyHtml", "id", "title", "updatedAt", "variables"]
+        "required": [
+          "attachmentReferences",
+          "bodyHtml",
+          "id",
+          "subject",
+          "title",
+          "updatedAt",
+          "variables"
+        ]
       },
       "MailReservationListItem": {
         "type": "object",
@@ -4238,7 +4992,11 @@
           "status": {
             "type": "string",
             "description": "예약 상태",
-            "enum": ["SCHEDULED", "PENDING_SEND", "SENT"],
+            "enum": [
+              "SCHEDULED",
+              "PENDING_SEND",
+              "SENT"
+            ],
             "example": "SCHEDULED"
           },
           "senderEmailAddress": {
@@ -4282,7 +5040,9 @@
             }
           }
         },
-        "required": ["items"]
+        "required": [
+          "items"
+        ]
       },
       "MailReservationDetailResponse": {
         "type": "object",
@@ -4302,7 +5062,11 @@
           "status": {
             "type": "string",
             "description": "예약 상태",
-            "enum": ["SCHEDULED", "PENDING_SEND", "SENT"],
+            "enum": [
+              "SCHEDULED",
+              "PENDING_SEND",
+              "SENT"
+            ],
             "example": "SCHEDULED"
           },
           "senderEmailAddress": {
@@ -4383,7 +5147,11 @@
             "format": "date-time"
           }
         },
-        "required": ["mailId", "reservationId", "reservationTime"]
+        "required": [
+          "mailId",
+          "reservationId",
+          "reservationTime"
+        ]
       },
       "MailReservationStatusResponse": {
         "type": "object",
@@ -4395,7 +5163,71 @@
             }
           }
         },
-        "required": ["items"]
+        "required": [
+          "items"
+        ]
+      },
+      "MailGroupItem": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "senderEmail": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "reservationTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SCHEDULED",
+              "PENDING_SEND",
+              "SENDING",
+              "SENT"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "mailIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "required": [
+          "createdAt",
+          "groupId",
+          "mailIds",
+          "reservationTime",
+          "senderEmail",
+          "status"
+        ]
+      },
+      "MailGroupListResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MailGroupItem"
+            }
+          }
+        },
+        "required": [
+          "groups"
+        ]
       },
       "MailFileListResponse": {
         "type": "object",
@@ -4407,7 +5239,9 @@
             }
           }
         },
-        "required": ["files"]
+        "required": [
+          "files"
+        ]
       },
       "MailFileDownloadResponse": {
         "type": "object",
@@ -4422,7 +5256,10 @@
             "description": "URL 만료 시각"
           }
         },
-        "required": ["expiresAt", "getUrl"]
+        "required": [
+          "expiresAt",
+          "getUrl"
+        ]
       },
       "DeleteByPartResponse": {
         "type": "object",
@@ -4432,7 +5269,9 @@
             "format": "int32"
           }
         },
-        "required": ["deletedCount"]
+        "required": [
+          "deletedCount"
+        ]
       }
     },
     "securitySchemes": {
@@ -4441,8 +5280,8 @@
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://accounts.google.com/o/oauth2/auth",
-            "tokenUrl": "https://api.dev.scouter.yourssu.com/oauth2/swagger/callback",
-            "refreshUrl": "https://api.dev.scouter.yourssu.com/oauth2/swagger/callback",
+            "tokenUrl": "https://scouter-dev-api.yourssu.com/oauth2/swagger/callback",
+            "refreshUrl": "https://scouter-dev-api.yourssu.com/oauth2/swagger/callback",
             "scopes": {
               "openid": "OpenId Connect",
               "profile": "기본 프로필 정보",

--- a/src/components/Icons/Editor/IcChangeTextAlignRight.tsx
+++ b/src/components/Icons/Editor/IcChangeTextAlignRight.tsx
@@ -1,10 +1,6 @@
 import { BaseIconProps } from '@/components/Icons/type';
 
-export const IcChangeTextAlignRight = ({
-  width = 16,
-  height = 16,
-  ...props
-}: BaseIconProps) => {
+export const IcChangeTextAlignRight = ({ width = 16, height = 16, ...props }: BaseIconProps) => {
   return (
     <svg
       fill="none"

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -41,7 +41,7 @@ const Body = ({ rows }: { rows: Row<unknown>[] }) => (
             key={cell.id}
             style={{
               minWidth: `${cell.column.getSize()}px`,
-              maxWidth: (cell.column.columnDef.meta as { fixedWidth?: boolean } | undefined)
+              maxWidth: (cell.column.columnDef.meta as undefined | { fixedWidth?: boolean })
                 ?.fixedWidth
                 ? `${cell.column.getSize()}px`
                 : undefined,

--- a/src/components/TemplateList/TemplateList.style.ts
+++ b/src/components/TemplateList/TemplateList.style.ts
@@ -33,7 +33,9 @@ export const TemplateTitle = styled.h3`
 export const TemplateDate = styled.span<{ $variant?: 'error' }>`
   ${({ theme }) => theme.typo.B2_Rg_15};
   color: ${({ $variant, theme }) =>
-    $variant === 'error' ? 'var(--color-text-statusNegative)' : theme.semantic.color.textBasicTertiary};
+    $variant === 'error'
+      ? 'var(--color-text-statusNegative)'
+      : theme.semantic.color.textBasicTertiary};
 `;
 
 export const TrashIconButton = styled.button`

--- a/src/components/VariableCard/DateVariableCard.tsx
+++ b/src/components/VariableCard/DateVariableCard.tsx
@@ -39,7 +39,9 @@ export const DateVariableCard = ({ title, dates, onDateChange }: DateVariableCar
               handleDateSelection(
                 index,
                 withTime
-                  ? formatTemplates['01/01(월) 00:00'](setYear(selectedDate, new Date().getFullYear()))
+                  ? formatTemplates['01/01(월) 00:00'](
+                      setYear(selectedDate, new Date().getFullYear()),
+                    )
                   : formatTemplates['01/01(월)'](setYear(selectedDate, new Date().getFullYear())),
               )
             }

--- a/src/pages/SendMail/components/MailEditDialog/MailEditDialog.tsx
+++ b/src/pages/SendMail/components/MailEditDialog/MailEditDialog.tsx
@@ -19,6 +19,7 @@ import {
   MailVariableProvider,
 } from '@/pages/SendMail/context';
 import { useMailActions } from '@/pages/SendMail/hooks/useMailReservation';
+import { useRecipientData } from '@/pages/SendMail/hooks/useRecipientData';
 import { applicantOptions } from '@/query/applicant/options';
 import { mailOptions } from '@/query/mail/options';
 import { MailDetail } from '@/query/mail/schema';
@@ -53,6 +54,26 @@ const MailDialogSaveButton = ({
         저장하기
       </BoxButton>
     </StyledFooter>
+  );
+};
+
+const MailDialogHeader = ({
+  subjects,
+  defaultSubject,
+  onClose,
+}: {
+  defaultSubject: string;
+  onClose: () => void;
+  subjects: Record<string, string>;
+}) => {
+  const { currentRecipientId } = useRecipientData();
+  const currentSubject = (currentRecipientId && subjects[currentRecipientId]) || defaultSubject;
+
+  return (
+    <StyledHeader>
+      <StyledTitleInput readOnly value={currentSubject} />
+      <IcCloseLine onClick={onClose} />
+    </StyledHeader>
   );
 };
 
@@ -92,6 +113,18 @@ const MailDialogContent = ({
     [allMembers, mailDetails],
   );
 
+  const subjects = useMemo(() => {
+    const map: Record<string, string> = {};
+    mailDetails.forEach((detail) => {
+      detail.receiverEmailAddresses.forEach((email) => {
+        const applicant = allApplicants.find((a) => a.email === email);
+        const key = applicant ? String(applicant.applicantId) : email;
+        map[key] = detail.mailSubject;
+      });
+    });
+    return map;
+  }, [allApplicants, mailDetails]);
+
   const initialBody = useMemo(() => {
     const body: Record<string, string> = {};
     mailDetails.forEach((detail) => {
@@ -129,10 +162,7 @@ const MailDialogContent = ({
     <MailInfoProvider initialMailInfo={{ bcc, cc, receiver: allReceivers, sender, subject }}>
       <MailContentProvider initialAttachments={initialAttachments} initialBody={initialBody}>
         <MailVariableProvider currentPart={undefined}>
-          <StyledHeader>
-            <StyledTitleInput readOnly value={subject} />
-            <IcCloseLine onClick={onClose} />
-          </StyledHeader>
+          <MailDialogHeader defaultSubject={subject} onClose={onClose} subjects={subjects} />
 
           <InfoSection
             isTitleIncluded={false}

--- a/src/pages/SendMail/components/MailEditorContent/MailEditorContent.tsx
+++ b/src/pages/SendMail/components/MailEditorContent/MailEditorContent.tsx
@@ -21,6 +21,7 @@ import { EditorWrapper, StyledEditorContent } from './MailEditorContent.style';
 interface MailEditorContentProps {
   initialContent?: string;
   onContentChange?: (html: string) => void;
+  onFocus?: () => void;
   readOnly?: boolean;
   recipientName?: string;
 }
@@ -36,7 +37,7 @@ export interface MailEditorContentRef {
 }
 
 export const MailEditorContent = forwardRef<MailEditorContentRef, MailEditorContentProps>(
-  ({ recipientName, initialContent, onContentChange, readOnly }, ref) => {
+  ({ recipientName, initialContent, onContentChange, onFocus, readOnly }, ref) => {
     const placeholderText = recipientName
       ? `${recipientName}님에게 보낼 내용`
       : '내용을 입력하세요';
@@ -72,7 +73,23 @@ export const MailEditorContent = forwardRef<MailEditorContentRef, MailEditorCont
         }).configure({
           allowBase64: true,
         }),
-        Link.configure({
+        Link.extend({
+          addAttributes() {
+            return {
+              ...this.parent?.(),
+              style: {
+                default: null,
+                parseHTML: (element) => element.getAttribute('style'),
+                renderHTML: (attributes) => {
+                  if (!attributes.style) {
+                    return {};
+                  }
+                  return { style: attributes.style };
+                },
+              },
+            };
+          },
+        }).configure({
           openOnClick: true,
           linkOnPaste: true,
           autolink: true,
@@ -94,6 +111,11 @@ export const MailEditorContent = forwardRef<MailEditorContentRef, MailEditorCont
       onUpdate: ({ editor }) => {
         if (onContentChange) {
           onContentChange(editor.getHTML());
+        }
+      },
+      onFocus: () => {
+        if (onFocus) {
+          onFocus();
         }
       },
     });

--- a/src/pages/SendMail/components/MailInfoSection/ApplicantInputField.tsx
+++ b/src/pages/SendMail/components/MailInfoSection/ApplicantInputField.tsx
@@ -38,6 +38,12 @@ export const ApplicantInputField = ({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && inputValue === '' && items.length > 0) {
+      onItemsUpdate(items.slice(0, -1));
+    }
+  };
+
   return (
     <div className="border-line-basicMedium flex min-h-[56px] w-full flex-row gap-[12px] border-b-1 px-[20px] py-[10px]">
       <div className="typo-b1_sb_16 text-text-basicPrimary flex min-w-[72px] items-center">
@@ -59,6 +65,7 @@ export const ApplicantInputField = ({
                   className="typo-b1_rg_16 text-text-basicPrimary h-[36px] w-full flex-1 border-0 bg-transparent p-0 outline-none focus:ring-0"
                   onChange={handleInputChange}
                   onFocus={() => setIsActive(true)}
+                  onKeyDown={handleKeyDown}
                   ref={inputRef}
                   value={inputValue}
                 />

--- a/src/pages/SendMail/components/MailInfoSection/InfoSection.tsx
+++ b/src/pages/SendMail/components/MailInfoSection/InfoSection.tsx
@@ -1,18 +1,24 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { EditorContent, Extension, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
 import { overlay } from 'overlay-kit';
-import { Suspense, useCallback, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { styled } from 'styled-components';
 
+import { VariableChipNode } from '@/components/VariableChip/VariableChipNode';
+import { PlainTextPaste } from '@/extensions/PlainTextPaste';
 import { ApplicantInputField } from '@/pages/SendMail/components/MailInfoSection/ApplicantInputField';
 import { AutoFillMembers } from '@/pages/SendMail/components/MailInfoSection/AutoFillIMembers';
 import { MemberInputField } from '@/pages/SendMail/components/MailInfoSection/MemberInputField';
-import { TextInputField } from '@/pages/SendMail/components/MailInfoSection/TextInputField';
 import { MailReservationDialog } from '@/pages/SendMail/components/MailReservationDialog/MailReservationDialog';
 import { useMailInfoContext } from '@/pages/SendMail/context';
 import { meOption } from '@/query/member/me/options';
 import { Part } from '@/query/part/schema';
+import { templateOptions } from '@/query/template/options';
 import { MailFormData } from '@/types/editor';
 import { MemberInputFieldKey } from '@/types/editor';
 import { formatTemplates } from '@/utils/date';
+import { transformBodyHtmlToContent } from '@/utils/transformTemplate';
 
 interface InfoSectionProps {
   isTitleIncluded: boolean;
@@ -22,6 +28,22 @@ interface InfoSectionProps {
   selectedPart: Part | undefined;
   selectedTemplateId: number | undefined;
 }
+
+const StyledSubjectEditor = styled(EditorContent)`
+  width: 100%;
+  outline: none;
+  display: flex;
+  align-items: center;
+
+  .tiptap {
+    outline: none;
+    width: 100%;
+
+    p {
+      margin: 0;
+    }
+  }
+`;
 
 export const InfoSection = ({
   readOnly,
@@ -38,6 +60,53 @@ export const InfoSection = ({
 
   const { data: me } = useSuspenseQuery(meOption());
 
+  // 템플릿 정보 가져오기
+  const templateResults = useSuspenseQueries({
+    queries: [...(selectedTemplateId ? [templateOptions.detail(selectedTemplateId)] : [])],
+  });
+  const templateDetail = templateResults[0]?.data;
+
+  // 제목 에디터 설정
+  const subjectEditor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        link: false,
+        underline: false,
+      }),
+      PlainTextPaste,
+      VariableChipNode,
+      Extension.create({
+        name: 'singleLine',
+        addKeyboardShortcuts() {
+          return {
+            Enter: () => true,
+            'Shift-Enter': () => true,
+          };
+        },
+      }),
+    ],
+    content:
+      selectedTemplateId && templateDetail
+        ? transformBodyHtmlToContent(templateDetail.subject || '', templateDetail.variables)
+        : '',
+    editable: false,
+    immediatelyRender: false,
+  });
+
+  // 템플릿 변경 감지 및 에디터 내용 동기화
+  useEffect(() => {
+    if (subjectEditor) {
+      const nextContent =
+        selectedTemplateId && templateDetail
+          ? transformBodyHtmlToContent(templateDetail.subject || '', templateDetail.variables)
+          : '';
+      const nextHtml = nextContent ? `<p>${nextContent}</p>` : '<p></p>';
+      if (subjectEditor.getHTML() !== nextHtml) {
+        subjectEditor.commands.setContent(nextHtml);
+      }
+    }
+  }, [subjectEditor, selectedTemplateId, templateDetail]);
+
   const [formData, setFormData] = useState<MailFormData>({
     members: {
       '받는 사람': mailInfo.receiver || [],
@@ -46,6 +115,28 @@ export const InfoSection = ({
     },
     subject: mailInfo.subject || '',
   });
+
+  // 템플릿 변경 감지 및 제목 동기화
+  useEffect(() => {
+    if (selectedTemplateId && templateDetail) {
+      const nextSubject = templateDetail.subject || '';
+      setFormData((prev) => ({
+        ...prev,
+        subject: nextSubject,
+      }));
+      updateMailInfo({
+        subject: nextSubject,
+      });
+    } else if (!selectedTemplateId) {
+      setFormData((prev) => ({
+        ...prev,
+        subject: '',
+      }));
+      updateMailInfo({
+        subject: '',
+      });
+    }
+  }, [templateDetail, selectedTemplateId, updateMailInfo]);
 
   // 멤버(칩) 업데이트
   const handleMemberUpdate = useCallback(
@@ -122,12 +213,24 @@ export const InfoSection = ({
         </Suspense>
       )}
       {isTitleIncluded && (
-        <TextInputField
-          label="제목"
-          onChange={handleSubjectUpdate}
-          readOnly={readOnly}
-          value={formData.subject}
-        />
+        <div className="border-line-basicMedium flex min-h-[56px] w-full flex-row gap-[12px] border-b-1 px-[20px] py-[10px]">
+          <div className="typo-b1_sb_16 text-text-basicPrimary flex min-w-[72px] items-center">
+            제목
+          </div>
+          {selectedTemplateId ? (
+            <div className="typo-b1_rg_16 text-text-basicPrimary flex min-h-[36px] w-full items-center">
+              <StyledSubjectEditor editor={subjectEditor} />
+            </div>
+          ) : (
+            <input
+              className="typo-b1_rg_16 text-text-basicPrimary h-[36px] w-full border-0 bg-transparent p-0 outline-none focus:ring-0"
+              onChange={handleSubjectUpdate}
+              placeholder="메일 제목을 입력하세요"
+              readOnly={readOnly}
+              value={formData.subject}
+            />
+          )}
+        </div>
       )}
       {reservationTime && (
         <div className="border-line-basicMedium flex min-h-[56px] w-full flex-row gap-[12px] border-b-1 px-[20px] py-[10px]">

--- a/src/pages/SendMail/components/MailInfoSection/MemberInputField.tsx
+++ b/src/pages/SendMail/components/MailInfoSection/MemberInputField.tsx
@@ -36,6 +36,12 @@ export const MemberInputField = ({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && inputValue === '' && items.length > 0) {
+      onItemsUpdate(items.slice(0, -1));
+    }
+  };
+
   return (
     <div className="border-line-basicMedium flex min-h-[56px] w-full flex-row gap-[12px] border-b-1 px-[20px] py-[10px]">
       <div className="typo-b1_sb_16 text-text-basicPrimary flex min-w-[72px] items-center">
@@ -56,6 +62,7 @@ export const MemberInputField = ({
                   className="typo-b1_rg_16 text-text-basicPrimary h-[36px] w-full flex-1 border-0 bg-transparent p-0 outline-none focus:ring-0"
                   onChange={handleInputChange}
                   onFocus={() => setIsActive(true)}
+                  onKeyDown={handleKeyDown}
                   ref={inputRef}
                   value={inputValue}
                 />

--- a/src/pages/SendMail/components/MailSidebar/MailSidebar.tsx
+++ b/src/pages/SendMail/components/MailSidebar/MailSidebar.tsx
@@ -21,7 +21,7 @@ export interface MailSidebarProps {
 
 export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSidebarProps) => {
   const { currentRecipientId } = useRecipientData();
-  const { currentContent, defaultContent } = useMailData(templateId, currentRecipientId);
+  const { currentContent } = useMailData(templateId, currentRecipientId);
   const { sendReservation } = useMailActions();
   const { snackbar } = useSnackbar();
   const { mailInfo } = useMailInfoContext();
@@ -35,7 +35,9 @@ export const MailSidebar = ({ partId, templateId, onReserveSuccess }: MailSideba
       <MailReservationDialog
         onClose={close}
         onReserve={async (date: Date) => {
-          await sendReservation(currentContent, defaultContent, date);
+          if (templateId) {
+            await sendReservation(templateId, date);
+          }
           close();
           snackbar({
             type: 'info',

--- a/src/pages/SendMail/components/MailSidebar/VariableList.tsx
+++ b/src/pages/SendMail/components/MailSidebar/VariableList.tsx
@@ -4,6 +4,7 @@ import { DateVariableCard } from '@/components/VariableCard/DateVariableCard';
 import { LinkVariableCard } from '@/components/VariableCard/LinkVariableCard';
 import { NameVariableCard } from '@/components/VariableCard/NameVariableCard';
 import { TextVariableCard } from '@/components/VariableCard/TextVariableCard';
+import { useMailInfoContext } from '@/pages/SendMail/context';
 import { useMailData } from '@/pages/SendMail/hooks/useMailData';
 import { useRecipientData } from '@/pages/SendMail/hooks/useRecipientData';
 import { useVariableList } from '@/pages/SendMail/hooks/useVariableList';
@@ -17,20 +18,29 @@ export const VariableList = ({ templateId }: VariableListProps) => {
   const { variableCardData } = useVariableList(templateId);
   const { currentRecipientId } = useRecipientData(); // 현재 선택된 지원자 ID
   const { currentContent } = useMailData(templateId, currentRecipientId); // 현재 본문 데이터
+  const { mailInfo } = useMailInfoContext();
 
-  // 1. 본문(HTML)에서 data-key들을 순서대로 추출
-  const regex = /data-key="([^"]+)"/g;
   const keyOrder: string[] = [];
-  let match;
 
-  // currentContent가 있을 때만 정규표현식 실행
-  if (currentContent) {
-    while ((match = regex.exec(currentContent)) !== null) {
+  // 1. 제목(subject)에서 {{var-key}} 패턴으로 추출
+  if (mailInfo?.subject) {
+    const subjectRegex = /{{(var-[^}]+)}}/g;
+    let match;
+    while ((match = subjectRegex.exec(mailInfo.subject)) !== null) {
       keyOrder.push(match[1]);
     }
   }
 
-  // 2. 중복 키 제거 (본문에 여러 번 등장해도 첫 번째 위치 기준)
+  // 2. 본문(HTML)에서 data-key들을 순서대로 추출
+  if (currentContent) {
+    const bodyRegex = /data-key="([^"]+)"/g;
+    let match;
+    while ((match = bodyRegex.exec(currentContent)) !== null) {
+      keyOrder.push(match[1]);
+    }
+  }
+
+  // 3. 중복 키 제거 (제목/본문에 등장하는 첫 번째 위치 기준)
   const uniqueKeyOrder = [...new Set(keyOrder)];
 
   // 3. 추출된 순서에 따라 variableCardData 정렬

--- a/src/pages/SendMail/components/MailTab/MailTab.tsx
+++ b/src/pages/SendMail/components/MailTab/MailTab.tsx
@@ -8,6 +8,7 @@ import { TemplateList } from '@/components/TemplateList/TemplateList';
 import { MailEditDialog } from '@/pages/SendMail/components/MailEditDialog/MailEditDialog';
 import { DeleteTemplateDialog } from '@/pages/Template/components/DeleteTemplateDialog/DeleteTemplateDialog';
 import { deleteMailReservation } from '@/query/mail/mutation/deleteMailReservation';
+import { postMailReservationRetry } from '@/query/mail/mutation/postMailReservationRetry';
 import { mailOptions, MailReservationKeys } from '@/query/mail/options';
 import { MailItem } from '@/query/mail/schema';
 import { formatTemplates } from '@/utils/date';
@@ -26,12 +27,17 @@ export const MailTab = ({
   emptyText,
   onCompose,
   readOnly,
-  sortOrder = 'desc',
+  sortOrder = 'asc',
   statuses,
 }: MailTabProps) => {
-  const methods = useForm({ defaultValues: { search: '' } });
-  const { watch } = methods;
-  const searchValue = watch('search');
+  const methods = useForm({
+    defaultValues: {
+      search: '',
+    },
+  });
+
+  const searchValue = methods.watch('search');
+
   const { data: mails } = useSuspenseQuery(mailOptions.all());
   const [selectedMailIds, setSelectedMailIds] = useState<null | number[]>(null);
   const [pendingDeleteGroup, setPendingDeleteGroup] = useState<null | {
@@ -42,48 +48,53 @@ export const MailTab = ({
 
   const { mutateAsync: deleteReservation } = useMutation({
     mutationFn: deleteMailReservation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: MailReservationKeys.all });
+    },
+  });
+
+  const { mutateAsync: retryReservation } = useMutation({
+    mutationFn: postMailReservationRetry,
   });
 
   const handleConfirmDelete = async () => {
-    if (!pendingDeleteGroup) { return; }
-    await Promise.all(
-      pendingDeleteGroup.ids.map((id) => deleteReservation({ reservationId: id })),
-    );
+    if (!pendingDeleteGroup) {
+      return;
+    }
+    await Promise.all(pendingDeleteGroup.ids.map((id) => deleteReservation({ reservationId: id })));
     queryClient.invalidateQueries({ queryKey: MailReservationKeys.all });
     setPendingDeleteGroup(null);
+  };
+
+  const handleConfirmRetry = async (mailIds: number[]) => {
+    await Promise.all(mailIds.map((id) => retryReservation({ reservationId: id })));
+    queryClient.invalidateQueries({ queryKey: MailReservationKeys.all });
   };
 
   const filteredMails = useMemo(
     () =>
       mails.filter(
         (mail) =>
-          statuses.includes(mail.status) &&
+          statuses.includes(mail.status as any) &&
           mail.mailSubject.toLowerCase().includes(searchValue.toLowerCase()),
       ),
     [mails, statuses, searchValue],
   );
 
-  const groupedMails = useMemo(() => {
-    const map = new Map<string, typeof filteredMails>();
-    for (const mail of filteredMails) {
-      if (!map.has(mail.mailSubject)) {
-        map.set(mail.mailSubject, []);
-      }
-      map.get(mail.mailSubject)!.push(mail);
-    }
-    return [...map.values()].sort((a, b) => {
-      const aFailed = a.some((m) => m.status === 'PENDING_SEND');
-      const bFailed = b.some((m) => m.status === 'PENDING_SEND');
+  const sortedMails = useMemo(() => {
+    return [...filteredMails].sort((a, b) => {
+      const aFailed = a.status === 'PENDING_SEND';
+      const bFailed = b.status === 'PENDING_SEND';
       if (aFailed !== bFailed) {
         return aFailed ? -1 : 1;
       }
-      const timeA = new Date(a[0].reservationTime).getTime();
-      const timeB = new Date(b[0].reservationTime).getTime();
+      const timeA = new Date(a.reservationTime).getTime();
+      const timeB = new Date(b.reservationTime).getTime();
       return sortOrder === 'asc' ? timeA - timeB : timeB - timeA;
     });
   }, [filteredMails, sortOrder]);
 
-  const hasAnyMails = mails.some((mail) => statuses.includes(mail.status));
+  const hasAnyMails = mails.some((mail) => statuses.includes(mail.status as any));
 
   if (!hasAnyMails) {
     return (
@@ -116,29 +127,36 @@ export const MailTab = ({
       </div>
 
       <div className="flex flex-col gap-3">
-        {groupedMails.map((group) => {
-          const isPendingSend = group.some((m) => m.status === 'PENDING_SEND');
+        {sortedMails.map((group) => {
+          const isPendingSend = group.status === 'PENDING_SEND';
           return (
             <TemplateList
               action={
                 isPendingSend ? (
-                  <BoxButton onClick={() => {}} size="small" variant="outlined">
+                  <BoxButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleConfirmRetry(group.resolvedReservationIds);
+                    }}
+                    size="small"
+                    variant="outlined"
+                  >
                     재전송하기
                   </BoxButton>
                 ) : undefined
               }
-              date={formatTemplates['01/01(월) 00:00'](group[0].reservationTime)}
-              key={group[0].mailSubject}
-              onClick={() => setSelectedMailIds(group.map((m) => m.reservationId))}
+              date={formatTemplates['01/01(월) 00:00'](group.reservationTime)}
+              key={group.groupId}
+              onClick={() => setSelectedMailIds(group.resolvedReservationIds)}
               onDelete={() =>
                 setPendingDeleteGroup({
-                  ids: group.map((m) => m.reservationId),
-                  subject: group[0].mailSubject,
+                  ids: group.resolvedReservationIds,
+                  subject: group.mailSubject,
                 })
               }
               readonly={readOnly}
               text={isPendingSend ? '에 전송 실패' : readOnly ? '' : '에 예약됨'}
-              title={group[0].mailSubject}
+              title={group.mailSubject}
               variant={isPendingSend ? 'error' : undefined}
             />
           );

--- a/src/pages/SendMail/components/MailToolbar/MailToolbar.tsx
+++ b/src/pages/SendMail/components/MailToolbar/MailToolbar.tsx
@@ -42,7 +42,9 @@ export const MailToolbar = ({ editor, readOnly }: MailToolbarProps) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
 
   if (readOnly) {
-    if (mailContent.attachments.length === 0) { return null; }
+    if (mailContent.attachments.length === 0) {
+      return null;
+    }
     return (
       <ToolbarWrapper>
         <AttachmentList $readOnly>

--- a/src/pages/SendMail/components/SendMailPageLayout/SendMailPageLayout.tsx
+++ b/src/pages/SendMail/components/SendMailPageLayout/SendMailPageLayout.tsx
@@ -13,7 +13,7 @@ export const SendMailPageLayout = ({ slots }: SendMailPageLayoutProps) => {
   return (
     <PageLayout>
       <div className="flex w-full flex-[1_1_0] flex-row">
-        <div className="flex w-full flex-col gap-[20px] p-[40px]">
+        <div className="flex min-w-0 flex-1 flex-col gap-[20px] p-[40px]">
           {slots.dropdown}
           {slots.info}
           <div className="flex h-full">{slots.editor}</div>

--- a/src/pages/SendMail/hooks/useMailReservation.ts
+++ b/src/pages/SendMail/hooks/useMailReservation.ts
@@ -1,32 +1,23 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
-import {
-  useMailContentContext,
-  useMailInfoContext,
-  useMailVariableContext,
-} from '@/pages/SendMail/context';
-import { useRecipientData } from '@/pages/SendMail/hooks/useRecipientData';
-import { useVariableValue } from '@/pages/SendMail/hooks/useVariableValue';
+import { api } from '@/apis/api.ts';
+import { useMailInfoContext, useMailVariableContext } from '@/pages/SendMail/context';
 import { applicantOptions } from '@/query/applicant/options';
-import { deleteMailReservation } from '@/query/mail/mutation/deleteMailReservation';
 import { postMailReservation } from '@/query/mail/mutation/postMailReservation';
 import { putMailReservation } from '@/query/mail/mutation/putMailReservation';
 import { MailReservationKeys } from '@/query/mail/options';
 import { MailDetail } from '@/query/mail/schema';
 import { memberOptions } from '@/query/member/options';
-import { buildMailRequest } from '@/utils/buildMailRequest';
+import { templateOptions } from '@/query/template/options';
 
 export const useMailActions = () => {
   const queryClient = useQueryClient();
   const { mailInfo } = useMailInfoContext();
-  const { mailContent } = useMailContentContext();
 
   const { data: allMembers } = useSuspenseQuery(memberOptions('액티브'));
   const { data: allApplicants } = useSuspenseQuery(applicantOptions());
-  const { getVariableValue } = useVariableValue();
 
   const { variableValue } = useMailVariableContext();
-  const { currentRecipientId } = useRecipientData();
 
   const { mutateAsync: mutatePostMailReservation, isPending } = useMutation({
     mutationFn: postMailReservation,
@@ -51,248 +42,126 @@ export const useMailActions = () => {
     return name;
   };
 
-  const replaceChips = (html: string, targetId?: string) => {
-    if (!html) {
-      return '';
-    }
-    return html.replace(/<span[^>]*data-variable-chip[^>]*>.*?<\/span>/g, (match) => {
-      const keyMatch = match.match(/data-key="([^"]*)"/);
-      const perRecipientMatch = match.match(/data-per-recipient="([^"]*)"/);
-      const labelMatch = match.match(/data-label="([^"]*)"/);
-      const typeMatch = match.match(/data-type="([^"]*)"/);
-
-      const key = keyMatch?.[1] || '';
-      const isIndividual = perRecipientMatch?.[1] === 'true';
-      const label = labelMatch?.[1] || '';
-      const type = typeMatch?.[1] || '';
-
-      const value = getVariableValue(key, isIndividual, label, targetId);
-
-      // 값이 있으면 치환, 없으면 칩 원본 그대로 반환
-      if (typeof value === 'string' && value.trim() !== '') {
-        if (type.toUpperCase() === 'LINK') {
-          let linkText = value;
-          let linkUrl = value;
-          try {
-            const parsed = JSON.parse(value);
-            if (parsed && typeof parsed === 'object') {
-              linkText = parsed.text || parsed.url || value;
-              linkUrl = parsed.url || value;
-            }
-          } catch {
-            // fallback
-          }
-
-          const href = linkUrl.startsWith('http') ? linkUrl : `https://${linkUrl}`;
-          return `<a href="${href}" target="_blank" rel="noreferrer" style="color: #1155cc; text-decoration: underline;">${linkText}</a>`;
-        }
-        return value;
-      }
-      return match;
-    });
-  };
-
-  const extractInlineImages = (html: string) => {
-    let resultHtml = html;
-    const inlineImageReferences: { contentId: string; fileId: number }[] = [];
-
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    const images = doc.querySelectorAll('img');
-
-    images.forEach((img) => {
-      const fileIdAttr = img.getAttribute('data-file-id');
-      const contentIdAttr = img.getAttribute('data-content-id');
-
-      if (fileIdAttr && contentIdAttr) {
-        const fileId = parseInt(fileIdAttr, 10);
-        if (!isNaN(fileId)) {
-          inlineImageReferences.push({ fileId, contentId: contentIdAttr });
-        }
-      }
-    });
-
-    resultHtml = doc.body.innerHTML;
-    return { resultHtml, inlineImageReferences };
-  };
-
-  const executeSend = async (requestData: ReturnType<typeof buildMailRequest>['request']) => {
-    return mutatePostMailReservation(requestData);
-  };
-
   const updateReservation = async (mailDetails: MailDetail[], reservationTime: Date) => {
-    const newReceiverEmails = mailInfo.receiver.map(convertNameToEmail);
-    const existingEmails = mailDetails.flatMap((d) => d.receiverEmailAddresses);
+    if (mailDetails.length === 0) {
+      return;
+    }
+    const detail = mailDetails[0];
+    const reservationId = detail.reservationId;
 
-    const toUpdate = mailDetails.filter((detail) =>
-      detail.receiverEmailAddresses.some((email) => newReceiverEmails.includes(email)),
-    );
-    const toDelete = mailDetails.filter((detail) =>
-      detail.receiverEmailAddresses.every((email) => !newReceiverEmails.includes(email)),
-    );
-    const toCreate = newReceiverEmails.filter((email) => !existingEmails.includes(email));
-
-    const reservationTimeIso = reservationTime.toISOString();
-
-    // 각 detail에 대해, 수신자별 body를 구하고 동일 여부에 따라 PUT 또는 삭제+재생성으로 분기
-    const putsToMake: { body: string; detail: MailDetail; emails: string[] }[] = [];
-    const detailsToSplit: MailDetail[] = [];
-
-    for (const detail of toUpdate) {
-      const relevantEmails = detail.receiverEmailAddresses.filter((e) =>
-        newReceiverEmails.includes(e),
-      );
-      const emailBodies = relevantEmails.map((email) => {
-        const applicant = allApplicants?.find((a) => a.email === email);
-        return applicant
-          ? (mailContent.body[String(applicant.applicantId)] ?? detail.mailBody)
-          : detail.mailBody;
+    // Fetch templateId from reservation groups
+    let templateId: number | undefined;
+    try {
+      const groupsData = await queryClient.fetchQuery({
+        queryKey: ['mailReservations', 'groups'] as const,
+        queryFn: () => api.get('api/mails/reservation/groups').json<{ groups: any[] }>(),
       });
-      const allSameBody = emailBodies.every((b) => b === emailBodies[0]);
-
-      if (allSameBody && relevantEmails.length > 0) {
-        putsToMake.push({ detail, body: emailBodies[0], emails: relevantEmails });
-      } else {
-        // 수신자별로 다른 body → 기존 예약 삭제 후 개별 재생성
-        detailsToSplit.push(detail);
+      const group = groupsData.groups.find((g) => g.mailIds.includes(detail.mailId));
+      if (group) {
+        templateId = group.templateId;
       }
+    } catch (e) {
+      console.error('Failed to fetch templateId from reservation groups', e);
     }
 
-    // 분리 대상 detail의 수신자 이메일은 새로 생성
-    const emailsFromSplit = detailsToSplit.flatMap((d) =>
-      d.receiverEmailAddresses.filter((e) => newReceiverEmails.includes(e)),
-    );
-    const allEmailsToCreate = [...toCreate, ...emailsFromSplit];
+    const resolvedTemplateId = templateId ?? 0;
 
-    await Promise.all([
-      ...putsToMake.map(({ detail, body, emails }) =>
-        putMailReservation({
-          reservationId: detail.reservationId,
-          mailSubject: mailInfo.subject,
-          mailBody: body,
-          bodyFormat: detail.bodyFormat as 'HTML' | 'TEXT',
-          receiverEmailAddresses: emails,
-          ccEmailAddresses: mailInfo.cc.map(convertNameToEmail),
-          bccEmailAddresses: mailInfo.bcc.map(convertNameToEmail),
-          reservationTime: reservationTimeIso,
-          attachmentReferences: mailContent.attachments.map((a) => ({ fileId: a.fileId })),
-        }),
-      ),
-      ...[...toDelete, ...detailsToSplit].map((detail) =>
-        deleteMailReservation({ reservationId: detail.reservationId }),
-      ),
-      ...allEmailsToCreate.map((email) => {
-        const applicant = allApplicants?.find((a) => a.email === email);
-        const originalBody =
-          mailDetails.find((d) => d.receiverEmailAddresses.includes(email))?.mailBody ?? '';
-        const body = applicant
-          ? (mailContent.body[String(applicant.applicantId)] ?? originalBody)
-          : originalBody;
-        return mutatePostMailReservation(
-          buildMailRequest({
-            inlineImageReferences: [],
-            mailInfo: {
-              receiver: [email],
-              cc: mailInfo.cc.map(convertNameToEmail),
-              bcc: mailInfo.bcc.map(convertNameToEmail),
-              subject: mailInfo.subject,
-            },
-            mailContent: { ...mailContent, body },
-            reservedDate: reservationTime,
-          }).request,
-        );
-      }),
-    ]);
+    // Get the recipients from mailInfo.receiver
+    const newReceiverEmails = mailInfo.receiver.map(convertNameToEmail);
+
+    const recipients = newReceiverEmails.map((email) => {
+      const targetApplicant = allApplicants?.find((a) => a.name === email || a.email === email);
+      return {
+        email,
+        ...(targetApplicant ? { applicantId: targetApplicant.applicantId } : {}),
+        bindings: {},
+      };
+    });
+
+    await putMailReservation({
+      reservationId,
+      templateId: resolvedTemplateId,
+      reservationTime: reservationTime.toISOString(),
+      recipients,
+      sharedBindings: {},
+      ccEmailAddresses: mailInfo.cc.map(convertNameToEmail),
+      bccEmailAddresses: mailInfo.bcc.map(convertNameToEmail),
+    });
 
     queryClient.invalidateQueries({ queryKey: MailReservationKeys.all });
   };
 
-  const sendReservation = async (rawBody: string, defaultBody: string, reservedDate?: Date) => {
-    const hasIndividualVar =
-      Object.keys(variableValue.perApplicant).length > 0 && currentRecipientId !== null;
+  const sendReservation = async (templateId: number, reservedDate: Date) => {
+    // 1. Fetch template details to get its variables
+    const template = await queryClient.fetchQuery(templateOptions.detail(templateId));
 
-    if (hasIndividualVar && !currentRecipientId) {
-      console.error('개인화 변수가 존재하지만 현재 지원자 ID가 없습니다.');
-      return;
-    }
-    if (hasIndividualVar) {
-      const sendPromises = mailInfo.receiver.map(async (receiverEmail) => {
-        const targetApplicant = allApplicants?.find(
-          (a) => a.name === receiverEmail || a.email === receiverEmail,
-        );
-        const targetId = targetApplicant ? String(targetApplicant.applicantId) : undefined;
-        const targetEmail = targetApplicant?.email || receiverEmail;
-
-        // 지원자별로 수정된 본문이 있다면 확인
-        let specificBody = defaultBody; // 기본은 템플릿 내용
-
-        if (targetId === currentRecipientId) {
-          // 1. 현재 내가 편집 중인 탭이라면 -> 지금 에디터에 떠 있는 최신 값(currentEditorHtml) 사용
-          specificBody = rawBody;
-        } else if (targetId && mailContent.body[targetId]) {
-          // 2. 다른 탭인데 수정 이력이 있다면 -> 저장된 개별 본문 사용
-          specificBody = mailContent.body[targetId];
+    // Helper to format variables (specifically rendering Link type to HTML a tags)
+    const formatVariableValue = (v: { type: string }, val: string) => {
+      if (v.type === '링크') {
+        try {
+          const parsed = JSON.parse(val);
+          if (parsed && typeof parsed === 'object' && parsed.url) {
+            const linkText = parsed.text || parsed.url;
+            const linkUrl = parsed.url.startsWith('http') ? parsed.url : `https://${parsed.url}`;
+            return `<a href="${linkUrl}" target="_blank" rel="noopener noreferrer" style="color: #1155cc; text-decoration: underline;">${linkText}</a>`;
+          }
+        } catch {
+          // Fallback if not valid JSON
         }
-
-        const targetMailBody = replaceChips(specificBody, targetId);
-        const { resultHtml: finalBody, inlineImageReferences } =
-          extractInlineImages(targetMailBody);
-
-        // 이메일로 지원자 ID 찾기
-        const requestBody = buildMailRequest({
-          inlineImageReferences,
-          mailInfo: {
-            receiver: [targetEmail],
-            cc: mailInfo.cc.map(convertNameToEmail),
-            bcc: mailInfo.bcc.map(convertNameToEmail),
-            subject: mailInfo.subject,
-          },
-          mailContent: {
-            ...mailContent,
-            body: finalBody,
-          },
-          reservedDate: reservedDate || null,
-        }).request;
-        return executeSend(requestBody);
-      });
-
-      await Promise.all(sendPromises); // 모든 요청이 끝날 때까지 대기
-      return;
-    }
-
-    const sendPromises = mailInfo.receiver.map(async (receiverName) => {
-      const targetApplicant = allApplicants.find(
-        (a) => a.name === receiverName || a.email === receiverName,
-      );
-      const targetId = targetApplicant ? String(targetApplicant.applicantId) : undefined;
-      const targetEmail = targetApplicant?.email || receiverName;
-
-      let specificBody = defaultBody;
-      if (targetId === currentRecipientId) {
-        specificBody = rawBody;
-      } else if (targetId && mailContent.body[targetId]) {
-        specificBody = mailContent.body[targetId];
       }
+      return val;
+    };
 
-      const targetMailBody = replaceChips(specificBody, targetId);
-      const { resultHtml: finalBody, inlineImageReferences } = extractInlineImages(targetMailBody);
+    // 2. Prepare cc and bcc email addresses
+    const ccEmailAddresses = mailInfo.cc.map(convertNameToEmail);
+    const bccEmailAddresses = mailInfo.bcc.map(convertNameToEmail);
 
-      return executeSend(
-        buildMailRequest({
-          inlineImageReferences,
-          mailInfo: {
-            receiver: [targetEmail],
-            cc: mailInfo.cc.map(convertNameToEmail),
-            bcc: mailInfo.bcc.map(convertNameToEmail),
-            subject: mailInfo.subject,
-          },
-          mailContent: { ...mailContent, body: finalBody },
-          reservedDate: reservedDate || null,
-        }).request,
-      );
+    // 3. Prepare common bindings (sharedBindings)
+    const sharedBindings: Record<string, string> = {};
+    template.variables.forEach((v) => {
+      if (v.type === '사람/지원자' || v.type === '텍스트/파트명') {
+        return;
+      }
+      if (!v.perRecipient) {
+        const rawValue = variableValue.common[v.key] ?? '';
+        sharedBindings[v.key] = formatVariableValue(v, rawValue);
+      }
     });
 
-    await Promise.all(sendPromises);
+    // 4. Prepare recipients list
+    const newReceiverEmails = mailInfo.receiver.map(convertNameToEmail);
+    const recipients = newReceiverEmails.map((email) => {
+      const targetApplicant = allApplicants?.find((a) => a.name === email || a.email === email);
+      const bindings: Record<string, string> = {};
+
+      template.variables.forEach((v) => {
+        if (v.type === '사람/지원자' || v.type === '텍스트/파트명') {
+          return;
+        }
+        if (v.perRecipient) {
+          const id = targetApplicant ? String(targetApplicant.applicantId) : email;
+          const rawValue = variableValue.perApplicant[id]?.[v.key] ?? '';
+          bindings[v.key] = formatVariableValue(v, rawValue);
+        }
+      });
+
+      return {
+        email,
+        ...(targetApplicant ? { applicantId: targetApplicant.applicantId } : {}),
+        bindings,
+      };
+    });
+
+    // 5. Post to API
+    await mutatePostMailReservation({
+      templateId,
+      reservationTime: reservedDate.toISOString(),
+      recipients,
+      sharedBindings,
+      ccEmailAddresses,
+      bccEmailAddresses,
+    });
   };
+
   return { sendReservation, updateReservation, isPending };
 };

--- a/src/pages/Template/components/AddTemplateDialog/AddTemplateDialog.tsx
+++ b/src/pages/Template/components/AddTemplateDialog/AddTemplateDialog.tsx
@@ -27,15 +27,17 @@ interface AddTemplateDialogProps {
 export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialogProps) => {
   const [formData, setFormData] = useState({
     title: '',
+    subject: '',
     content: '',
     variables: getDefaultVariables(),
     attachments: [] as AttachmentType[],
   });
 
   const handleSave = () => {
-    if (formData.title.trim()) {
+    if (formData.title.trim() && formData.subject.trim()) {
       onSave({
         title: formData.title.trim(),
+        subject: formData.subject.trim(),
         content: formData.content,
         variables: formData.variables,
         attachments: formData.attachments,
@@ -47,6 +49,7 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
   const handleClose = () => {
     setFormData({
       title: '',
+      subject: '',
       content: '',
       variables: getDefaultVariables(),
       attachments: [],
@@ -58,6 +61,13 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
     setFormData((prev) => ({
       ...prev,
       title: e.target.value,
+    }));
+  };
+
+  const handleSubjectChange = (subject: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      subject,
     }));
   };
 
@@ -94,7 +104,7 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
           <StyledHeader>
             <StyledTitleInput
               onChange={handleTitleChange}
-              placeholder="제목을 입력하세요"
+              placeholder="템플릿 제목을 입력하세요"
               value={formData.title}
             />
             <IcCloseLine onClick={onClose} />
@@ -104,16 +114,18 @@ export const AddTemplateDialog = ({ isOpen, onClose, onSave }: AddTemplateDialog
               <TemplateEditor
                 onAttachmentsChange={handleAttachmentsChange}
                 onContentChange={handleContentChange}
+                onSubjectChange={handleSubjectChange}
                 onVariablesChange={handleVariablesChange}
                 templateAttachments={formData.attachments}
                 templateContent={formData.content}
+                templateSubject={formData.subject}
                 templateVariables={formData.variables}
               />
             </MailContentProvider>
           </StyledBody>
           <StyledFooter>
             <BoxButton
-              disabled={!formData.title.trim()}
+              disabled={!formData.title.trim() || !formData.subject.trim()}
               onClick={handleSave}
               size="large"
               variant="filledPrimary"

--- a/src/pages/Template/components/EditTemplateDialog/EditTemplateDialog.tsx
+++ b/src/pages/Template/components/EditTemplateDialog/EditTemplateDialog.tsx
@@ -35,8 +35,15 @@ export const EditTemplateDialog = ({
 }: EditTemplateDialogProps) => {
   const { data: templateDetail } = useSuspenseQuery(templateOptions.detail(templateId));
 
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    attachments: AttachmentType[];
+    content: string;
+    subject: string;
+    title: string;
+    variables: Variable[];
+  }>({
     title: templateDetail.title,
+    subject: templateDetail.subject,
     content: templateDetail.content,
     variables: templateDetail.variables,
     attachments: templateDetail.attachments || [],
@@ -46,6 +53,7 @@ export const EditTemplateDialog = ({
   useEffect(() => {
     setFormData({
       title: templateDetail.title,
+      subject: templateDetail.subject,
       content: templateDetail.content,
       variables: templateDetail.variables,
       attachments: templateDetail.attachments || [],
@@ -53,12 +61,13 @@ export const EditTemplateDialog = ({
   }, [templateDetail]);
 
   const handleSave = () => {
-    if (!formData.title.trim()) {
+    if (!formData.title.trim() || !formData.subject.trim()) {
       return;
     }
     onSave({
       ...templateDetail,
       title: formData.title.trim(),
+      subject: formData.subject.trim(),
       content: formData.content,
       variables: formData.variables,
       attachments: formData.attachments,
@@ -75,6 +84,13 @@ export const EditTemplateDialog = ({
     setFormData((prev) => ({
       ...prev,
       title: e.target.value,
+    }));
+  };
+
+  const handleSubjectChange = (subject: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      subject,
     }));
   };
 
@@ -111,7 +127,7 @@ export const EditTemplateDialog = ({
             </VisuallyHidden>
             <StyledTitleInput
               onChange={handleTitleChange}
-              placeholder="제목을 입력하세요"
+              placeholder="템플릿 제목을 입력하세요"
               value={formData.title}
             />
             <IcCloseLine onClick={onClose} />
@@ -122,9 +138,11 @@ export const EditTemplateDialog = ({
               <TemplateEditor
                 onAttachmentsChange={handleAttachmentsChange}
                 onContentChange={handleContentChange}
+                onSubjectChange={handleSubjectChange}
                 onVariablesChange={handleVariablesChange}
                 templateAttachments={formData.attachments}
                 templateContent={formData.content}
+                templateSubject={formData.subject}
                 templateVariables={formData.variables}
               />
             </MailContentProvider>
@@ -132,7 +150,7 @@ export const EditTemplateDialog = ({
 
           <StyledFooter>
             <BoxButton
-              disabled={!formData.title.trim()}
+              disabled={!formData.title.trim() || !formData.subject.trim()}
               onClick={handleSave}
               size="large"
               variant="filledPrimary"

--- a/src/pages/Template/components/TemplateEditor.tsx
+++ b/src/pages/Template/components/TemplateEditor.tsx
@@ -1,6 +1,13 @@
+import { Extension } from '@tiptap/core';
+import Placeholder from '@tiptap/extension-placeholder';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
 import { useEffect, useRef } from 'react';
+import { styled } from 'styled-components';
 
 import { getChipType } from '@/components/VariableChip/utils';
+import { VariableChipNode } from '@/components/VariableChip/VariableChipNode';
+import { PlainTextPaste } from '@/extensions/PlainTextPaste';
 import {
   MailEditorContent,
   MailEditorContentRef,
@@ -9,27 +16,92 @@ import { MailHeader } from '@/pages/SendMail/components/MailHeader/MailHeader';
 import { useMailContentContext } from '@/pages/SendMail/context';
 import { Variable, VariableType } from '@/types/editor';
 import { AttachmentType } from '@/utils/buildMailRequest';
+import { transformBodyHtmlToContent, transformContentToBodyHtml } from '@/utils/transformTemplate';
 
 interface TemplateEditorProps {
   onAttachmentsChange?: (attachments: AttachmentType[]) => void;
   onContentChange: (content: string) => void;
+  onSubjectChange: (subject: string) => void;
   onVariablesChange: (variables: Variable[]) => void;
   templateAttachments?: AttachmentType[];
   templateContent: string;
+  templateSubject: string;
   templateVariables: Variable[];
 }
+
+const stripParagraphTags = (html: string) => {
+  return html.replace(/<\/p><p>/g, ' ').replace(/<\/?p>/g, '');
+};
+
+const StyledSubjectEditor = styled(EditorContent)`
+  width: 100%;
+  outline: none;
+
+  .tiptap {
+    outline: none;
+    width: 100%;
+
+    p {
+      margin: 0;
+    }
+
+    p.is-editor-empty:first-child::before {
+      color: ${({ theme }) => theme.semantic.color.textBasicDisabled};
+      content: attr(data-placeholder);
+      float: left;
+      height: 0;
+      pointer-events: none;
+    }
+  }
+`;
 
 export const TemplateEditor = ({
   templateAttachments = [],
   templateContent,
+  templateSubject = '',
   templateVariables,
   onAttachmentsChange,
   onContentChange,
+  onSubjectChange,
   onVariablesChange,
 }: TemplateEditorProps) => {
   const editorRef = useRef<MailEditorContentRef>(null);
+  const lastFocusedField = useRef<'content' | 'subject'>('content');
   const { mailContent, actions } = useMailContentContext();
   const initialMount = useRef(true);
+
+  const subjectEditor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        link: false,
+        underline: false,
+      }),
+      PlainTextPaste,
+      VariableChipNode,
+      Placeholder.configure({
+        placeholder: '메일 제목을 입력하세요',
+        emptyEditorClass: 'is-editor-empty',
+      }),
+      Extension.create({
+        name: 'singleLine',
+        addKeyboardShortcuts() {
+          return {
+            Enter: () => true,
+            'Shift-Enter': () => true,
+          };
+        },
+      }),
+    ],
+    content: templateSubject ? transformBodyHtmlToContent(templateSubject, templateVariables) : '',
+    editable: true,
+    immediatelyRender: false,
+    onUpdate: ({ editor }) => {
+      onSubjectChange(stripParagraphTags(transformContentToBodyHtml(editor.getHTML())));
+    },
+    onFocus: () => {
+      lastFocusedField.current = 'subject';
+    },
+  });
 
   // 컨텍스트에 초기 첨부파일 상태 세팅
   useEffect(() => {
@@ -47,8 +119,44 @@ export const TemplateEditor = ({
     }
   }, [mailContent.attachments, onAttachmentsChange]);
 
+  // templateSubject가 상위 컴포넌트(예: 초기 데이터 로드)에서 바뀔 때 에디터에 반영
+  useEffect(() => {
+    if (subjectEditor) {
+      const currentHtml = subjectEditor.getHTML();
+      const rawHtml = templateSubject
+        ? transformBodyHtmlToContent(templateSubject, templateVariables)
+        : '';
+      const nextHtml = rawHtml ? `<p>${rawHtml}</p>` : '<p></p>';
+
+      if (currentHtml !== nextHtml) {
+        subjectEditor.commands.setContent(nextHtml);
+      }
+    }
+  }, [subjectEditor, templateSubject, templateVariables]);
+
+  const insertVariableToSubject = (variable: Variable) => {
+    if (subjectEditor) {
+      subjectEditor
+        .chain()
+        .focus()
+        .insertContent({
+          type: 'variableChip',
+          attrs: {
+            key: variable.key,
+            type: getChipType(variable.type),
+            label: variable.displayName,
+            perRecipient: variable.perRecipient,
+          },
+        })
+        .insertContent(' ')
+        .run();
+    }
+  };
+
   const handleVariableClick = (variable: Variable) => {
-    if (editorRef.current) {
+    if (lastFocusedField.current === 'subject') {
+      insertVariableToSubject(variable);
+    } else if (editorRef.current) {
       const chipType = getChipType(variable.type);
       editorRef.current.insertVariable(
         variable.key,
@@ -69,18 +177,41 @@ export const TemplateEditor = ({
     };
 
     onVariablesChange([...templateVariables, newVariable]);
-    editorRef.current?.insertVariable(
-      newVariable.key,
-      getChipType(newVariable.type),
-      newVariable.displayName,
-      newVariable.perRecipient,
-    );
+
+    if (lastFocusedField.current === 'subject') {
+      insertVariableToSubject(newVariable);
+    } else {
+      editorRef.current?.insertVariable(
+        newVariable.key,
+        getChipType(newVariable.type),
+        newVariable.displayName,
+        newVariable.perRecipient,
+      );
+    }
   };
 
   const handleVariableDelete = (variable: Variable) => {
+    onVariablesChange(templateVariables.filter((v) => v.key !== variable.key));
+
     if (editorRef.current) {
-      onVariablesChange(templateVariables.filter((v) => v.key !== variable.key));
       editorRef.current.deleteVariable(variable.key);
+    }
+
+    if (subjectEditor) {
+      const transaction = subjectEditor.state.tr;
+      const nodesToDelete: { pos: number; size: number }[] = [];
+
+      subjectEditor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'variableChip' && node.attrs.key === variable.key) {
+          nodesToDelete.push({ pos, size: node.nodeSize });
+        }
+      });
+
+      nodesToDelete.reverse().forEach(({ pos, size }) => {
+        transaction.delete(pos, pos + size);
+      });
+
+      subjectEditor.view.dispatch(transaction);
     }
   };
 
@@ -93,9 +224,18 @@ export const TemplateEditor = ({
         type="normal"
         variables={templateVariables}
       />
+      <div className="border-line-basicMedium flex min-h-[48px] items-center border-b px-[16px] py-[10px]">
+        <StyledSubjectEditor
+          className="typo-b1_rg_16 text-text-basicPrimary w-full"
+          editor={subjectEditor}
+        />
+      </div>
       <MailEditorContent
         initialContent={templateContent}
         onContentChange={onContentChange}
+        onFocus={() => {
+          lastFocusedField.current = 'content';
+        }}
         ref={editorRef}
       />
     </div>

--- a/src/pages/Template/components/TemplateTab/TemplateTab.tsx
+++ b/src/pages/Template/components/TemplateTab/TemplateTab.tsx
@@ -72,6 +72,7 @@ export const TemplateTab = () => {
           ...oldData,
           date: data.updatedAt,
           title: updatedPayload.title,
+          subject: updatedPayload.subject,
           content: updatedPayload.content,
           variables: updatedPayload.variables,
         };

--- a/src/query/mail/mutation/postMailReservation.ts
+++ b/src/query/mail/mutation/postMailReservation.ts
@@ -1,20 +1,16 @@
 import { api } from '@/apis/api.ts';
 
 export interface PostMailReservationParams {
-  attachmentReferences: {
-    fileId: number;
+  bccEmailAddresses?: string[];
+  ccEmailAddresses?: string[];
+  recipients: {
+    applicantId?: number;
+    bindings: Record<string, string>;
+    email: string;
   }[];
-  bccEmailAddresses: string[];
-  bodyFormat: 'HTML' | 'PLAIN_TEXT';
-  ccEmailAddresses: string[];
-  inlineImageReferences: {
-    contentId: string;
-    fileId: number;
-  }[];
-  mailBody: string;
-  mailSubject: string;
-  receiverEmailAddresses: string[];
   reservationTime: string;
+  sharedBindings: Record<string, string>;
+  templateId: number;
 }
 
 export const postMailReservation = (data: PostMailReservationParams) => {

--- a/src/query/mail/mutation/putMailReservation.ts
+++ b/src/query/mail/mutation/putMailReservation.ts
@@ -1,15 +1,17 @@
 import { api } from '@/apis/api.ts';
 
-interface PutMailReservationParams {
-  attachmentReferences: { fileId: number }[];
-  bccEmailAddresses: string[];
-  bodyFormat: 'HTML' | 'TEXT';
-  ccEmailAddresses: string[];
-  mailBody: string;
-  mailSubject: string;
-  receiverEmailAddresses: string[];
+export interface PutMailReservationParams {
+  bccEmailAddresses?: string[];
+  ccEmailAddresses?: string[];
+  recipients: {
+    applicantId?: number;
+    bindings: Record<string, string>;
+    email: string;
+  }[];
   reservationId: number;
-  reservationTime: null | string;
+  reservationTime: string;
+  sharedBindings: Record<string, string>;
+  templateId: number;
 }
 
 export const putMailReservation = (params: PutMailReservationParams) => {

--- a/src/query/mail/options.ts
+++ b/src/query/mail/options.ts
@@ -1,7 +1,60 @@
 import { queryOptions } from '@tanstack/react-query';
 
 import { api } from '@/apis/api.ts';
-import { MailDetailSchema, MailListSchema } from '@/query/mail/schema';
+import { MailDetailSchema, MailGroupListSchema, MailListSchema } from '@/query/mail/schema';
+import { BaseTemplateSchema } from '@/query/template/schema';
+
+const resolveGroupSubject = (
+  templateSubject: string,
+  variables: Array<{ displayName: string; key: string; perRecipient: boolean; type: string }>,
+  resolvedSubject: string,
+): string => {
+  const placeholderMatches = [...templateSubject.matchAll(/\{\{([^}]+)\}\}/g)];
+  const variableKeys = placeholderMatches.map((m) => m[1]);
+
+  const escapeRegExp = (string: string) => {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+
+  let regexString = '^';
+  let lastIndex = 0;
+  placeholderMatches.forEach((match) => {
+    const matchIndex = match.index!;
+    regexString += escapeRegExp(templateSubject.substring(lastIndex, matchIndex));
+    regexString += '(.*?)';
+    lastIndex = matchIndex + match[0].length;
+  });
+  regexString += escapeRegExp(templateSubject.substring(lastIndex));
+  regexString += '$';
+
+  const regex = new RegExp(regexString);
+  const matchResult = resolvedSubject.match(regex);
+
+  const resolvedValues: Record<string, string> = {};
+  if (matchResult) {
+    variableKeys.forEach((key, index) => {
+      resolvedValues[key] = matchResult[index + 1];
+    });
+  }
+
+  let finalSubject = templateSubject;
+  variables.forEach((v) => {
+    const isPerRecipient = v.perRecipient || v.type === 'APPLICANT';
+    const placeholder = `{{${v.key}}}`;
+    if (isPerRecipient) {
+      finalSubject = finalSubject.replaceAll(placeholder, `{{${v.displayName}}}`);
+    } else {
+      const val = resolvedValues[v.key];
+      if (val !== undefined) {
+        finalSubject = finalSubject.replaceAll(placeholder, val);
+      } else {
+        finalSubject = finalSubject.replaceAll(placeholder, `{{${v.displayName}}}`);
+      }
+    }
+  });
+
+  return finalSubject;
+};
 
 export const MailReservationKeys = {
   all: ['mailReservations'] as const,
@@ -13,10 +66,76 @@ export const mailOptions = {
     queryOptions({
       queryKey: MailReservationKeys.all,
       queryFn: async () => {
-        const data = await api.get('api/mails/reservation').json();
-        const response = MailListSchema.parse(data);
-        const mailData = response.items;
-        return mailData;
+        const [groupsData, listData] = await Promise.all([
+          api.get('api/mails/reservation/groups').json().then(MailGroupListSchema.parse),
+          api.get('api/mails/reservation').json().then(MailListSchema.parse),
+        ]);
+
+        const validGroups = groupsData.groups.filter((g) => g.mailIds && g.mailIds.length > 0);
+
+        const templateIds = [
+          ...new Set(
+            validGroups
+              .map((g) => g.templateId)
+              .filter((id): id is number => id !== null && id !== undefined),
+          ),
+        ];
+        const templatesData = await Promise.all(
+          templateIds.map((id) =>
+            api
+              .get(`api/mails/templates/${id}`)
+              .json()
+              .then(BaseTemplateSchema.parse)
+              .catch((err) => {
+                console.error(`Failed to fetch template ${id}`, err);
+                return null;
+              }),
+          ),
+        );
+        const templateMap = new Map(
+          templatesData
+            .filter((t): t is Exclude<typeof t, null> => t !== null)
+            .map((t) => [t.id, t]),
+        );
+
+        return validGroups
+          .filter((group) => {
+            if (group.templateId === null || group.templateId === undefined) {
+              return true;
+            }
+            return templateMap.has(group.templateId);
+          })
+          .map((group) => {
+            const matchingMail = listData.items.find((item) => group.mailIds.includes(item.mailId));
+
+            // TODO: 백엔드에서 reservationIds 대신 mailIds를 잘못 내려주고 있어 각각 예약 메일 단건 조회가 불가능한 이슈 우회.
+            // 전체 예약 목록에서 mailId에 대응하는 reservationId를 매핑하여 상세 조회/삭제/재시도 시 사용하도록 처리.
+            // Slack thread: https://yourssu.slack.com/archives/C082XCSQK0F/p1780224372483989
+            const resolvedReservationIds = group.mailIds.map((mailId) => {
+              const match = listData.items.find((item) => item.mailId === mailId);
+              return match ? match.reservationId : mailId;
+            });
+
+            let mailSubject = matchingMail?.mailSubject ?? '(제목 없음)';
+            if (group.templateId && templateMap.has(group.templateId) && matchingMail) {
+              const template = templateMap.get(group.templateId)!;
+              try {
+                mailSubject = resolveGroupSubject(
+                  template.subject,
+                  template.variables,
+                  matchingMail.mailSubject,
+                );
+              } catch (e) {
+                console.error('Failed to resolve dynamic subject', e);
+              }
+            }
+
+            return {
+              ...group,
+              mailSubject,
+              resolvedReservationIds,
+            };
+          });
       },
       staleTime: Infinity,
     }),

--- a/src/query/mail/schema.ts
+++ b/src/query/mail/schema.ts
@@ -42,6 +42,24 @@ export const MailListSchema = z.object({
   items: z.array(BaseMailItemSchema),
 });
 
+const MailGroupStateType = ['SCHEDULED', 'PENDING_SEND', 'SENDING', 'SENT'] as const;
+
+export const MailGroupItemSchema = z.object({
+  groupId: z.number(),
+  senderEmail: z.string(),
+  templateId: z.number().nullable().optional(),
+  reservationTime: z.string(),
+  status: z.enum(MailGroupStateType),
+  createdAt: z.string(),
+  mailIds: z.array(z.number()),
+});
+
+export const MailGroupListSchema = z.object({
+  groups: z.array(MailGroupItemSchema),
+});
+
 export type MailItem = z.infer<typeof MailItemSchema>;
 export type MailDetail = z.infer<typeof MailDetailSchema>;
 export type MailList = z.infer<typeof MailListSchema>;
+export type MailGroupItem = z.infer<typeof MailGroupItemSchema>;
+export type MailGroupList = z.infer<typeof MailGroupListSchema>;

--- a/src/query/schedule/options.ts
+++ b/src/query/schedule/options.ts
@@ -10,11 +10,12 @@ export const scheduleOptions = (partId: null | number) => {
     queryKey: partId !== null ? [...baseKey, partId] : baseKey,
     queryFn: async () => {
       const res = await api.get('recruiter/schedule', {
-        searchParams: partId !== null
-          ? {
-              partId: partId.toString(),
-            }
-          : undefined,
+        searchParams:
+          partId !== null
+            ? {
+                partId: partId.toString(),
+              }
+            : undefined,
       });
       const data = await res.json();
       return ScheduleArraySchema.parse(data);

--- a/src/query/template/mutations/postTemplatesFromForms.ts
+++ b/src/query/template/mutations/postTemplatesFromForms.ts
@@ -7,6 +7,7 @@ import { transformContentToBodyHtml, transformVariables } from '@/utils/transfor
 interface PostTemplateParams {
   attachments?: AttachmentType[];
   content: string;
+  subject: string;
   title: string;
   variables: Variable[];
 }
@@ -14,6 +15,7 @@ interface PostTemplateParams {
 export const postTemplateFromForms = (params: PostTemplateParams) => {
   const formattedParams = {
     title: params.title,
+    subject: params.subject,
     bodyHtml: transformContentToBodyHtml(params.content),
     variables: transformVariables(params.variables),
     attachmentReferences: params.attachments?.map((a) => ({ fileId: a.fileId })) || [],

--- a/src/query/template/mutations/putTemplate.ts
+++ b/src/query/template/mutations/putTemplate.ts
@@ -8,6 +8,7 @@ interface PutTemplateParams {
   attachments?: AttachmentType[];
   content: string;
   id: number;
+  subject: string;
   title: string;
   variables: Variable[];
 }
@@ -15,6 +16,7 @@ interface PutTemplateParams {
 export const putTemplate = (params: PutTemplateParams) => {
   const formattedParams = {
     title: params.title,
+    subject: params.subject,
     bodyHtml: transformContentToBodyHtml(params.content),
     variables: transformVariables(params.variables),
     attachmentReferences: params.attachments?.map((a) => ({ fileId: a.fileId })) || [],

--- a/src/query/template/options.ts
+++ b/src/query/template/options.ts
@@ -53,6 +53,7 @@ export const templateOptions = {
             displayName: variable.displayName,
             type: variableTypeMap[variable.type],
             perRecipient: variable.perRecipient,
+            attributeKey: variable.attributeKey,
             items:
               variable.items ??
               (['APPLICANT', 'PERSON'].includes(variable.type) ? [] : [{ value: '' }]),
@@ -63,6 +64,7 @@ export const templateOptions = {
         const templateDetail = {
           id: response.id,
           title: response.title,
+          subject: response.subject,
           content: transformBodyHtmlToContent(response.bodyHtml, templateVariables),
           variables: templateVariables,
           attachments:

--- a/src/query/template/schema.ts
+++ b/src/query/template/schema.ts
@@ -23,6 +23,7 @@ const VariableSchema = z.object({
   displayName: z.string(),
   perRecipient: z.boolean(),
   items: z.array(VariableItemSchema).optional(),
+  attributeKey: z.string().optional().nullable(),
 });
 
 export const VariablePayloadSchema = VariableSchema.extend({
@@ -34,6 +35,7 @@ export const VariablePayloadSchema = VariableSchema.extend({
 export const BaseTemplateSchema = z.object({
   id: z.number(),
   title: z.string(),
+  subject: z.string(),
   bodyHtml: z.string(),
   variables: z.array(VariableSchema),
   attachmentReferences: z

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -4,6 +4,7 @@ export type VariableType = '날짜' | '링크' | '사람' | '사람/지원자' |
 export type VariableKeyType = `var-${string}`;
 
 export interface BaseVariable {
+  attributeKey?: null | string;
   displayName: string;
   key: VariableKeyType;
   perRecipient: boolean;
@@ -11,6 +12,7 @@ export interface BaseVariable {
 }
 
 export interface Variable extends Omit<BaseVariable, 'items' | 'type'> {
+  attributeKey?: null | string;
   items: { value: string }[];
   type: VariableType;
 }

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -5,6 +5,7 @@ export interface Template {
   content: string;
   date: string;
   id: number;
+  subject: string;
   title: string;
   variables: Variable[];
 }

--- a/src/utils/transformTemplate.ts
+++ b/src/utils/transformTemplate.ts
@@ -38,11 +38,19 @@ export const transformBodyHtmlToContent = (bodyHtml: string, variables: BaseVari
 
 export const transformVariables = (variables: Variable[]) => {
   return variables.map((variable) => {
+    const backendType = variableTypeMap[variable.type];
+    const isApplicant = backendType === 'APPLICANT';
+
     return {
       key: variable.key,
-      type: variableTypeMap[variable.type],
+      type: backendType,
       displayName: variable.displayName,
       perRecipient: variable.perRecipient,
+      ...(isApplicant && {
+        // TODO: UI 레벨에서 key 변경이 가능하도록 지원하기 (applicant.email, applicant.phoneNumber 등)
+        // https://www.notion.so/mail-api-5-5-3562704010cd80ac8825d84a6677ca54?source=copy_link#3562704010cd81afa718d6659eacf6c4
+        attributeKey: 'applicant.name',
+      }),
     };
   });
 };


### PR DESCRIPTION
## 개요

템플릿과 메일 예약 스펙을 대량으로 개편했어요.

### 템플릿

- 템플릿에 메일 제목을 입력하고, 메일 제목에 변수를 주입할 수 있도록 했어요.

  | placeholder | 변수 주입 |
  | -- | -- |
  | <img width="712" height="275" alt="스크린샷 2026-05-31 21 18 46" src="https://github.com/user-attachments/assets/08d2b935-d499-409a-843f-cf3f885e8e66" /> | <img width="795" height="291" alt="스크린샷 2026-05-31 21 18 43" src="https://github.com/user-attachments/assets/418d74ad-3eb3-4d3f-a1a7-0b6ee7588010" /> |
  
<br />

### 메일 작성

- 받는 사람과 숨은 참조 필드에서 backspace 버튼을 누르면 칩을 제거할 수 있도록 사용성을 개선했어요.

- 템플릿 선택 시, 템플릿에서 작성했던 메일이 자동으로 제목 필드에 넣어지도록 했어요. 제목에 변수가 있다면, 우측 변수 리스트와 연동돼요.

  <img width="1522" height="535" alt="스크린샷 2026-05-31 21 20 58" src="https://github.com/user-attachments/assets/78b0ee68-2ad8-4d99-85b2-6a6589a73a7d" />

<br />

### 메일 예약

- 내부적으로 예약 메일 그루핑 로직을 변경했어요. 
  - 기존처럼 제목으로 그루핑하는 것이 아닌, 실제로 그루핑 되기 때문에 같은 이름으로 메일을 만들어도 다른 예약으로 분류돼요.

- 예약된 메일 제목에 템플릿에서 작성했던 메일 제목이 뜨도록 만들었어요. 변수가 있다면 `{{변수이름}}` 의 형태로 띄워줘요.

    <img width="806" height="122" alt="스크린샷 2026-05-31 21 25 22" src="https://github.com/user-attachments/assets/4613374f-0c53-44e4-a2c0-f5e66d6082f1" />

- 예약된 메일 내용 다이얼로그에서 지원자 탭을 변경하면 제목도 똑같이 연동되도록 변경했어요.

- 예약된 메일의 템플릿이 제거되어 조회가 불가능하거나, 그룹 정보는 있지만 실제로 아무 메일과도 연결되지 않은 케이스들은 보여주지 않도록 예외처리했어요.