### PR TITLE
feat: 예약된 메일 제목에 변수 칩 렌더링

### DIFF
--- a/src/components/TemplateList/TemplateList.style.ts
+++ b/src/components/TemplateList/TemplateList.style.ts
@@ -28,6 +28,10 @@ export const TemplateItemContent = styled.div`
 export const TemplateTitle = styled.h3`
   ${({ theme }) => theme.typo.T3_Sb_20};
   color: ${({ theme }) => theme.semantic.color.textBasicPrimary};
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
 `;
 
 export const TemplateDate = styled.span<{ $variant?: 'error' }>`

--- a/src/components/TemplateList/TemplateList.tsx
+++ b/src/components/TemplateList/TemplateList.tsx
@@ -15,7 +15,7 @@ export interface TemplateListProps {
   onDelete: () => void;
   readonly?: boolean;
   text: string;
-  title: string;
+  title: React.ReactNode;
   variant?: 'error';
 }
 

--- a/src/components/VariableChip/VariableChip.tsx
+++ b/src/components/VariableChip/VariableChip.tsx
@@ -14,6 +14,7 @@ type ChipSize = 'large' | 'small';
 type ChipType = 'applicant' | 'date' | 'link' | 'part' | 'person' | 'text';
 
 interface VariableChipProps {
+  deletable?: boolean;
   label: string;
   onClick?: () => void;
   onDelete?: () => void;
@@ -36,6 +37,7 @@ export const VariableChip = ({
   size = 'large',
   onClick,
   onDelete,
+  deletable = true,
 }: VariableChipProps) => {
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // 이벤트 버블링 방지
@@ -44,7 +46,7 @@ export const VariableChip = ({
     }
   };
 
-  const isDeletable = !(type === 'part' || type === 'applicant');
+  const isDeletable = deletable && !(type === 'part' || type === 'applicant');
 
   return (
     <ChipWrapper onClick={onClick} size={size} style={{ cursor: onClick ? 'pointer' : 'default' }}>

--- a/src/pages/SendMail/components/MailTab/MailTab.tsx
+++ b/src/pages/SendMail/components/MailTab/MailTab.tsx
@@ -5,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import TableSearchBar from '@/components/TableSearchBar/TableSearchBar';
 import { TemplateList } from '@/components/TemplateList/TemplateList';
+import { VariableChip } from '@/components/VariableChip/VariableChip';
 import { MailEditDialog } from '@/pages/SendMail/components/MailEditDialog/MailEditDialog';
 import { DeleteTemplateDialog } from '@/pages/Template/components/DeleteTemplateDialog/DeleteTemplateDialog';
 import { deleteMailReservation } from '@/query/mail/mutation/deleteMailReservation';
@@ -21,6 +22,60 @@ interface MailTabProps {
   sortOrder?: 'asc' | 'desc';
   statuses: MailItem['status'][];
 }
+
+const chipTypeMap: Record<string, 'applicant' | 'date' | 'link' | 'part' | 'person' | 'text'> = {
+  PERSON: 'person',
+  DATE: 'date',
+  LINK: 'link',
+  TEXT: 'text',
+  APPLICANT: 'applicant',
+  PARTNAME: 'part',
+};
+
+const renderSubjectWithChips = (
+  subject: string,
+  variables: Array<{ displayName: string; key: string; type: string }>,
+) => {
+  if (!subject) {
+    return '';
+  }
+
+  const regex = /\{\{([^}]+)\}\}/g;
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(subject)) !== null) {
+    const index = match.index;
+    const displayName = match[1];
+
+    if (index > lastIndex) {
+      parts.push(subject.substring(lastIndex, index));
+    }
+
+    const variable = variables.find((v) => v.displayName === displayName);
+    const backendType = variable?.type ?? 'TEXT';
+    const chipType = chipTypeMap[backendType] ?? 'text';
+
+    parts.push(
+      <VariableChip
+        deletable={false}
+        key={`${displayName}-${index}`}
+        label={displayName}
+        size="large"
+        type={chipType}
+      />,
+    );
+
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < subject.length) {
+    parts.push(subject.substring(lastIndex));
+  }
+
+  return parts.length > 0 ? parts : subject;
+};
 
 export const MailTab = ({
   dialogReadOnly,
@@ -156,7 +211,7 @@ export const MailTab = ({
               }
               readonly={readOnly}
               text={isPendingSend ? '에 전송 실패' : readOnly ? '' : '에 예약됨'}
-              title={group.mailSubject}
+              title={renderSubjectWithChips(group.mailSubject, group.variables)}
               variant={isPendingSend ? 'error' : undefined}
             />
           );

--- a/src/query/mail/options.ts
+++ b/src/query/mail/options.ts
@@ -130,10 +130,13 @@ export const mailOptions = {
               }
             }
 
+            const template = group.templateId ? templateMap.get(group.templateId) : null;
+
             return {
               ...group,
               mailSubject,
               resolvedReservationIds,
+              variables: template ? template.variables : [],
             };
           });
       },


### PR DESCRIPTION
## 개요

예약된 메일 제목에 변수가 있을 경우, 변수 칩 UI를 렌더링하도록 변경했어요.


| as-is | to-be |
| --- | --- |
| <img width="1768" height="1210" alt="image" src="https://github.com/user-attachments/assets/420e761a-260e-4dc5-b38c-ffc7665cf714" /> | <img width="1836" height="1266" alt="image" src="https://github.com/user-attachments/assets/d02fdb3f-69b7-4b12-a103-7410b2be73d3" /> |

### 참고하면 좋을 링크

https://yourssu.slack.com/archives/C082XCSQK0F/p1780234630025279

